### PR TITLE
Clarify README for filesystem

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -82,10 +82,12 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 Add this to your `claude_desktop_config.json`:
 ```json
 {
-  "filesystem": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/username/Desktop", "/path/to/other/allowed/dir"]
-  }
+    "mcpServers": {
+      "filesystem": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/username/Desktop", "/path/to/other/allowed/dir"]
+      }
+    }
 }
 ```
 


### PR DESCRIPTION
Fix the instructions so that it's clear that claude_desktop_config.json must have a top-level key called mcpServers.

<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server or adding a new one, provide details -->
- Server: filesystem
- Changes to: README

## Motivation and Context
The instructions don't work as-is, because they assume the config file already exists and already has a key called mcpServers.

## How Has This Been Tested?
When I followed the modified instructions, I was able to use Claude Desktop to view and create files on my filesystem.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New MCP Server
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My server follows MCP security best practices
- [X] I have updated the server's README accordingly
- [X] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options

## Additional context
