### PR TITLE
Fix missing mcpServers keys in README code examples

### DIFF
--- a/src/brave-search/README.md
+++ b/src/brave-search/README.md
@@ -38,11 +38,16 @@ Add this to your `claude_desktop_config.json`:
 
 ```json
 {
-  "brave-search": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-brave-search"],
-    "env": {
-      "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+  "mcpServers": {
+    "brave-search": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-brave-search"
+      ],
+      "env": {
+        "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
+      }
     }
   }
 }

--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -78,8 +78,14 @@ Add to your `claude_desktop_config.json`:
 
 ```json
 {
-  "everything": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-everything"]
+  "mcpServers": {
+    "everything": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-everything"
+      ]
+    }
   }
 }
+```

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -82,9 +82,16 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 Add this to your `claude_desktop_config.json`:
 ```json
 {
-  "filesystem": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/username/Desktop", "/path/to/other/allowed/dir"]
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop",
+        "/path/to/other/allowed/dir"
+      ]
+    }
   }
 }
 ```

--- a/src/gdrive/README.md
+++ b/src/gdrive/README.md
@@ -51,9 +51,14 @@ To integrate this server with the desktop app, add the following to your app's s
 
 ```json
 {
-  "gdrive": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-gdrive"]
+  "mcpServers": {
+    "gdrive": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-gdrive"
+      ]
+    }
   }
 }
 ```

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -117,11 +117,16 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
 
 ```json
 {
-  "github": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-github"],
-    "env": {
-      "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
     }
   }
 }

--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -61,11 +61,16 @@ Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
-  "google-maps": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-google-maps"],
-    "env": {
-      "GOOGLE_MAPS_API_KEY": "<YOUR_API_KEY>"
+  "mcpServers": {
+    "google-maps": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-google-maps"
+      ],
+      "env": {
+        "GOOGLE_MAPS_API_KEY": "<YOUR_API_KEY>"
+      }
     }
   }
 }

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -130,9 +130,14 @@ Example:
 Add this to your claude_desktop_config.json:
 ```json
 {
-  "memory": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-memory"]
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ]
+    }
   }
 }
 ```

--- a/src/postgres/README.md
+++ b/src/postgres/README.md
@@ -26,9 +26,15 @@ To use this server with the Claude Desktop app, add the following configuration 
 
 ```json
 {
-  "postgres": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://localhost/mydb"
+      ]
+    }
   }
 }
 ```

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -98,12 +98,17 @@ Add the following to your `claude_desktop_config.json`:
 
 ```json
 {
-  "slack": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-slack"],
-    "env": {
-      "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
-      "SLACK_TEAM_ID": "T01234567"
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-slack"
+      ],
+      "env": {
+        "SLACK_BOT_TOKEN": "xoxb-your-bot-token",
+        "SLACK_TEAM_ID": "T01234567"
+      }
     }
   }
 }


### PR DESCRIPTION
Fix the instructions so that it's clear that claude_desktop_config.json must have a top-level key called mcpServers.

<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server or adding a new one, provide details -->
- Server: filesystem and others
- Changes to: README

## Motivation and Context
The instructions don't work as-is, because they assume the config file already exists and already has a key called mcpServers.

## How Has This Been Tested?
When I followed the modified instructions, I was able to use Claude Desktop to view and create files on my filesystem.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New MCP Server
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My server follows MCP security best practices
- [X] I have updated the server's README accordingly
- [X] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options

## Additional context
