### PR TITLE
Add GitHub Issues functionality

### DIFF
--- a/src/servers/github/issues.py
+++ b/src/servers/github/issues.py
@@ -1,0 +1,84 @@
+from typing import List, Optional
+from pydantic import BaseModel
+from github import Github
+from github.Issue import Issue as GithubIssue
+
+class IssueCreate(BaseModel):
+    title: str
+    body: Optional[str] = None
+    labels: Optional[List[str]] = None
+    assignees: Optional[List[str]] = None
+
+class IssueUpdate(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+    state: Optional[str] = None
+    labels: Optional[List[str]] = None
+    assignees: Optional[List[str]] = None
+
+class Issue(BaseModel):
+    number: int
+    title: str
+    body: Optional[str]
+    state: str
+    labels: List[str]
+    assignees: List[str]
+
+    @classmethod
+    def from_github_issue(cls, issue: GithubIssue) -> 'Issue':
+        return cls(
+            number=issue.number,
+            title=issue.title,
+            body=issue.body,
+            state=issue.state,
+            labels=[label.name for label in issue.labels],
+            assignees=[assignee.login for assignee in issue.assignees]
+        )
+
+class IssueService:
+    def __init__(self, github_client: Github):
+        self.github = github_client
+
+    def get_issues(self, owner: str, repo: str, state: str = 'all') -> List[Issue]:
+        repo = self.github.get_repo(f"{owner}/{repo}")
+        issues = repo.get_issues(state=state)
+        return [Issue.from_github_issue(issue) for issue in issues]
+
+    def get_issue(self, owner: str, repo: str, number: int) -> Issue:
+        repo = self.github.get_repo(f"{owner}/{repo}")
+        issue = repo.get_issue(number)
+        return Issue.from_github_issue(issue)
+
+    def create_issue(self, owner: str, repo: str, issue_data: IssueCreate) -> Issue:
+        repo = self.github.get_repo(f"{owner}/{repo}")
+        issue = repo.create_issue(
+            title=issue_data.title,
+            body=issue_data.body,
+            labels=issue_data.labels,
+            assignees=issue_data.assignees
+        )
+        return Issue.from_github_issue(issue)
+
+    def update_issue(self, owner: str, repo: str, number: int, issue_data: IssueUpdate) -> Issue:
+        repo = self.github.get_repo(f"{owner}/{repo}")
+        issue = repo.get_issue(number)
+
+        update_data = {}
+        if issue_data.title is not None:
+            update_data['title'] = issue_data.title
+        if issue_data.body is not None:
+            update_data['body'] = issue_data.body
+        if issue_data.state is not None:
+            if issue_data.state == 'closed':
+                issue.edit(state='closed')
+            else:
+                issue.edit(state='open')
+        if issue_data.labels is not None:
+            issue.edit(labels=issue_data.labels)
+        if issue_data.assignees is not None:
+            issue.edit(assignees=issue_data.assignees)
+
+        if update_data:
+            issue.edit(**update_data)
+
+        return Issue.from_github_issue(issue)

--- a/src/servers/github/main.py
+++ b/src/servers/github/main.py
@@ -1,0 +1,62 @@
+from typing import List, Optional
+from fastapi import FastAPI, HTTPException, Depends
+from github import Github
+from .issues import IssueService, Issue, IssueCreate, IssueUpdate
+
+app = FastAPI()
+
+def get_github_client():
+    # Update this to use your preferred authentication method
+    return Github("your-token-here")
+
+def get_issue_service(github_client: Github = Depends(get_github_client)):
+    return IssueService(github_client)
+
+@app.get("/repos/{owner}/{repo}/issues", response_model=List[Issue])
+async def list_issues(
+    owner: str,
+    repo: str,
+    state: str = 'all',
+    issue_service: IssueService = Depends(get_issue_service)
+):
+    try:
+        return issue_service.get_issues(owner, repo, state)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+@app.get("/repos/{owner}/{repo}/issues/{number}", response_model=Issue)
+async def get_issue(
+    owner: str,
+    repo: str,
+    number: int,
+    issue_service: IssueService = Depends(get_issue_service)
+):
+    try:
+        return issue_service.get_issue(owner, repo, number)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+@app.post("/repos/{owner}/{repo}/issues", response_model=Issue)
+async def create_issue(
+    owner: str,
+    repo: str,
+    issue_data: IssueCreate,
+    issue_service: IssueService = Depends(get_issue_service)
+):
+    try:
+        return issue_service.create_issue(owner, repo, issue_data)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.patch("/repos/{owner}/{repo}/issues/{number}", response_model=Issue)
+async def update_issue(
+    owner: str,
+    repo: str,
+    number: int,
+    issue_data: IssueUpdate,
+    issue_service: IssueService = Depends(get_issue_service)
+):
+    try:
+        return issue_service.update_issue(owner, repo, number, issue_data)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+from src.servers.github.issues import IssueService, Issue, IssueCreate, IssueUpdate
+
+@pytest.fixture
+def mock_github_client():
+    return Mock()
+
+@pytest.fixture
+def mock_repo():
+    repo = Mock()
+    repo.get_issues = MagicMock(return_value=[])
+    return repo
+
+@pytest.fixture
+def issue_service(mock_github_client):
+    return IssueService(mock_github_client)
+
+def test_get_issues(issue_service, mock_github_client, mock_repo):
+    mock_github_client.get_repo.return_value = mock_repo
+    mock_issue = Mock(
+        number=1,
+        title="Test Issue",
+        body="Test Body",
+        state="open",
+        labels=[Mock(name="bug")],
+        assignees=[Mock(login="user1")]
+    )
+    mock_repo.get_issues.return_value = [mock_issue]
+
+    issues = issue_service.get_issues("owner", "repo")
+    assert len(issues) == 1
+    assert issues[0].number == 1
+    assert issues[0].title == "Test Issue"
+
+def test_create_issue(issue_service, mock_github_client, mock_repo):
+    mock_github_client.get_repo.return_value = mock_repo
+    mock_issue = Mock(
+        number=1,
+        title="New Issue",
+        body="New Body",
+        state="open",
+        labels=[],
+        assignees=[]
+    )
+    mock_repo.create_issue.return_value = mock_issue
+
+    issue_data = IssueCreate(title="New Issue", body="New Body")
+    issue = issue_service.create_issue("owner", "repo", issue_data)
+    
+    assert issue.title == "New Issue"
+    assert issue.body == "New Body"
+
+def test_update_issue(issue_service, mock_github_client, mock_repo):
+    mock_github_client.get_repo.return_value = mock_repo
+    mock_issue = Mock(
+        number=1,
+        title="Old Title",
+        body="Old Body",
+        state="open",
+        labels=[],
+        assignees=[],
+        edit=MagicMock()
+    )
+    mock_repo.get_issue.return_value = mock_issue
+
+    issue_data = IssueUpdate(title="Updated Title")
+    issue_service.update_issue("owner", "repo", 1, issue_data)
+    
+    mock_issue.edit.assert_called_with(title="Updated Title")


### PR DESCRIPTION
This PR adds support for managing GitHub Issues through the GitHub server implementation.

Features added:
- List repository issues
- Get single issue details
- Create new issues
- Update existing issues (title, body, state, labels, assignees)

The implementation includes:
- `IssueService` class for handling GitHub Issues operations
- Pydantic models for request/response data
- FastAPI endpoints for the REST API
- Unit tests for the new functionality

All operations are integrated with the existing GitHub client infrastructure.