### PR TITLE
[sqlite server] Remove docs on missing Anthropic summary feature

### DIFF
--- a/src/sqlite/README.md
+++ b/src/sqlite/README.md
@@ -1,7 +1,7 @@
 # SQLite MCP Server
 
 ## Overview
-A Model Context Protocol (MCP) server implementation that provides database interaction and business intelligence capabilities through SQLite. This server enables running SQL queries, analyzing business data, and automatically generating business insight memos that can be enhanced with Claude's analysis when an Anthropic API key is provided.
+A Model Context Protocol (MCP) server implementation that provides database interaction and business intelligence capabilities through SQLite. This server enables running SQL queries, analyzing business data, and automatically generating business insight memos.
 
 ## Components
 
@@ -9,7 +9,6 @@ A Model Context Protocol (MCP) server implementation that provides database inte
 The server exposes a single dynamic resource:
 - `memo://insights`: A continuously updated business insights memo that aggregates discovered insights during analysis
   - Auto-updates as new insights are discovered via the append-insight tool
-  - Optional enhancement through Claude for professional formatting (requires Anthropic API key)
 
 ### Prompts
 The server provides a demonstration prompt:
@@ -25,7 +24,7 @@ The server offers six core tools:
 #### Query Tools
 - `read-query`
    - Execute SELECT queries to read data from the database
-   - Input: 
+   - Input:
      - `query` (string): The SELECT SQL query to execute
    - Returns: Query results as array of objects
 

--- a/src/sqlite/src/mcp_server_sqlite/server.py
+++ b/src/sqlite/src/mcp_server_sqlite/server.py
@@ -25,7 +25,7 @@ Here is some more information about mcp and this specific mcp server:
 Prompts:
 This server provides a pre-written prompt called "mcp-demo" that helps users create and analyze database scenarios. The prompt accepts a "topic" argument and guides users through creating tables, analyzing data, and generating insights. For example, if a user provides "retail sales" as the topic, the prompt will help create relevant database tables and guide the analysis process. Prompts basically serve as interactive templates that help structure the conversation with the LLM in a useful way.
 Resources:
-This server exposes one key resource: "memo://insights", which is a business insights memo that gets automatically updated throughout the analysis process. As users analyze the database and discover insights, the memo resource gets updated in real-time to reflect new findings. The memo can even be enhanced with Claude's help if an Anthropic API key is provided, turning raw insights into a well-structured business document. Resources act as living documents that provide context to the conversation.
+This server exposes one key resource: "memo://insights", which is a business insights memo that gets automatically updated throughout the analysis process. As users analyze the database and discover insights, the memo resource gets updated in real-time to reflect new findings. Resources act as living documents that provide context to the conversation.
 Tools:
 This server provides several SQL-related tools:
 "read-query": Executes SELECT queries to read data from the database

--- a/src/sqlite/uv.lock
+++ b/src/sqlite/uv.lock
@@ -139,7 +139,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-sqlite"
-version = "0.4.1"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Description

Remove docs on missing Anthropic summary feature mentioned in sqlite server docs. 

If this feature was removed by mistake or actually is present, please ignore this PR.

## Server Details
- Server: sqlite
- Changes to: documentation and resource description

## Motivation and Context
The sqlite docs mention an optional anthropic summary feature if API key is present. Looking through the code, the Anthropic SDK is not included/referenced. It also doesn't look like sampling is used (though this wouldn't require the API key from my understanding)

## How Has This Been Tested?
Just changes to docs

## Breaking Changes
None

## Types of changes
- [ ] New MCP Server
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My server follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
- The update to uv.lock matches the earlier update to pyproject.toml - https://github.com/modelcontextprotocol/servers/pull/33
