### PR TITLE
Readme: Add missing servers to the featured server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Each MCP server is implemented with either the [Typescript MCP SDK](https://gith
 
 - **[Filesystem](src/filesystem)** - Secure file operations with configurable access controls
 - **[GitHub](src/github)** - Repository management, file operations, and GitHub API integration
+- **[GitLab](src/gitlab)** - GitLab API, enabling project management
+- **[Git](src/git)** - Tools to read, search, and manipulate Git repositories
 - **[Google Drive](src/gdrive)** - File access and search capabilities for Google Drive
 - **[PostgreSQL](src/postgres)** - Read-only database access with schema inspection
+- **[Sqlite](src/sqlite)** - Database interaction and business intelligence capabilities
 - **[Slack](src/slack)** - Channel management and messaging capabilities
+- **[Sentry](src/sentry)** - Retrieving and analyzing issues from Sentry.io
 - **[Memory](src/memory)** - Knowledge graph-based persistent memory system
 - **[Puppeteer](src/puppeteer)** - Browser automation and web scraping
 - **[Brave Search](src/brave-search)** - Web and local search using Brave's Search API


### PR DESCRIPTION
## Description
Adding to readme.md some missing servers to the featured server list.  (gitlab, git, sqlite, sentry)
As description I have used the one provided by servers README.

## Motivation and Context
I think it is better to the project to show all the current servers implementations.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New MCP Server
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My server follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options
