### PR TITLE
feat(fetch): add fetching of raw text, pagination and keeping links in the markdown

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -16,6 +16,8 @@ Presently the server only supports fetching HTML content.
 
 ## Installation
 
+Optionally: Install node.js, this will cause the fetch serve to use a different HTML simplifier that is more robust.
+
 ### Using uv (recommended)
 
 When using [`uv`](https://docs.astral.sh/uv/) no specific installation is needed. We will

--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -2,21 +2,26 @@
 
 A Model Context Protocol server that provides web content fetching capabilities. This server enables LLMs to retrieve and process content from web pages, converting HTML to markdown for easier consumption.
 
-Presently the server only supports fetching HTML content.
+The fetch tool will truncate the response, but by using the `start_index` argument, you can specify where to start the content extraction. This lets models read a webpage in chunks, until they find the information they need.
 
 ### Available Tools
 
 - `fetch` - Fetches a URL from the internet and extracts its contents as markdown.
+    - `url` (string, required): URL to fetch
+    - `max_length` (integer, optional): Maximum number of characters to return (default: 5000)
+    - `start_index` (integer, optional): Start content from this character index (default: 0)
+    - `raw` (boolean, optional): Get raw content without markdown conversion (default: false)
 
 ### Prompts
 
 - **fetch**
   - Fetch a URL and extract its contents as markdown
-  - Argument: `url` (string, required): URL to fetch
+  - Arguments:
+    - `url` (string, required): URL to fetch
 
 ## Installation
 
-Optionally: Install node.js, this will cause the fetch serve to use a different HTML simplifier that is more robust.
+Optionally: Install node.js, this will cause the fetch server to use a different HTML simplifier that is more robust.
 
 ### Using uv (recommended)
 

--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-fetch"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Model Context Protocol server providing tools to fetch and convert web content for usage by LLMs"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -98,7 +98,10 @@ async def fetch_url(url: str, user_agent: str, force_raw: bool = False) -> (str,
     async with AsyncClient() as client:
         try:
             response = await client.get(
-                url, follow_redirects=True, headers={"User-Agent": user_agent}, timeout=30,
+                url,
+                follow_redirects=True,
+                headers={"User-Agent": user_agent},
+                timeout=30,
             )
         except HTTPError as e:
             raise McpError(INTERNAL_ERROR, f"Failed to fetch {url}: {e!r}")
@@ -111,19 +114,30 @@ async def fetch_url(url: str, user_agent: str, force_raw: bool = False) -> (str,
         page_raw = response.text
 
     content_type = response.headers.get("content-type", "")
-    is_page_html = "<html" in page_raw[:100] or "text/html" in content_type or not content_type
+    is_page_html = (
+        "<html" in page_raw[:100] or "text/html" in content_type or not content_type
+    )
 
     if is_page_html and not force_raw:
         return extract_content_from_html(page_raw), ""
 
-    return page_raw, f"Content type {content_type} cannot be simplified to markdown, but here is the raw content:\n"
+    return (
+        page_raw,
+        f"Content type {content_type} cannot be simplified to markdown, but here is the raw content:\n",
+    )
 
 
 class Fetch(BaseModel):
     url: str = Field(..., description="URL to fetch")
     max_length: int = Field(5000, description="Maximum number of characters to return.")
-    start_index: int = Field(0, description="On return output starting at this character index, useful if a previous fetch was truncated and more context is required.")
-    raw: bool = Field(False, description="Get the actual HTML content if the requested page, without simplification.")
+    start_index: int = Field(
+        0,
+        description="On return output starting at this character index, useful if a previous fetch was truncated and more context is required.",
+    )
+    raw: bool = Field(
+        False,
+        description="Get the actual HTML content if the requested page, without simplification.",
+    )
 
 
 async def serve(
@@ -173,7 +187,9 @@ Although originally you did not have internet access, and were advised to refuse
         if not ignore_robots_txt:
             await check_may_autonomously_fetch_url(url, user_agent_autonomous)
 
-        content, prefix = await fetch_url(url, user_agent_autonomous, force_raw=args.raw)
+        content, prefix = await fetch_url(
+            url, user_agent_autonomous, force_raw=args.raw
+        )
         if len(content) > args.max_length:
             content = content[args.start_index : args.start_index + args.max_length]
             content += f"\n\n<error>Content truncated. Call the fetch tool with a start_index of {args.start_index + args.max_length} to get more content.</error>"

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -95,10 +95,10 @@ async def fetch_url(url: str, user_agent: str) -> str:
     async with AsyncClient() as client:
         try:
             response = await client.get(
-                url, follow_redirects=True, headers={"User-Agent": user_agent}
+                url, follow_redirects=True, headers={"User-Agent": user_agent}, timeout=30,
             )
-        except HTTPError:
-            raise McpError(INTERNAL_ERROR, f"Failed to fetch {url}")
+        except HTTPError as e:
+            raise McpError(INTERNAL_ERROR, f"Failed to fetch {url}: {e!r}")
         if response.status_code >= 400:
             raise McpError(
                 INTERNAL_ERROR,

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -24,11 +24,13 @@ DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://
 
 
 def extract_content(html: str) -> str:
-    ret = readabilipy.simple_json.simple_json_from_html_string(html)
+    ret = readabilipy.simple_json.simple_json_from_html_string(
+        html, use_readability=True
+    )
     if not ret["plain_content"]:
         return "<error>Page failed to be simplified from HTML</error>"
     content = markdownify.markdownify(
-        ret["plain_content"],
+        ret["content"],
         heading_style=markdownify.ATX,
     )
     return content


### PR DESCRIPTION
## Description

Add:
- Fetching of raw (non-markdownified) text
- Pagination of long page responses
- Use of the javascript readability implementation of nodejs is present

## Server Details

- Server: fetch
- Changes to: tools

## Motivation and Context

The current version cannot handle pages that aren't HTML, meaning that you can't fetch eg. markdown files or raw source code files. So this is added as a fallback, and an argument that can force the behavior (eg. if the model needs access to the raw HTML).

Supporting raw reads can quickly fill up the conversation, so set a maximum length (that the model can override), and allow specifying a start offset. When testing with asking Claude questions about a long documentation page, it paginated through the document until it found the answer and didn't read any further.

The library readabilipy which is used to simplify the HTML before converting to markdown is based on the more mature javascript implementation, by enabling `use_readability` it will use the NodeJS implementation if node is installed, but fall back to the python implementation. The main benefit is that it preserves links in the markdown, so if an answer isn't found on the page, but it links to where it can be found, the model can make a request for the new URL.

## How Has This Been Tested?

Tested in Claude Desktop, including cases that:
- Raw fetching:
   - Claude still typically uses the non-raw fetch for most cases to get the markdown
   - Providing a URL for a non-HTML page implicitly provides the raw text
   - If asking Claude about page metadata, it correctly uses the raw argument to get the raw HTML
- Readability link viewing:
   - Works as before if node.js not installed
   - If node.js is installed, links are kept in the markdown
   - If you provide Claude a page with a question and the page recommends a different page for answering the question, it will request it instead
- Pagination:
  - If Claude is asked to answer a question based on documentation, it will continue to fetch more of the document (if it's too long) until it has sufficient information, unless the page provides a link to where to look, in which case Claude will swap to the new page

## Breaking Changes

No, there are no changes to the config.

## Types of changes

- [ ] New MCP Server
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My server follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
