### PR TITLE
Add Qdrant to official integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
 - **[Tinybird](https://github.com/tinybirdco/mcp-tinybird)** - Interact with Tinybird serverless ClickHouse platform
 - <img height="12" width="12" src="https://pics.fatwang2.com/56912e614b35093426c515860f9f2234.svg" /> [Search1API](https://github.com/fatwang2/search1api-mcp) - One API for Search, Crawling, and Sitemaps
-- <img height="12" width="12" src="https://qdrant.tech/img/brand-resources-logos/logomark.svg" /> [Qdrant](https://github.com/qdrant/mcp-server-qdrant/) - Implement semantic memory layer on top of the Qdrant vector search engine
+- <img height="12" width="12" src="https://qdrant.tech/img/brand-resources-logos/logomark.svg" /> **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory layer on top of the Qdrant vector search engine
 
 ### 🌎 Community Servers
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Official integrations are maintained by companies building production ready MCP 
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
 - **[Tinybird](https://github.com/tinybirdco/mcp-tinybird)** - Interact with Tinybird serverless ClickHouse platform
 - <img height="12" width="12" src="https://pics.fatwang2.com/56912e614b35093426c515860f9f2234.svg" /> [Search1API](https://github.com/fatwang2/search1api-mcp) - One API for Search, Crawling, and Sitemaps
+- <img height="12" width="12" src="https://qdrant.tech/img/brand-resources-logos/logomark.svg" /> [Qdrant](https://github.com/qdrant/mcp-server-qdrant/) - Implement semantic memory layer on top of the Qdrant vector search engine
 
 ### 🌎 Community Servers
 


### PR DESCRIPTION
Add Qdrant to the list of the Official Integrations. This time, it is a separate repo, not a part of this one.

Context: https://github.com/modelcontextprotocol/servers/pull/62