### PR TITLE
feat(servers): add LLM.txt MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/servers",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/servers",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "workspaces": [
         "src/*"
@@ -197,6 +197,10 @@
       "resolved": "src/google-maps",
       "link": true
     },
+    "node_modules/@modelcontextprotocol/server-llm-txt": {
+      "resolved": "src/llm-txt",
+      "link": true
+    },
     "node_modules/@modelcontextprotocol/server-memory": {
       "resolved": "src/memory",
       "link": true
@@ -269,6 +273,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -322,6 +334,16 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -391,6 +413,11 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -414,6 +441,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -904,12 +937,67 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-3.0.0.tgz",
+      "integrity": "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
+      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/debug": {
@@ -919,6 +1007,11 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/default-browser": {
       "version": "4.0.0",
@@ -1023,6 +1116,26 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg=="
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.6",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
@@ -1072,6 +1185,17 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -1721,6 +1845,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1973,6 +2108,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2036,6 +2176,135 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/jsdom": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
+      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "cssstyle": "^3.0.0",
+        "data-urls": "^4.0.0",
+        "decimal.js": "^10.4.3",
+        "domexception": "^4.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.4",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^12.0.1",
+        "ws": "^8.13.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
+      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
@@ -2287,6 +2556,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ=="
+    },
     "node_modules/object-inspect": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
@@ -2435,6 +2709,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2758,6 +3043,17 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
@@ -2765,6 +3061,14 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -2838,6 +3142,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-tick": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
@@ -2896,6 +3205,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -2920,6 +3234,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
     },
     "node_modules/run-applescript": {
       "version": "5.0.0",
@@ -3045,6 +3364,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -3390,6 +3720,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
     "node_modules/tar-fs": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
@@ -3440,6 +3775,28 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -3520,6 +3877,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
@@ -3558,6 +3924,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -3571,6 +3948,36 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3655,6 +4062,19 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3723,7 +4143,7 @@
     },
     "src/brave-search": {
       "name": "@modelcontextprotocol/server-brave-search",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1"
@@ -3779,7 +4199,7 @@
     },
     "src/everart": {
       "name": "@modelcontextprotocol/server-everart",
-      "version": "0.1.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.5.0",
@@ -3849,7 +4269,7 @@
     },
     "src/everything": {
       "name": "@modelcontextprotocol/server-everything",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -3878,7 +4298,7 @@
     },
     "src/filesystem": {
       "name": "@modelcontextprotocol/server-filesystem",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -3960,7 +4380,7 @@
     },
     "src/gdrive": {
       "name": "@modelcontextprotocol/server-gdrive",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",
@@ -3997,7 +4417,7 @@
     },
     "src/github": {
       "name": "@modelcontextprotocol/server-github",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -4050,7 +4470,7 @@
     },
     "src/gitlab": {
       "name": "@modelcontextprotocol/server-gitlab",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -4103,7 +4523,7 @@
     },
     "src/google-maps": {
       "name": "@modelcontextprotocol/server-google-maps",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -4153,9 +4573,75 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "src/llm-txt": {
+      "name": "@modelcontextprotocol/server-llm-txt",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.0.1",
+        "@types/jsdom": "^21.1.6",
+        "@types/node-fetch": "^2.6.12",
+        "jsdom": "^22.1.0",
+        "node-fetch": "^3.3.2",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "mcp-server-llm-txt": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.4",
+        "shx": "^0.3.4",
+        "typescript": "^5.6.2"
+      }
+    },
+    "src/llm-txt/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "src/llm-txt/node_modules/@types/node": {
+      "version": "20.17.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.9.tgz",
+      "integrity": "sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "src/llm-txt/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "src/llm-txt/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "src/memory": {
       "name": "@modelcontextprotocol/server-memory",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1"
@@ -4190,7 +4676,7 @@
     },
     "src/postgres": {
       "name": "@modelcontextprotocol/server-postgres",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -4217,7 +4703,7 @@
     },
     "src/puppeteer": {
       "name": "@modelcontextprotocol/server-puppeteer",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1",
@@ -4243,7 +4729,7 @@
     },
     "src/sequentialthinking": {
       "name": "@modelcontextprotocol/server-sequential-thinking",
-      "version": "0.1.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.5.0",
@@ -4271,7 +4757,7 @@
     },
     "src/slack": {
       "name": "@modelcontextprotocol/server-slack",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@modelcontextprotocol/server-memory": "*",
     "@modelcontextprotocol/server-filesystem": "*",
     "@modelcontextprotocol/server-everart": "*",
-    "@modelcontextprotocol/server-sequential-thinking": "*"
+    "@modelcontextprotocol/server-sequential-thinking": "*",
+    "@modelcontextprotocol/server-llm-txt": "*"
   }
 }

--- a/src/server-llm-txt/README.md
+++ b/src/server-llm-txt/README.md
@@ -1,0 +1,124 @@
+# LLM.txt MCP Server
+
+This is a Model Context Protocol (MCP) server that provides access to LLM.txt files from the [LLM.txt Directory](https://directory.llmstxt.cloud/). It supports listing available files, fetching content, and searching within files.
+
+## Features
+
+- Directory listing with local caching (24-hour cache)
+- OS-specific cache locations:
+  - Windows: `%LOCALAPPDATA%\llm-txt-mcp`
+  - macOS: `~/Library/Caches/llm-txt-mcp`
+  - Linux: `~/.cache/llm-txt-mcp`
+- Multi-query search with context
+
+## Installation
+
+### Recommended: Using MCP Get
+
+The easiest way to install is using MCP Get, which will automatically configure the server in Claude Desktop:
+
+```bash
+npx @michaellatman/mcp-get@latest install @modelcontextprotocol/server-llm-txt
+```
+
+### Manual Configuration
+
+Alternatively, you can manually configure the server in your Claude Desktop configuration by adding this to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "llm-txt": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-llm-txt"
+      ]
+    }
+  }
+}
+```
+
+## Tools
+
+### 1. list_llm_txt
+
+Lists all available LLM.txt files from the directory. Results are cached locally for 24 hours.
+
+Example response:
+
+```json
+[
+  {
+    "id": 1,
+    "url": "https://docs.squared.ai/llms.txt",
+    "name": "AI Squared",
+    "description": "AI Squared provides a data and AI integration platform that helps make intelligent insights accessible to all."
+  }
+]
+```
+
+### 2. get_llm_txt
+
+Fetches content from an LLM.txt file by ID (obtained from list_llm_txt).
+
+Parameters:
+- `id`: The numeric ID of the LLM.txt file
+
+Example response:
+
+```json
+{
+  "id": 1,
+  "url": "https://docs.squared.ai/llms.txt",
+  "name": "AI Squared",
+  "description": "AI Squared provides a data and AI integration platform that helps make intelligent insights accessible to all.",
+  "content": "# AI Squared\n\n## Docs\n\n- [Create Catalog](https://docs.squared.ai/api-reference/catalogs/create_catalog)\n- [Update Catalog](https://docs.squared.ai/api-reference/catalogs/update_catalog)\n..."
+}
+```
+
+### 3. search_llm_txt
+
+Search for multiple substrings within an LLM.txt file.
+
+Parameters:
+- `id`: The numeric ID of the LLM.txt file
+- `queries`: Array of strings to search for (case-insensitive)
+- `context_lines` (optional): Number of lines to show before and after matches (default: 2)
+
+Example response:
+
+```json
+{
+  "id": 1,
+  "url": "https://docs.squared.ai/llms.txt",
+  "name": "AI Squared",
+  "matches": [
+    {
+      "lineNumber": 42,
+      "snippet": "- [PostgreSQL](https://docs.squared.ai/guides/data-integration/destinations/database/postgresql): PostgreSQL\n popularly known as Postgres, is a powerful, open-source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale data workloads.\n- [null](https://docs.squared.ai/guides/data-integration/destinations/e-commerce/facebook-product-catalog)",
+      "matchedLine": "- [PostgreSQL](https://docs.squared.ai/guides/data-integration/destinations/database/postgresql): PostgreSQL\n popularly known as Postgres, is a powerful, open-source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale data workloads.",
+      "matchedQueries": ["postgresql", "database"]
+    }
+  ]
+}
+```
+
+## FAQ
+
+### Why do the tools use numeric IDs instead of string identifiers?
+
+While the examples above show string IDs for clarity, the actual implementation uses numeric IDs. We found that when using string IDs (like domain names or slugs), language models were more likely to hallucinate plausible-looking but non-existent LLM.txt files. Using opaque numeric IDs encourages models to actually check the list of available files first rather than guessing at possible IDs.
+
+## Development
+
+To run in development mode with automatic recompilation:
+
+```bash
+npm install
+npm run watch
+```
+
+## License
+
+MIT

--- a/src/server-llm-txt/index.ts
+++ b/src/server-llm-txt/index.ts
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolRequest} from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  GetLLMTxtOptionsSchema,
+  ListLLMTxtOptionsSchema,
+  type LLMTxt,
+  type LLMTxtList,
+  type LLMTxtListItem
+} from './schemas.js';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Define schema for search tool
+const SearchLLMTxtOptionsSchema = z.object({
+  id: z.number().describe(
+    "The ID of the LLM.txt file to search in. Must be obtained first using the list_llm_txt command."
+  ),
+  queries: z.array(z.string()).min(1).describe(
+    "Array of substrings to search for. Each query is searched case-insensitively. At least one query is required."
+  ),
+  context_lines: z.number().optional().default(2).describe(
+    "Number of lines to show before and after each match for context. Defaults to 2 lines."
+  ),
+});
+
+const tools = {
+  get_llm_txt: {
+    description: "Fetch an LLM.txt file from a given URL. Format your response in beautiful markdown.",
+    inputSchema: zodToJsonSchema(GetLLMTxtOptionsSchema)
+  },
+  list_llm_txt: {
+    description: "List available LLM.txt files from the directory. Use this first before fetching a specific LLM.txt file. Format your response in beautiful markdown.",
+    inputSchema: zodToJsonSchema(ListLLMTxtOptionsSchema)
+  },
+  search_llm_txt: {
+    description: "Search for multiple substrings in an LLM.txt file. Requires a valid ID obtained from list_llm_txt command. Returns snippets with page numbers for each match. Format your response in beautiful markdown, using code blocks for snippets.",
+    inputSchema: zodToJsonSchema(SearchLLMTxtOptionsSchema)
+  }
+};
+
+const server = new Server({
+  name: "server-llm-txt",
+  version: "0.1.0",
+  author: "Michael Latman (https://michaellatman.com)"
+}, {
+  capabilities: {
+    tools
+  }
+});
+
+const DIRECTORY_URL = "https://directory.llmstxt.cloud/";
+const MAX_RESPONSE_LENGTH = 100000;
+const CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Get cache directory based on OS
+function getCacheDir(): string {
+  const platform = os.platform();
+  let cacheDir: string;
+
+  switch (platform) {
+    case 'win32':
+      cacheDir = path.join(os.homedir(), 'AppData', 'Local', 'llm-txt-mcp');
+      break;
+    case 'darwin':
+      cacheDir = path.join(os.homedir(), 'Library', 'Caches', 'llm-txt-mcp');
+      break;
+    default: // linux and others
+      cacheDir = path.join(os.homedir(), '.cache', 'llm-txt-mcp');
+  }
+
+  // Ensure cache directory exists
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
+  }
+
+  return cacheDir;
+}
+
+// Cache management functions
+function getCachedList(): LLMTxtList | null {
+  const cacheFile = path.join(getCacheDir(), 'llm-list-cache.json');
+  
+  try {
+    if (!fs.existsSync(cacheFile)) {
+      return null;
+    }
+
+    const cacheData = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+    const now = Date.now();
+
+    if (now - cacheData.timestamp > CACHE_DURATION_MS) {
+      return null; // Cache expired
+    }
+
+    return cacheData.data;
+  } catch (error) {
+    console.error('Error reading cache:', error);
+    return null;
+  }
+}
+
+function saveToCache(data: LLMTxtList): void {
+  const cacheFile = path.join(getCacheDir(), 'llm-list-cache.json');
+  const cacheData = {
+    timestamp: Date.now(),
+    data
+  };
+
+  try {
+    fs.writeFileSync(cacheFile, JSON.stringify(cacheData), 'utf-8');
+  } catch (error) {
+    console.error('Error writing cache:', error);
+  }
+}
+
+// Simple hash function to convert string to number
+function hashUrl(url: string): number {
+  let hash = 0;
+  for (let i = 0; i < url.length; i++) {
+    const char = url.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash); // Ensure positive number
+}
+
+async function getLLMTxt(id: number, page: number = 1): Promise<LLMTxt> {
+  // First get the list to find the URL for this ID
+  const allItems = await listLLMTxt(); // Get all items
+  const item = allItems.find(item => item.id === id);
+  
+  if (!item) {
+    throw new Error(`No LLM.txt found with ID: ${id}`);
+  }
+
+  const response = await fetch(item.url, {
+    headers: {
+      "Accept": "text/plain",
+      "User-Agent": "llm-txt-mcp-server"
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch LLM.txt: ${response.statusText}`);
+  }
+
+  const fullContent = await response.text();
+  const start = (page - 1) * MAX_RESPONSE_LENGTH;
+  let content = fullContent.slice(start, start + MAX_RESPONSE_LENGTH);
+  const hasNextPage = start + content.length < fullContent.length;
+
+  return {
+    id: item.id,
+    url: item.url,
+    name: item.name,
+    description: item.description,
+    hasNextPage,
+    currentPage: page,
+    content,
+  };
+}
+
+// Cache the promise of fetching the list to prevent multiple concurrent fetches
+let listFetchPromise: Promise<LLMTxtList> | null = null;
+
+async function listLLMTxt(): Promise<LLMTxtList> {
+  // If we're already fetching, return that promise
+  if (listFetchPromise) {
+    return listFetchPromise;
+  }
+
+  // Check cache first
+  const cachedList = getCachedList();
+  if (cachedList) {
+    return cachedList;
+  }
+
+  // Create a new fetch promise
+  listFetchPromise = (async () => {
+    try {
+      const response = await fetch(DIRECTORY_URL, {
+        headers: {
+          "Accept": "text/html",
+          "User-Agent": "llm-txt-mcp-server"
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch LLM.txt list: ${response.statusText}`);
+      }
+
+      const html = await response.text();
+      const dom = new JSDOM(html);
+      const document = dom.window.document;
+
+      // Find all llm.txt links
+      const links: LLMTxtListItem[] = Array.from(document.querySelectorAll('li'))
+        .map(li => {
+          // Try to find llms-full.txt link first, fall back to llms.txt
+          const fullLink = li.querySelector('a[href*="llms-full.txt"]');
+          const link = fullLink || li.querySelector('a[href*="llms.txt"]');
+          if (!link) return null;
+
+          const url = link.getAttribute('href') || '';
+          return {
+            id: hashUrl(url),
+            url,
+            name: li.querySelector('h3')?.textContent?.trim() || 'Unknown',
+            description: li.querySelector('p')?.textContent?.trim() || ''
+          };
+        })
+        .filter((item): item is LLMTxtListItem => item !== null && item.url.endsWith('.txt'));
+
+      // Save to cache
+      saveToCache(links);
+      
+      return links;
+    } finally {
+      // Clear the promise after it's done (success or failure)
+      listFetchPromise = null;
+    }
+  })();
+
+  return listFetchPromise;
+}
+
+async function searchLLMTxt(id: number, queries: string[], contextLines: number = 2): Promise<any> {
+  // First get the list to find the URL for this ID
+  const allItems = await listLLMTxt();
+  const item = allItems.find(item => item.id === id);
+  
+  if (!item) {
+    throw new Error(`No LLM.txt found with ID: ${id}`);
+  }
+
+  const response = await fetch(item.url, {
+    headers: {
+      "Accept": "text/plain",
+      "User-Agent": "llm-txt-mcp-server"
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch LLM.txt: ${response.statusText}`);
+  }
+
+  const content = await response.text();
+  const lines = content.split('\n');
+  const results = [];
+  const searchRegexes = queries.map(query => new RegExp(query, 'gi'));
+  
+  let charCount = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const matches = searchRegexes.some(regex => regex.test(lines[i]));
+    if (matches) {
+      const startLine = Math.max(0, i - contextLines);
+      const endLine = Math.min(lines.length - 1, i + contextLines);
+      const snippet = lines.slice(startLine, endLine + 1).join('\n');
+      const page = Math.floor(charCount / MAX_RESPONSE_LENGTH) + 1;
+      
+      // Find which queries matched this line
+      const matchedQueries = queries.filter(query => 
+        new RegExp(query, 'gi').test(lines[i])
+      );
+      
+      results.push({
+        page,
+        lineNumber: i + 1,
+        snippet,
+        matchedLine: lines[i],
+        matchedQueries
+      });
+    }
+    charCount += lines[i].length + 1; // +1 for the newline character
+  }
+
+  return {
+    id: item.id,
+    url: item.url,
+    name: item.name,
+    matches: results
+  };
+}
+
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  try {
+    if (!request.params.arguments) {
+      throw new Error("Arguments are required");
+    }
+
+    switch (request.params.name) {
+      case "get_llm_txt": {
+        const args = GetLLMTxtOptionsSchema.parse(request.params.arguments);
+        const result = await getLLMTxt(args.id, args.page);
+        
+        // Always truncate to MAX_RESPONSE_LENGTH and indicate if there's more
+        const content = result.content.slice(0, MAX_RESPONSE_LENGTH);
+        const hasMoreContent = result.content.length > MAX_RESPONSE_LENGTH || result.hasNextPage;
+        
+        const response = {
+  
+          currentPage: result.currentPage,
+          ...(hasMoreContent && {
+            hasNextPage: true
+          }),
+          content
+        };
+        
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      }
+
+      case "list_llm_txt": {
+        const result = await listLLMTxt();
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "search_llm_txt": {
+        const args = SearchLLMTxtOptionsSchema.parse(request.params.arguments);
+        const result = await searchLLMTxt(args.id, args.queries, args.context_lines);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+  } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      const issues = error.issues.map((issue: z.ZodIssue) => `${issue.path.join('.')}: ${issue.message}`).join(', ');
+      throw new Error(`Invalid arguments: ${issues}`);
+    }
+    throw error;
+  }
+});
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: Object.entries(tools).map(([name, tool]) => ({
+      name,
+      description: tool.description,
+      inputSchema: tool.inputSchema
+    }))
+  };
+});
+
+async function runServer() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("LLM.txt MCP Server running on stdio");
+}
+
+runServer().catch((error) => {
+  console.error("Server error:", error);
+  process.exit(1);
+}); 

--- a/src/server-llm-txt/package.json
+++ b/src/server-llm-txt/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@modelcontextprotocol/server-llm-txt",
+  "version": "0.6.1",
+  "description": "MCP server for serving llm.txt files",
+  "author": "Michael Latman (https://michaellatman.com)",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "mcp-server-llm-txt": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && shx chmod +x dist/*.js",
+    "prepare": "npm run build",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.0.1",
+    "@types/node-fetch": "^2.6.12",
+    "node-fetch": "^3.3.2",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.23.5",
+    "jsdom": "^22.1.0",
+    "@types/jsdom": "^21.1.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.4",
+    "shx": "^0.3.4",
+    "typescript": "^5.6.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/modelcontextprotocol/servers.git"
+  },
+  "bugs": {
+    "url": "https://github.com/modelcontextprotocol/servers/issues"
+  },
+  "homepage": "https://github.com/modelcontextprotocol/servers#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/server-llm-txt/schemas.ts
+++ b/src/server-llm-txt/schemas.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+// Schema for items in the list view (without content)
+export const LLMTxtListItemSchema = z.object({
+  id: z.number(),
+  url: z.string().url(),
+  name: z.string(),
+  description: z.string()
+});
+
+export type LLMTxtListItem = z.infer<typeof LLMTxtListItemSchema>;
+
+// Schema for a full item with content
+export const LLMTxtSchema = z.object({
+  id: z.number(),
+  url: z.string().url(),
+  name: z.string(),
+  description: z.string(),
+  content: z.string(),
+  hasNextPage: z.boolean().optional(),
+  currentPage: z.number()
+});
+
+export type LLMTxt = z.infer<typeof LLMTxtSchema>;
+
+// List of items (without content)
+export const LLMTxtListSchema = z.array(LLMTxtListItemSchema);
+
+export type LLMTxtList = z.infer<typeof LLMTxtListSchema>;
+
+export const GetLLMTxtOptionsSchema = z.object({
+  id: z.number().describe(
+    "The ID of the LLM.txt file to fetch. Must be obtained first using the list_llm_txt command."
+  ),
+  page: z.number().optional().default(1).describe(
+    "Page number to fetch, starting from 1. Each page contains a fixed number of characters."
+  )
+});
+
+export type GetLLMTxtOptions = z.infer<typeof GetLLMTxtOptionsSchema>;
+
+export const ListLLMTxtOptionsSchema = z.object({
+  // Empty object since we're removing pagination
+});
+
+export type ListLLMTxtOptions = z.infer<typeof ListLLMTxtOptionsSchema>; 

--- a/src/server-llm-txt/tsconfig.json
+++ b/src/server-llm-txt/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["node_modules", "dist"]
+} 


### PR DESCRIPTION
## Description
Add LLM text search server with caching and real examples

## Server Details
- Server: server-llm-txt
- Changes to: New server implementation with search tools and caching

## Motivation and Context
This server provides a way to search through [LLM.txt](https://llmstxt.org/) files and return snippets with page numbers. It includes caching for improved performance and examples from various llms.txt files.

## How Has This Been Tested?
- Tested search functionality with multiple llms.txt files
- Manually verified caching behavior
- Confirmed page number calculations
- Tested with various query patterns and context sizes

## Breaking Changes
No breaking changes. This is a new server that doesn't affect existing functionality.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
None
