### PR TITLE
Add MySQL MCP server to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[Spotify MCP](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify. 
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
-- **[MySQL MCP](https://github.com/designcomputer/mysql_mcp_server)** - MySQL database integration with configurable access controls, schema inspection, and comprehensive security guidelines
+- **[MySQL](https://github.com/designcomputer/mysql_mcp_server)** - MySQL database integration with configurable access controls and schema inspection
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[Spotify MCP](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify. 
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
+- **[MySQL MCP](https://github.com/designcomputer/mysql_mcp_server)** - MySQL database integration with configurable access controls, schema inspection, and comprehensive security guidelines
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 


### PR DESCRIPTION
## Description
Adding MySQL MCP server implementation to Community Servers section in README.md

## Server Details
- Server: mysql-mcp-server (new community server addition)
- Changes to: README.md only - adding entry to Community Servers list

## Motivation and Context
Adding reference to a new community implementation of an MCP server that provides MySQL database integration. This helps increase visibility of available MCP servers and provides another database integration option for the community.

## How Has This Been Tested?
This is a documentation update only - adding a reference to an existing, tested implementation. 

The referenced MySQL MCP server itself has been thoroughly tested:
- Automated testing via GitHub Actions workflow
- Tests run against MySQL 8.0 in a containerized environment
- Tested with Python 3.11 and 3.12
- Full test suite runs with pytest
- Integration tested with Claude Desktop as the LLM client
- Includes verification of module installation and dependencies

## Breaking Changes
None - this is a documentation addition only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] Changes follow existing entry format in README.md
- [x] Added in alphabetical order in Community Servers section