### PR TITLE
feat: github: add capability to list commits of a branch

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -102,6 +102,16 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `from_branch` (optional string): Source branch (defaults to repo default)
    - Returns: Created branch reference
 
+10. `list_commits`
+   - Gets commits of a branch in a repository
+   - Inputs:
+     - `owner` (string): Repository owner
+     - `repo` (string): Repository name
+     - `page` (optional string): page number
+     - `per_page` (optional string): number of record per page
+     - `sha` (optional string): branch name
+   - Returns: List of commits
+
 ## Setup
 
 ### Personal Access Token

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -18,6 +18,7 @@ import {
   GitHubSearchResponseSchema,
   GitHubTreeSchema,
   GitHubCommitSchema,
+  GitHubListCommitsSchema,
   CreateRepositoryOptionsSchema,
   CreateIssueOptionsSchema,
   CreatePullRequestOptionsSchema,
@@ -42,7 +43,8 @@ import {
   CreatePullRequestSchema,
   ForkRepositorySchema,
   CreateBranchSchema,
-  ListCommitsSchema
+  ListCommitsSchema,
+  GitHubListCommits
 } from './schemas.js';
 import { z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
@@ -474,7 +476,7 @@ async function listCommits(
   page: number = 1,
   perPage: number = 30,
   sha?: string,
-): Promise<GitHubCommit[]> {
+): Promise<GitHubListCommits> {
   const url = new URL(`https://api.github.com/repos/${owner}/${repo}/commits`);
   url.searchParams.append("page", page.toString());
   url.searchParams.append("per_page", perPage.toString());
@@ -499,7 +501,7 @@ async function listCommits(
     throw new Error(`GitHub API error: ${response.statusText}`);
   }
 
-  return GitHubCommitSchema.array().parse(await response.json());
+  return GitHubListCommitsSchema.parse(await response.json());
 }
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {

--- a/src/github/schemas.ts
+++ b/src/github/schemas.ts
@@ -93,6 +93,25 @@ export const GitHubTreeSchema = z.object({
   truncated: z.boolean()
 });
 
+export const GitHubListCommitsSchema = z.array(z.object({
+  sha: z.string(),
+  node_id: z.string(),
+  commit: z.object({
+    author: GitHubAuthorSchema,
+    committer: GitHubAuthorSchema,
+    message: z.string(),
+    tree: z.object({
+      sha: z.string(),
+      url: z.string()
+    }),
+    url: z.string(),
+    comment_count: z.number(),
+  }),
+  url: z.string(),
+  html_url: z.string(),
+  comments_url: z.string()
+}));
+
 export const GitHubCommitSchema = z.object({
   sha: z.string(),
   node_id: z.string(),
@@ -378,6 +397,7 @@ export type GitHubContent = z.infer<typeof GitHubContentSchema>;
 export type FileOperation = z.infer<typeof FileOperationSchema>;
 export type GitHubTree = z.infer<typeof GitHubTreeSchema>;
 export type GitHubCommit = z.infer<typeof GitHubCommitSchema>;
+export type GitHubListCommits = z.infer<typeof GitHubListCommitsSchema>;
 export type GitHubReference = z.infer<typeof GitHubReferenceSchema>;
 export type CreateRepositoryOptions = z.infer<typeof CreateRepositoryOptionsSchema>;
 export type CreateIssueOptions = z.infer<typeof CreateIssueOptionsSchema>;

--- a/src/github/schemas.ts
+++ b/src/github/schemas.ts
@@ -308,6 +308,15 @@ export const SearchRepositoriesSchema = z.object({
   perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)")
 });
 
+export const ListCommitsSchema = z.object({
+  owner: z.string().describe("Repository owner (username or organization)"),
+  repo: z.string().describe("Repository name"),
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+  perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)"),
+  sha: z.string().optional()
+    .describe("SHA of the file being replaced (required when updating existing files)")
+});
+
 export const CreateRepositorySchema = z.object({
   name: z.string().describe("Repository name"),
   description: z.string().optional().describe("Repository description"),


### PR DESCRIPTION
Add ListCommits functionality to get commit details of a branch in a repository

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: GitHub
- Changes to: Tools

## Motivation and Context
To read commit messages and generate contextual release notes

## How Has This Been Tested?
Tested with Claude Desktop Client. Generated release notes using a prompt like this -
`Get last 5 commit messages from master branch in x/y repo and generate release notes for the same
`

This used the list_commits tool to get commit messages and use them to generate release notes.

<img width="722" alt="image" src="https://github.com/user-attachments/assets/55c4829b-fcf5-482c-b4f8-c58e54e25687">

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
