### PR TITLE
Make `merge_commit_sha` nullable in GitHub server

### DIFF
--- a/src/github/schemas.ts
+++ b/src/github/schemas.ts
@@ -281,7 +281,7 @@ export const GitHubPullRequestSchema = z.object({
   updated_at: z.string(),
   closed_at: z.string().nullable(),
   merged_at: z.string().nullable(),
-  merge_commit_sha: z.string(),
+  merge_commit_sha: z.string().nullable(),
   assignee: GitHubIssueAssigneeSchema.nullable(),
   assignees: z.array(GitHubIssueAssigneeSchema),
   head: GitHubPullRequestHeadSchema,


### PR DESCRIPTION
Fixes #227.

<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: type definitions

## Motivation and Context
Fixes #227 - `merge_commit_sha` will be nullable immediately after a PR is created so should be marked as nullable otherwise the parsing will fail.

## How Has This Been Tested?
Tested locally with the changes to the server applied.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
