### PR TITLE
Add website of awesome-mcp-servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A growing set of community-developed and maintained servers demonstrates various
 Additional resources on MCP.
 
 - **[Awesome MCP Servers by punkpeye](https://github.com/punkpeye/awesome-mcp-servers)** - A curated list of MCP servers by **[Frank Fiegel](https://github.com/punkpeye)**
-- **[Awesome MCP Servers by wong2](https://github.com/wong2/awesome-mcp-servers)** - A curated list of MCP servers by **[wong2](https://github.com/wong2)**
+- **[Awesome MCP Servers by wong2](https://github.com/wong2/awesome-mcp-servers)** - **[website](https://mcpservers.org)** - A curated list of MCP servers by **[wong2](https://github.com/wong2)**
 - **[Awesome MCP Servers by appcypher](https://github.com/appcypher/awesome-mcp-servers)** - A curated list of MCP servers by **[Stephen Akinyemi](https://github.com/appcypher)**
 - **[mcp-get](https://mcp-get.com)** - Command line tool for installing and managing MCP servers by **[Michael Latman](https://github.com/michaellatman)**
 - **[mcp-cli](https://github.com/wong2/mcp-cli)** - A CLI inspector for the Model Context Protocol by **[wong2](https://github.com/wong2)**

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A growing set of community-developed and maintained servers demonstrates various
 Additional resources on MCP.
 
 - **[Awesome MCP Servers by punkpeye](https://github.com/punkpeye/awesome-mcp-servers)** - A curated list of MCP servers by **[Frank Fiegel](https://github.com/punkpeye)**
-- **[Awesome MCP Servers by wong2](https://github.com/wong2/awesome-mcp-servers)** - **[website](https://mcpservers.org)** - A curated list of MCP servers by **[wong2](https://github.com/wong2)**
+- **[Awesome MCP Servers by wong2](https://github.com/wong2/awesome-mcp-servers)** (**[website](https://mcpservers.org)**) - A curated list of MCP servers by **[wong2](https://github.com/wong2)**
 - **[Awesome MCP Servers by appcypher](https://github.com/appcypher/awesome-mcp-servers)** - A curated list of MCP servers by **[Stephen Akinyemi](https://github.com/appcypher)**
 - **[mcp-get](https://mcp-get.com)** - Command line tool for installing and managing MCP servers by **[Michael Latman](https://github.com/michaellatman)**
 - **[mcp-cli](https://github.com/wong2/mcp-cli)** - A CLI inspector for the Model Context Protocol by **[wong2](https://github.com/wong2)**


### PR DESCRIPTION
My `awesome-mcp-servers` repo now has a [website](https://mcpservers.org/) for easier viewing and filtering.