### PR TITLE
Replaced hyphen with underscore in Sqlite & Sentry tools..

### DIFF
--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -6,7 +6,7 @@ A Model Context Protocol server for retrieving and analyzing issues from Sentry.
 
 ### Tools
 
-1. `get-sentry-issue`
+1. `get_sentry_issue`
    - Retrieve and analyze a Sentry issue by ID or URL
    - Input:
      - `issue_id_or_url` (string): Sentry issue ID or URL to analyze

--- a/src/sentry/src/mcp_server_sentry/server.py
+++ b/src/sentry/src/mcp_server_sentry/server.py
@@ -223,7 +223,7 @@ async def serve(auth_token: str) -> Server:
     async def handle_list_tools() -> list[types.Tool]:
         return [
             types.Tool(
-                name="get-sentry-issue",
+                name="get_sentry_issue",
                 description="""Retrieve and analyze a Sentry issue by ID or URL. Use this tool when you need to:
                 - Investigate production errors and crashes
                 - Access detailed stacktraces from Sentry
@@ -247,7 +247,7 @@ async def serve(auth_token: str) -> Server:
     async def handle_call_tool(
         name: str, arguments: dict | None
     ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
-        if name != "get-sentry-issue":
+        if name != "get_sentry_issue":
             raise ValueError(f"Unknown tool: {name}")
 
         if not arguments or "issue_id_or_url" not in arguments:

--- a/src/sqlite/README.md
+++ b/src/sqlite/README.md
@@ -22,26 +22,26 @@ The server provides a demonstration prompt:
 The server offers six core tools:
 
 #### Query Tools
-- `read-query`
+- `read_query`
    - Execute SELECT queries to read data from the database
    - Input:
      - `query` (string): The SELECT SQL query to execute
    - Returns: Query results as array of objects
 
-- `write-query`
+- `write_query`
    - Execute INSERT, UPDATE, or DELETE queries
    - Input:
      - `query` (string): The SQL modification query
    - Returns: `{ affected_rows: number }`
 
-- `create-table`
+- `create_table`
    - Create new tables in the database
    - Input:
      - `query` (string): CREATE TABLE SQL statement
    - Returns: Confirmation of table creation
 
 #### Schema Tools
-- `list-tables`
+- `list_tables`
    - Get a list of all tables in the database
    - No input required
    - Returns: Array of table names
@@ -53,7 +53,7 @@ The server offers six core tools:
    - Returns: Array of column definitions with names and types
 
 #### Analysis Tools
-- `append-insight`
+- `append_insight`
    - Add new business insights to the memo resource
    - Input:
      - `insight` (string): Business insight discovered from data analysis

--- a/src/sqlite/src/mcp_server_sqlite/server.py
+++ b/src/sqlite/src/mcp_server_sqlite/server.py
@@ -27,12 +27,12 @@ Resources:
 This server exposes one key resource: "memo://insights", which is a business insights memo that gets automatically updated throughout the analysis process. As users analyze the database and discover insights, the memo resource gets updated in real-time to reflect new findings. Resources act as living documents that provide context to the conversation.
 Tools:
 This server provides several SQL-related tools:
-"read-query": Executes SELECT queries to read data from the database
-"write-query": Executes INSERT, UPDATE, or DELETE queries to modify data
-"create-table": Creates new tables in the database
-"list-tables": Shows all existing tables
-"describe-table": Shows the schema for a specific table
-"append-insight": Adds a new business insight to the memo resource
+"read_query": Executes SELECT queries to read data from the database
+"write_query": Executes INSERT, UPDATE, or DELETE queries to modify data
+"create_table": Creates new tables in the database
+"list_tables": Shows all existing tables
+"describe_table": Shows the schema for a specific table
+"append_insight": Adds a new business insight to the memo resource
 </mcp>
 <demo-instructions>
 You are an AI assistant tasked with generating a comprehensive business scenario based on a given topic.
@@ -68,7 +68,7 @@ a. Present 1 additional multiple-choice query options to the user. Its important
 b. Explain the purpose of each query option.
 c. Wait for the user to select one of the query options.
 d. After each query be sure to opine on the results.
-e. Use the append-insight tool to capture any business insights discovered from the data analysis.
+e. Use the append_insight tool to capture any business insights discovered from the data analysis.
 
 7. Generate a dashboard:
 a. Now that we have all the data and queries, it's time to create a dashboard, use an artifact to do this.
@@ -233,7 +233,7 @@ async def main(db_path: str):
         """List available tools"""
         return [
             types.Tool(
-                name="read-query",
+                name="read_query",
                 description="Execute a SELECT query on the SQLite database",
                 inputSchema={
                     "type": "object",
@@ -244,7 +244,7 @@ async def main(db_path: str):
                 },
             ),
             types.Tool(
-                name="write-query",
+                name="write_query",
                 description="Execute an INSERT, UPDATE, or DELETE query on the SQLite database",
                 inputSchema={
                     "type": "object",
@@ -255,7 +255,7 @@ async def main(db_path: str):
                 },
             ),
             types.Tool(
-                name="create-table",
+                name="create_table",
                 description="Create a new table in the SQLite database",
                 inputSchema={
                     "type": "object",
@@ -266,7 +266,7 @@ async def main(db_path: str):
                 },
             ),
             types.Tool(
-                name="list-tables",
+                name="list_tables",
                 description="List all tables in the SQLite database",
                 inputSchema={
                     "type": "object",
@@ -274,7 +274,7 @@ async def main(db_path: str):
                 },
             ),
             types.Tool(
-                name="describe-table",
+                name="describe_table",
                 description="Get the schema information for a specific table",
                 inputSchema={
                     "type": "object",
@@ -285,7 +285,7 @@ async def main(db_path: str):
                 },
             ),
             types.Tool(
-                name="append-insight",
+                name="append_insight",
                 description="Add a business insight to the memo",
                 inputSchema={
                     "type": "object",
@@ -303,13 +303,13 @@ async def main(db_path: str):
     ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
         """Handle tool execution requests"""
         try:
-            if name == "list-tables":
+            if name == "list_tables":
                 results = db._execute_query(
                     "SELECT name FROM sqlite_master WHERE type='table'"
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
-            elif name == "describe-table":
+            elif name == "describe_table":
                 if not arguments or "table_name" not in arguments:
                     raise ValueError("Missing table_name argument")
                 results = db._execute_query(
@@ -317,7 +317,7 @@ async def main(db_path: str):
                 )
                 return [types.TextContent(type="text", text=str(results))]
 
-            elif name == "append-insight":
+            elif name == "append_insight":
                 if not arguments or "insight" not in arguments:
                     raise ValueError("Missing insight argument")
 
@@ -332,19 +332,19 @@ async def main(db_path: str):
             if not arguments:
                 raise ValueError("Missing arguments")
 
-            if name == "read-query":
+            if name == "read_query":
                 if not arguments["query"].strip().upper().startswith("SELECT"):
-                    raise ValueError("Only SELECT queries are allowed for read-query")
+                    raise ValueError("Only SELECT queries are allowed for read_query")
                 results = db._execute_query(arguments["query"])
                 return [types.TextContent(type="text", text=str(results))]
 
-            elif name == "write-query":
+            elif name == "write_query":
                 if arguments["query"].strip().upper().startswith("SELECT"):
-                    raise ValueError("SELECT queries are not allowed for write-query")
+                    raise ValueError("SELECT queries are not allowed for write_query")
                 results = db._execute_query(arguments["query"])
                 return [types.TextContent(type="text", text=str(results))]
 
-            elif name == "create-table":
+            elif name == "create_table":
                 if not arguments["query"].strip().upper().startswith("CREATE TABLE"):
                     raise ValueError("Only CREATE TABLE statements are allowed")
                 db._execute_query(arguments["query"])


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Sqlite and Sentry MCP servers are not working of Amzaon Nova models as tool names do not accept `hyphen` in the name. It seems to be logical to me to have some sort of standard convention in the tool names. I checked all MCP Servers, all seems to follow tool names convention with this regular expression `[a-zA-Z][a-zA-Z0-9_]*` other than Sqlite and Sentry. I have replaced `hyphen` with `underscore` in these MCP servers.

## Server Details

- Server: Sqlite, Sentry
- Changes to: tools

## Motivation and Context

Sqlite and Sentry MCP servers are not working of Amzaon Nova models as tool names do not accept `hyphen` in the name. It seems to be logical to me to have some sort of standard convention in the tool names. I checked all MCP Servers, all seems to follow tool names convention with this regular expression `[a-zA-Z][a-zA-Z0-9_]*` other than Sqlite and Sentry. I have replaced `hyphen` with `underscore` in these MCP servers.

## How Has This Been Tested?
I have tested the Sqlite MCP server with MCP client (https://github.com/rakesh-eltropy/mcp-client).

## Breaking Changes

NA

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
NA
