### PR TITLE
Update case sensitivity handling for filesystem server

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -24,7 +24,7 @@ if (args.length === 0) {
 
 // Normalize all paths consistently
 function normalizePath(p: string): string {
-  return path.normalize(p).toLowerCase();
+  return path.normalize(p);
 }
 
 function expandHome(filepath: string): string {


### PR DESCRIPTION
Should fix #194 

This issue mentioned problems with how the filesystem server was handling case sensitivity - it shouldn't always do `.toLowerCase()` since this breaks access to paths on case-sensitive filesystems. This PR removes the forced lowercase conversion and lets the native filesystem handle case sensitivity.