### PR TITLE
fix(github): Allow body to be nullable in GithubIssueSchema

### DIFF
--- a/src/github/schemas.ts
+++ b/src/github/schemas.ts
@@ -274,7 +274,7 @@ export const GitHubIssueSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
   closed_at: z.string().nullable(),
-  body: z.string(),
+  body: z.string().nullable(),
 });
 
 // Pull Request related schemas


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
Fix for GithubIssueSchema, as body field can be nullable.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: `github`
- Changes to: `GithubIssueSchema`

## Motivation and Context
Tried using list_issues tool and it failed with next error:
```
Error executing code: MCP error -32603: Invalid arguments: 6.body: Expected string, received null
```

Technically, get_issue also was breaking, as `GithubIssue` object may have body which equals to null.

## How Has This Been Tested?
Locally with latest version via Claude Desktop

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly - not needed.
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally - no tests for Github MCP server.
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
Got this error when validating https://github.com/modelcontextprotocol/servers/issues/296
