### PR TITLE
filesystem - load files into model context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1565,6 +1565,13 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -5189,9 +5196,10 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "0.5.0",
+        "@modelcontextprotocol/sdk": "1.0.1",
         "diff": "^5.1.0",
         "glob": "^10.3.10",
+        "mime-types": "^2.1.35",
         "minimatch": "^10.0.1",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -5200,6 +5208,7 @@
       },
       "devDependencies": {
         "@types/diff": "^5.0.9",
+        "@types/mime-types": "^2.1.4",
         "@types/minimatch": "^5.1.2",
         "@types/node": "^20.11.0",
         "shx": "^0.3.4",

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -9,6 +9,7 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 - Move files/directories
 - Search files
 - Get file metadata
+- Load files into model context
 
 **Note**: The server will only allow operations within directories specified via `args`.
 
@@ -16,7 +17,18 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 
 ### Resources
 
-- `file://system`: File system operations interface
+The server supports files and directories as resources:
+
+- **Files** (`file:///<path>`)
+  - Text files are provided as UTF-8 text
+  - Binary files (images, PDFs, etc.) are provided as base64-encoded blobs
+  - Automatic MIME type detection for common file types
+
+- **Directories** (`folder:///<path>`)
+  - Listed as resources with `inode/directory` MIME type
+  - Contents provided as newline-separated file listing
+  - Pagination support for large directories
+
 
 ### Tools
 
@@ -102,6 +114,21 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - No input required
   - Returns:
     - Directories that this server can read/write from
+
+### Prompts
+
+- **load_file**
+  - Load and a single file into model context
+  - Input: `path` (string, absolute path to file)
+  - Automatic file type detection and handling, supports text, image, and binary files
+  - Only supports files in allowed directories
+
+- **load_folder**
+  - Recursively load all files in a folder into model context
+  - Input: `path` (string, absolute path to folder)
+  - Automatic file type detection and handling, supports text, image, and binary files
+  - Limit of 30 files
+  - Only supports files in allowed directories
 
 ## Usage with Claude Desktop
 Add this to your `claude_desktop_config.json`:

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -4,7 +4,11 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
   ToolSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import fs from "fs/promises";
@@ -711,90 +715,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 });
-
-// server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
-//   try {
-//     const pageSize = 100;
-//     let results: Array<{uri: string, name: string, mimeType?: string}> = [];
-    
-//     // Handle cursor-based pagination if provided
-//     const cursor = request.params?.cursor;
-//     let startPath: string;
-    
-//     if (cursor) {
-//       startPath = await validatePath(cursor);
-//     } else {
-//       // If no cursor, check if we're listing a specific folder
-//       const uri = request.params?.uri as string | undefined;
-//       const folderMatch = uri?.match(/^folder:\/\/(.+)/);
-//       if (folderMatch) {
-//         startPath = await validatePath(folderMatch[1]);
-//       } else {
-//         startPath = allowedDirectories[0];
-//       }
-//     }
-
-//     // Read directory contents
-//     const entries = await fs.readdir(startPath, { withFileTypes: true });
-    
-//     for (const entry of entries) {
-//       const fullPath = path.join(startPath, entry.name);
-//       try {
-//         await validatePath(fullPath);
-        
-//         let mimeType: string | undefined;
-//         if (entry.isFile()) {
-//           // MIME type detection logic remains the same
-//           if (entry.name.endsWith('.json')) mimeType = 'application/json';
-//           else if (entry.name.endsWith('.txt')) mimeType = 'text/plain';
-//           else if (entry.name.endsWith('.md')) mimeType = 'text/markdown';
-//           else if (entry.name.match(/\.(jpg|jpeg)$/i)) mimeType = 'image/jpeg';
-//           else if (entry.name.endsWith('.png')) mimeType = 'image/png';
-//         }
-
-//         // Get path relative to workspace root
-//         const relativePath = path.relative(process.cwd(), fullPath);
-//         // Convert backslashes to forward slashes for URI compatibility
-//         const uriPath = relativePath.split(path.sep).join('/');
-        
-//         // Use appropriate URI scheme based on type
-//         const uri = entry.isDirectory() 
-//           ? `folder://${uriPath}`
-//           : `file://${uriPath}`;
-
-//         results.push({
-//           uri,
-//           name: entry.name,
-//           mimeType: entry.isDirectory() ? 'inode/directory' : mimeType,
-//         });
-//       } catch {
-//         // Skip invalid paths
-//         continue;
-//       }
-//     }
-
-//     // Sort results for consistency
-//     results.sort((a, b) => a.name.localeCompare(b.name));
-
-//     // Handle pagination
-//     let nextCursor: string | undefined;
-//     if (results.length > pageSize) {
-//       results = results.slice(0, pageSize);
-//       const lastEntry = results[results.length - 1];
-//       const lastPath = path.dirname(lastEntry.uri.replace(/^(file|folder):\/\//, ''));
-//       nextCursor = lastPath;
-//     }
-
-//     return {
-//       resources: results,
-//       nextCursor,
-//     };
-//   } catch (error) {
-//     const errorMessage = error instanceof Error ? error.message : String(error);
-//     throw new Error(`Failed to list resources: ${errorMessage}`);
-//   }
-// });
-
 
 // Add this handler after the other resource handlers
 server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -12,7 +12,8 @@ import path from "path";
 import os from 'os';
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { diffLines, createTwoFilesPatch } from 'diff';
+import { createTwoFilesPatch } from 'diff';
+import * as mimeTypes from 'mime-types';
 import { minimatch } from 'minimatch';
 
 // Command line argument parsing
@@ -163,7 +164,9 @@ const server = new Server(
   },
   {
     capabilities: {
+      resources: {},
       tools: {},
+      prompts: {}
     },
   },
 );

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -19,14 +19,16 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.5.0",
+    "@modelcontextprotocol/sdk": "1.0.1",
     "diff": "^5.1.0",
     "glob": "^10.3.10",
+    "mime-types": "^2.1.35",
     "minimatch": "^10.0.1",
     "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",
+    "@types/mime-types": "^2.1.4",
     "@types/minimatch": "^5.1.2",
     "@types/node": "^20.11.0",
     "shx": "^0.3.4",


### PR DESCRIPTION
## Description

Adds resource templates and prompts to the filesystem reference server to load files and folders into model context.
Applied a limit of 30 files for loading into context.

- loads files (e.g. images, pdfs) into context (rather than as base64 in a message).
- demonstrates a practical use of prompts for loading files into context.
<img width="360" alt="image" src="https://github.com/user-attachments/assets/9ae941f0-7064-41e9-b9b3-a68a166196f1">
<img width="263" alt="image" src="https://github.com/user-attachments/assets/c6abe0ab-7400-434b-8079-e0f0cd2f5131">
<img width="375" alt="image" src="https://github.com/user-attachments/assets/959c3964-462f-46cd-9859-2a678cc8c0dc">

Note: This differs from drag/drop of files into Claude is that this allows the chat to keep track of the uris of files in the context and pass them to tools

## Server Details

- Server: filesystem
- Changes to: resources, prompts

## Motivation and Context
- Allows loading images, pdf etc. into model context. There are lots of reasons why files would be loaded into context.
- Tools do not load into model context but into a message.
- Model context is preferable for images, pdfs and most non-text data
- Model context is the only way to load larger files - these cannot be loaded via tools because they hit message response size limits.
- demonstrates a practical use of prompts for loading files into context.

## How Has This Been Tested?
Tested prompts with Claude

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Addresses this issue: https://github.com/modelcontextprotocol/servers/issues/297
Relevant to this discussion: https://github.com/modelcontextprotocol/specification/discussions/90
Very valuable conversation on reddit: https://www.reddit.com/r/mcp/comments/1hamhob/comment/m1cbq30/
