### PR TITLE
feat(time): add support for offset style timezones

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -1,18 +1,18 @@
 # Time MCP Server
 
-A Model Context Protocol server that provides time and timezone conversion capabilities. This server enables LLMs to get current time information and perform timezone conversions using IANA timezone names, with automatic system timezone detection.
+A Model Context Protocol server that provides time and timezone conversion capabilities. This server enables LLMs to get current time information and perform timezone conversions using IANA timezone names or offset formats (e.g. +0530), with automatic system timezone detection.
 
 ### Available Tools
 
 - `get_current_time` - Get current time in a specific timezone or system timezone.
   - Required arguments:
-    - `timezone` (string): IANA timezone name (e.g., 'America/New_York', 'Europe/London')
+    - `timezone` (string): IANA timezone name (e.g., 'America/New_York', 'Europe/London') or offset format (e.g., '+0530', '-0800')
 
 - `convert_time` - Convert time between timezones.
   - Required arguments:
-    - `source_timezone` (string): Source IANA timezone name
+    - `source_timezone` (string): Source IANA timezone name or offset format
     - `time` (string): Time in 24-hour format (HH:MM)
-    - `target_timezone` (string): Target IANA timezone name
+    - `target_timezone` (string): Target IANA timezone name or offset format
 
 ## Installation
 

--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -4,14 +4,13 @@ import json
 from typing import Sequence
 import re
 
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, available_timezones
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
 from mcp.shared.exceptions import McpError
 
 from pydantic import BaseModel
-from zoneinfo import available_timezones
 
 
 
@@ -38,23 +37,21 @@ class TimeConversionInput(BaseModel):
     target_tz_list: list[str]
 
 
-
 def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
     if local_tz_override:
-        # Try to handle offset-style timezone first
-        if local_tz_override.startswith('+') or local_tz_override.startswith('-'):
-            return get_zoneinfo(local_tz_override)
-        return ZoneInfo(local_tz_override)
+        return get_zoneinfo(local_tz_override)
 
     # Get local timezone from datetime.now()
-    tzinfo = datetime.now().astimezone(tz=None).tzinfo
-    if tzinfo is not None:
-        # Convert tzinfo to string and handle potential offset format
+    try:
+        tzinfo = datetime.now().astimezone().tzinfo
+        if tzinfo is None:
+            raise McpError("Could not determine local timezone - tzinfo is None")
+        
         tz_str = str(tzinfo)
-        if tz_str.startswith('+') or tz_str.startswith('-'):
-            return get_zoneinfo(tz_str)
-        return ZoneInfo(tz_str)
-    raise McpError("Could not determine local timezone - tzinfo is None")
+        return get_zoneinfo(tz_str)
+        
+    except Exception as e:
+        raise McpError(f"Error getting local timezone: {str(e)}")
 
 
 def parse_offset_timezone(timezone_name: str) -> ZoneInfo | None:

--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -38,14 +38,22 @@ class TimeConversionInput(BaseModel):
     target_tz_list: list[str]
 
 
+
 def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
     if local_tz_override:
+        # Try to handle offset-style timezone first
+        if local_tz_override.startswith('+') or local_tz_override.startswith('-'):
+            return get_zoneinfo(local_tz_override)
         return ZoneInfo(local_tz_override)
 
     # Get local timezone from datetime.now()
     tzinfo = datetime.now().astimezone(tz=None).tzinfo
     if tzinfo is not None:
-        return ZoneInfo(str(tzinfo))
+        # Convert tzinfo to string and handle potential offset format
+        tz_str = str(tzinfo)
+        if tz_str.startswith('+') or tz_str.startswith('-'):
+            return get_zoneinfo(tz_str)
+        return ZoneInfo(tz_str)
     raise McpError("Could not determine local timezone - tzinfo is None")
 
 

--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 import json
 from typing import Sequence
+import re
 
 from zoneinfo import ZoneInfo
 from mcp.server import Server
@@ -10,6 +11,8 @@ from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource
 from mcp.shared.exceptions import McpError
 
 from pydantic import BaseModel
+from zoneinfo import available_timezones
+
 
 
 class TimeTools(str, Enum):
@@ -46,8 +49,47 @@ def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
     raise McpError("Could not determine local timezone - tzinfo is None")
 
 
+def parse_offset_timezone(timezone_name: str) -> ZoneInfo | None:
+    """Handle offset-style timezones like +0530 and convert to the closest matching IANA timezone"""
+    offset_pattern = re.compile(r'^[+-]\d{4}$')
+    if not offset_pattern.match(timezone_name):
+        return None
+        
+    sign = timezone_name[0]
+    hours = int(timezone_name[1:3])
+    minutes = int(timezone_name[3:5])
+    
+    # Convert to total minutes
+    total_minutes = hours * 60 + minutes
+    if sign == "-":
+        total_minutes = -total_minutes
+
+    # Get all available timezones and find the one that matches our offset
+    now = datetime.now()
+    
+    for tz_name in available_timezones():
+        try:
+            tz = ZoneInfo(tz_name)
+            dt = now.astimezone(tz)
+            offset = dt.utcoffset()
+            if offset and offset.total_seconds() / 60 == total_minutes:
+                return tz
+        except Exception:
+            continue
+            
+    raise McpError(f"Could not find a timezone matching offset {timezone_name}")
+
+
 def get_zoneinfo(timezone_name: str) -> ZoneInfo:
+    """Get ZoneInfo object from timezone name, handling both IANA names and offset formats"""
     try:
+        # First try to handle offset-style timezone
+        if timezone_name.startswith('+') or timezone_name.startswith('-'):
+            tz = parse_offset_timezone(timezone_name)
+            if tz:
+                return tz
+        
+        # If not an offset or offset parsing failed, try as IANA timezone
         return ZoneInfo(timezone_name)
     except Exception as e:
         raise McpError(f"Invalid timezone: {str(e)}")


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
This PR adds support for offset style time zones. Currently, they error when you try to run the MCP server and your time zone isn't in an IANA format.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: Time
- Changes to: Add support for offset format timezones (eg: +0530 timezone)

## Motivation and Context
I was running into an issue where when I ran the MCP server time using UVX, I would get a "zone info not found" error with my time zone key in a different format than what the MCP server was expecting. This now adds support for the offset format of time zones.

The error I get: 
`zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key +0530'`

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
- I added test cases to `time_server_test.py` that test the functionality with various offset timezones
- I ran it locally and tried it on Claude and it works, see below

<img width="766" alt="image" src="https://github.com/user-attachments/assets/8ae4082c-faa3-4958-8404-7f61189ab285" />


## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
