### PR TITLE
Added Vega-Lite community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify. 
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
+- **[Vega-Lite](https://github.com/isaacwasserman/mcp-vegalite-server)** - Generate visualizations from fetched data using the VegaLite format and renderer.
 - **[Snowflake](https://github.com/datawiz168/mcp-snowflake-service)** - This MCP server enables LLMs to interact with Snowflake databases, allowing for secure and controlled data operations.
 - **[MySQL](https://github.com/designcomputer/mysql_mcp_server)** - MySQL database integration with configurable access controls and schema inspection
 - **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection


### PR DESCRIPTION
## Description
Added a link to `mcp-vegalite-server` in the "Community Servers" section.

## Motivation and Context
The current list of community servers has lots of data sources but seems to be missing any sort of data visualization tools. While Claude Desktop natively renders Recharts visualizations well, it would be beneficial to have a way to produce charts in a canonical MCP-like way (especially for alternative clients). `mcp-vegalite-server` meets this requirement.

## How Has This Been Tested?
This has been tested with Claude Desktop as a client, and it has also been tested with [langchain-mcp](https://github.com/rectalogic/langchain-mcp), a LangChain client for MCP, with both Claude Sonnet 3.5 and GPT-4o.

## Breaking Changes
No changes have been made to the official servers.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
