### PR TITLE
Added official Neo4j servers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Official integrations are maintained by companies building production ready MCP 
 - <img height="12" width="12" src="https://e2b.dev/favicon.ico" alt="E2B Logo" /> **[E2B](https://github.com/e2b-dev/mcp-server)** - Run code in secure sandboxes hosted by [E2B](https://e2b.dev)
 - <img height="12" width="12" src="https://exa.ai/images/favicon-32x32.png" alt="Exa Logo" /> **[Exa](https://github.com/exa-labs/exa-mcp-server)** - Search Engine made for AIs by [Exa](https://exa.ai)
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
+- <img height="12" width="12" src="https://neo4j.com/favicon.ico" alt="Neo4j Logo" /> **[Neo4j](https://github.com/neo4j-contrib/mcp-neo4j/)** - Neo4j graph database server (schema + read/write-cypher) and separate graph database backed memory 
 - <img height="12" width="12" src="https://www.tinybird.co/favicon.ico" alt="Tinybird Logo" /> **[Tinybird](https://github.com/tinybirdco/mcp-tinybird)** - Interact with Tinybird serverless ClickHouse platform
 - <img height="12" width="12" src="https://pics.fatwang2.com/56912e614b35093426c515860f9f2234.svg" /> [Search1API](https://github.com/fatwang2/search1api-mcp) - One API for Search, Crawling, and Sitemaps
 - <img height="12" width="12" src="https://qdrant.tech/img/brand-resources-logos/logomark.svg" /> **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory layer on top of the Qdrant vector search engine
@@ -64,6 +65,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MySQL](https://github.com/designcomputer/mysql_mcp_server)** (by DesignComputer) - MySQL database integration in Python with configurable access controls and schema inspection
 - **[MySQL](https://github.com/benborla/mcp-server-mysql)** (by benborla) - MySQL database integration in NodeJS with configurable access controls and schema inspection
 - **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection
+server
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 - **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Interact with Todoist to manage your tasks.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Snowflake](https://github.com/datawiz168/mcp-snowflake-service)** - This MCP server enables LLMs to interact with Snowflake databases, allowing for secure and controlled data operations.
 - **[MySQL](https://github.com/designcomputer/mysql_mcp_server)** (by DesignComputer) - MySQL database integration in Python with configurable access controls and schema inspection
 - **[MySQL](https://github.com/benborla/mcp-server-mysql)** (by benborla) - MySQL database integration in NodeJS with configurable access controls and schema inspection
-- **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection
-server
+- **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection server
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 - **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Interact with Todoist to manage your tasks.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Snowflake](https://github.com/datawiz168/mcp-snowflake-service)** - This MCP server enables LLMs to interact with Snowflake databases, allowing for secure and controlled data operations.
 - **[MySQL](https://github.com/designcomputer/mysql_mcp_server)** (by DesignComputer) - MySQL database integration in Python with configurable access controls and schema inspection
 - **[MySQL](https://github.com/benborla/mcp-server-mysql)** (by benborla) - MySQL database integration in NodeJS with configurable access controls and schema inspection
-- **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection server
+- **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.
 - **[BigQuery](https://github.com/ergut/mcp-bigquery-server)** (by ergut) - Server implementation for Google BigQuery integration that enables direct BigQuery database access and querying capabilities
 - **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Interact with Todoist to manage your tasks.


### PR DESCRIPTION
## Description

Added official neo4j servers to README.

## Server Details

- Server: neo4j
- Changes to: get-neo4j-schema, read-neo4j-cypher, write-neo4j-cypher tools

- Server: memory-neo4j
- Changes: Persist conversation state entities and relationships to a live graph database

## Motivation and Context

Neo4j as an open source graph database is a perfect companion for LLMs, providing factual information in a richly connected network of information for enhanced accuracy and explainability.

See: https://neo4j.com/generativeai/

Esp. GraphRAG as retrieval mechanism shines for fetching relevant context to answer user's questions.
LLMs like Claude are great at turning user questions and tasks into Cypher graph database statements to query and update the database.

See: https://neo4j.com/blog/what-is-graphrag/

## How Has This Been Tested?

Tested with Claude AI Desktop with a variety of Neo4j databases and data models with read and write operations.
See some of the screenshots below.

## Breaking Changes

New servers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My changes follows MCP security best practices
- [X] I have updated the server's README accordingly
- [X] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options

## Additional context

Here are some examples from sessions

![Bildschirmfoto 2024-12-13 um 17 41 14](https://github.com/user-attachments/assets/cc4e037b-7281-49c9-a5ad-c5484b3d02b2)
<img width="1697" alt="Bildschirmfoto 2024-12-01 um 18 35 37" src="https://github.com/user-attachments/assets/db5abfdb-d428-4cef-8ef4-674f6c363d3e" />
<img width="812" alt="Bildschirmfoto 2024-11-30 um 11 51 35" src="https://github.com/user-attachments/assets/df990649-9c98-4967-acf5-2428fc245157" />
<img width="550" alt="Bildschirmfoto 2024-11-30 um 11 56 37" src="https://github.com/user-attachments/assets/a400f270-634d-4c8a-9133-ba6e09dd98af" />
<img width="714" alt="Bildschirmfoto 2024-12-01 um 14 18 14" src="https://github.com/user-attachments/assets/d7a12f18-8a58-4e09-83a2-9c07f94fc078" />
