### PR TITLE
Update README.md with Airtable MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[mcp-k8s-go](https://github.com/strowk/mcp-k8s-go)** - Golang-based Kubernetes server for MCP to browse pods and their logs, events, namespaces and more. Built to be extensible.
 - **[TMDB](https://github.com/Laksh-star/mcp-server-tmdb)** - This MCP server integrates with The Movie Database (TMDB) API to provide movie information, search capabilities, and recommendations.
 - **[MongoDB](https://github.com/kiliczsh/mcp-mongo-server)** - A Model Context Protocol Server for MongoDB.
+- **[Airtable](https://github.com/felores/airtable-mcp)** - Airtable Model Context Protocol Server.
 
 
 ## 📚 Resources


### PR DESCRIPTION
Airtable MCP server added

A Model Context Protocol server that provides tools for interacting with Airtable's API. This server enables programmatic management of Airtable bases, tables, fields, and records with proper type validation and error handling.

## Server Details
- Server: Airtable

## Motivation and Context
Really useful to build tables on the fly


## How Has This Been Tested?
Each tool was tested extensively, some iterations with Cline allowed me to refine the structure format requested by Airtable. The system prompt provided helps Claude and IDEs build tables in steps so it is less prone to errors.

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
