### PR TITLE
feat: add git_show tool

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -73,6 +73,12 @@ Please note that mcp-server-git is currently in early development. The functiona
      - `repo_path` (string): Path to Git repository
      - `branch_name` (string): Name of branch to checkout
    - Returns: Confirmation of branch switch
+9. `git_show`
+   - Shows the contents of a commit
+   - Inputs:
+     - `repo_path` (string): Path to Git repository
+     - `revision` (string): The revision (commit hash, branch name, tag) to show
+   - Returns: Contents of the specified commit
 
 ## Installation
 


### PR DESCRIPTION
## Description

Adds a new `git_show` tool to display commit details and diffs in the Git server

## Server Details
- Server: git
- Changes to: tools

## Motivation and Context

I want to reference a specific commit when instructing an LLM on making subsequent changes. Ie: "Update this file with similar changes to `<commit sha>`".

## How Has This Been Tested?

Tested using the `@modelcontextprotocol/inspector` tool.

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
