### PR TITLE
Added the functionality of timestamps

### DIFF
--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -36,15 +36,25 @@ Observations are discrete pieces of information about an entity. They are:
 - Attached to specific entities
 - Can be added or removed independently
 - Should be atomic (one fact per observation)
+- Must include a Unix timestamp
 
 Example:
 ```json
 {
   "entityName": "John_Smith",
   "observations": [
-    "Speaks fluent Spanish",
-    "Graduated in 2019",
-    "Prefers morning meetings"
+    {
+      "content": "Speaks fluent Spanish",
+      "timestamp": 1734940800
+    },
+    {
+      "content": "Graduated in 2019",
+      "timestamp": 1734940800
+    },
+    {
+      "content": "Prefers morning meetings",
+      "timestamp": 1734940800
+    }
   ]
 }
 ```
@@ -171,7 +181,8 @@ Follow these steps for each interaction:
    - If any new information was gathered during the interaction, update your memory as follows:
      a) Create entities for recurring organizations, people, and significant events
      b) Connect them to the current entities using relations
-     b) Store facts about them as observations
+     c) Store facts about them as observations
+     d) IMPORTANT: Always include the Unix timestamp with each observation (e.g., for December 17, 2024, use timestamp: 1734940800)
 ```
 
 ## License


### PR DESCRIPTION
This is to assist Claude with several basic aspects of memory, including chronology of observations, the ability to spot patterns with respect to time and just aligns with basic memory utility in my view.



## Description

## Server Details
<!-- Added timestamping for Claude -->
- Server: <!-- Memory server -->
- Changes to: <!-- Added functionality -->

## Motivation and Context
<!-- I was about to use the memory server for personal use, but I noticed Claude had no way to place the observations relative to time, this got me thinking how important the variable of time is with respect to memory, so hopefully there are others who agree that this is a productive and helpful change. -->

## How Has This Been Tested?
<!-- I battle tested this with Claude by engaging in thoughtful conversation and observed his memory file, he makes good use of the timekeeping as well as the observations -->

## Breaking Changes
<!-- No breaking changes!! -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
![Screenshot 2024-12-17 094934](https://github.com/user-attachments/assets/e051caa8-0d1c-427a-9d59-ee6a9deacc9b)
<!-- There was also one tiny error I
 corrected in the readme, a series of lettered points used 'b)' twice in a row, so now its a 'c)'. -->
