### PR TITLE
Added printEnv tool to the everything server

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -1,4 +1,4 @@
-# Everything MCP Server 
+# Everything MCP Server
 
 This MCP server attempts to exercise all the features of the MCP protocol. It is not intended to be a useful server, but rather a test server for builders of MCP clients. It implements prompts, tools, resources, sampling, and more to showcase MCP capabilities.
 
@@ -15,7 +15,7 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
 2. `add`
    - Adds two numbers together
    - Inputs:
-     - `a` (number): First number 
+     - `a` (number): First number
      - `b` (number): Second number
    - Returns: Text result of the addition
 
@@ -27,7 +27,7 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
    - Returns: Completion message with duration and steps
    - Sends progress notifications during execution
 
-4. `sampleLLM` 
+4. `sampleLLM`
    - Demonstrates LLM sampling capability using MCP sampling feature
    - Inputs:
      - `prompt` (string): The prompt to send to the LLM
@@ -39,17 +39,23 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
    - No inputs required
    - Returns: Base64 encoded PNG image data
 
+6. `printEnv`
+   - Prints all environment variables
+   - Useful for debugging MCP server configuration
+   - No inputs required
+   - Returns: JSON string of all environment variables
+
 ### Resources
 
 The server provides 100 test resources in two formats:
-- Even numbered resources: 
+- Even numbered resources:
   - Plaintext format
   - URI pattern: `test://static/resource/{even_number}`
   - Content: Simple text description
 
 - Odd numbered resources:
   - Binary blob format
-  - URI pattern: `test://static/resource/{odd_number}`  
+  - URI pattern: `test://static/resource/{odd_number}`
   - Content: Base64 encoded binary data
 
 Resource features:

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -40,6 +40,8 @@ const LongRunningOperationSchema = z.object({
   steps: z.number().default(5).describe("Number of steps in the operation"),
 });
 
+const PrintEnvSchema = z.object({});
+
 const SampleLLMSchema = z.object({
   prompt: z.string().describe("The prompt to send to the LLM"),
   maxTokens: z
@@ -54,6 +56,7 @@ enum ToolName {
   ECHO = "echo",
   ADD = "add",
   LONG_RUNNING_OPERATION = "longRunningOperation",
+  PRINT_ENV = "printEnv",
   SAMPLE_LLM = "sampleLLM",
   GET_TINY_IMAGE = "getTinyImage",
 }
@@ -298,6 +301,11 @@ export const createServer = () => {
         inputSchema: zodToJsonSchema(AddSchema) as ToolInput,
       },
       {
+        name: ToolName.PRINT_ENV,
+        description: "Prints all environment variables, helpful for debugging MCP server configuration",
+        inputSchema: zodToJsonSchema(PrintEnvSchema) as ToolInput,
+      },
+      {
         name: ToolName.LONG_RUNNING_OPERATION,
         description:
           "Demonstrates a long running operation with progress updates",
@@ -369,6 +377,17 @@ export const createServer = () => {
           {
             type: "text",
             text: `Long running operation completed. Duration: ${duration} seconds, Steps: ${steps}.`,
+          },
+        ],
+      };
+    }
+
+    if (name === ToolName.PRINT_ENV) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(process.env, null, 2),
           },
         ],
       };


### PR DESCRIPTION
This is to help debug environment variable configuration

## Description

## Server Details
- Server: everything
- Changes to: tools - adding a new tool

## Motivation and Context

I've been hacking on some clients and I often want to check e2e env var setup

## How Has This Been Tested?

Tested locally


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options
