### PR TITLE
docs: add Rijksmuseum MCP server to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A growing set of community-developed and maintained servers demonstrates various
 
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[NS Travel Information](https://github.com/r-huijts/ns-mcp-server)** - Access Dutch Railways (NS) real-time train travel information and disruptions through the official NS API.
+- **[Rijksmuseum](https://github.com/r-huijts/rijksmuseum-mcp)** - Interface with the Rijksmuseum API to search artworks, retrieve artwork details, access image tiles, and explore user collections.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify. 
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
 - **[Vega-Lite](https://github.com/isaacwasserman/mcp-vegalite-server)** - Generate visualizations from fetched data using the VegaLite format and renderer.


### PR DESCRIPTION
## Description
Add Rijksmuseum MCP server to the community servers section in README.md. This server enables LLMs to interact with the Rijksmuseum API, allowing them to search artworks, retrieve artwork details, access image tiles, and explore user collections from Amsterdam's famous museum.

## Server Details
- Server: N/A (documentation update only)
- Changes to: README.md community servers list

## Motivation and Context
This addition enriches the MCP ecosystem by providing access to one of the world's largest art collections through the Rijksmuseum API. This enables LLMs to access and analyze art historical data, images, and cultural heritage information.

## How Has This Been Tested?
N/A - This is a documentation update only, adding a reference to an external server.

## Breaking Changes
No breaking changes - this is an additive change to the README.md file.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] My code follows the repository's style guidelines
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The Rijksmuseum server repository includes comprehensive documentation, setup instructions, and usage examples. The server follows the established pattern of other community servers in the README.md file.