### PR TITLE
docs: add ChromaDB server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Docker](https://github.com/ckreiling/mcp-server-docker)** - Integrate with Docker to manage containers, images, volumes, and networks.
 - **[Kubernetes](https://github.com/Flux159/mcp-server-kubernetes)** - Connect to Kubernetes cluster and manage pods, deployments, and services.
 - **[OpenAPI](https://github.com/snaggle-ai/openapi-mcp-server)** - Interact with [OpenAPI](https://www.openapis.org/) APIs.
+- **[ChromaDB](https://github.com/privetin/mcp-chroma)** - Semantic search and document management using ChromaDB, featuring intuitive similarity metrics (0-100%) and comprehensive collection management.
 - **[Pandoc](https://github.com/vivekVells/mcp-pandoc)** - MCP server for seamless document format conversion using Pandoc, supporting Markdown, HTML, and plain text, with other formats like PDF, csv and docx in development.
 - **[Pinecone](https://github.com/sirmews/mcp-pinecone)** - MCP server for searching and uploading records to Pinecone. Allows for simple RAG features, leveraging Pinecone's Inference API.
 - **[HuggingFace Spaces](https://github.com/evalstate/mcp-hfspace)** - Server for using HuggingFace Spaces, supporting Open Source Image, Audio, Text Models and more. Claude Desktop mode for easy integration.


### PR DESCRIPTION
## Description
Adding ChromaDB server to the community servers section in README.md. This server provides semantic search and document management capabilities with intuitive similarity metrics.

## Server Details
- Server: ChromaDB (new community server)
- Changes to: README.md only (adding server reference)

## Motivation and Context
This server enables LLMs to perform semantic search and document management using ChromaDB, with an intuitive 0-100% similarity scale. It fills a gap in the current server ecosystem by providing vector search capabilities with human-friendly similarity metrics.

## How Has This Been Tested?
Tested with Claude Desktop client for:
- Collection creation and management
- Document embedding and retrieval
- Semantic search with intuitive similarity scores
- Persistent storage operations

## Breaking Changes
None - This PR only adds a reference to the README.md

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Server repository: https://github.com/privetin/mcp-chroma