### PR TITLE
Add a section about MCP frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Google Tasks](https://github.com/zcaceres/gtasks-mcp)** - Google Tasks API Model Context Protocol Server.
 - **[Fetch](https://github.com/zcaceres/fetch-mcp)** - A server that flexibly fetches HTML, JSON, Markdown, or plaintext
 
+## 📚 Frameworks
+
+These are high-level frameworks that make it easier to build MCP servers.
+
+* [FastMCP](https://github.com/jlowin/fastmcp) (Python)
+* [FastMCP](https://github.com/punkpeye/fastmcp) (TypeScript)
+
 ## 📚 Resources
 
 Additional resources on MCP.


### PR DESCRIPTION
Adds a section about MCP frameworks.

These servers make it easier to write MCP compliant servers by abstracting away lots of boilerplate code.