### PR TITLE
Remove trailing comma in docker readme

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -124,7 +124,7 @@ Note: all directories must be mounted to `/projects` by default.
         "--mount", "type=bind,src=/path/to/other/allowed/dir,dst=/projects/other/allowed/dir,ro",
         "--mount", "type=bind,src=/path/to/file.txt,dst=/projects/path/to/file.txt",
         "mcp/filesystem",
-        "/projects",
+        "/projects"
       ]
     }
   }


### PR DESCRIPTION
based on comment in #399

remove trailing comma in docker readme, see comment in #399 

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: filesystem
- Changes to: readme

## Motivation and Context
Trailing comma in json example

## How Has This Been Tested?
N/A

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
N/A
