### PR TITLE
Stringify object in sampling response example

### DIFF
--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -411,7 +411,7 @@ export const createServer = () => {
         maxTokens,
       );
       return {
-        content: [{ type: "text", text: `LLM sampling result: ${result}` }],
+        content: [{ type: "text", text: `LLM sampling result: ${JSON.stringify(result)}` }],
       };
     }
 


### PR DESCRIPTION
Without this, the response will come through as:

```
LLM sampling result: [object Object]
```