### PR TITLE
Hint to LLM to add the period to timestamps

### DIFF
--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -102,7 +102,7 @@ const replyToThreadTool: Tool = {
       },
       thread_ts: {
         type: "string",
-        description: "The timestamp of the parent message",
+        description: "The timestamp of the parent message in the format '1234567890.123456'. Timestamps in the format without the period can be converted by adding the period such that 6 numbers come after it.",
       },
       text: {
         type: "string",
@@ -168,7 +168,7 @@ const getThreadRepliesTool: Tool = {
       },
       thread_ts: {
         type: "string",
-        description: "The timestamp of the parent message",
+        description: "The timestamp of the parent message in the format '1234567890.123456'. Timestamps in the format without the period can be converted by adding the period such that 6 numbers come after it.",
       },
     },
     required: ["channel_id", "thread_ts"],


### PR DESCRIPTION
## Description

This small change makes it so Claude will correctly handle being given permalink URLs like `https://<wokspace>.slack.com/archives/C0123456789/p1403051575000407` (with Claude guessing correctly that `p1403051575000407` has the timestamp, but before wasn't smart enough to add the period)

## Server Details

- Server: slack
- Changes to: tool args description

## Motivation and Context

(description covers it 😄)

## How Has This Been Tested?

Tried locally:
- Before: Claude tried `1403051575000407` as the `thread_ts` and failed
- After: Claude tried `1403051575.000407` and succeeded

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

❤️ 
