### PR TITLE
fix sampling

### DIFF
--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -411,7 +411,7 @@ export const createServer = () => {
         maxTokens,
       );
       return {
-        content: [{ type: "text", text: `LLM sampling result: ${result}` }],
+        content: [{ type: "text", text: `LLM sampling result: ${result.content.text}` }],
       };
     }
 


### PR DESCRIPTION
fix sampling so that text is returned not `[object Object]`

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: everythinh
- Changes to: sample llm tool

## Motivation and Context
unblocks sampling pr in python-sdk

## How Has This Been Tested?
I tested this locally with my sampling client demo

## Breaking Changes
if you depend on the bug then its breaking otherwise no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

for https://github.com/modelcontextprotocol/python-sdk/pull/132