### PR TITLE
Update release workflow to build dockerhub images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,3 +210,11 @@ jobs:
           gh release create "$VERSION" \
             --title "Release $VERSION" \
             --notes-file RELEASE_NOTES.md
+
+      - name: Docker MCP images
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCKER_TOKEN }}
+          repository: docker/labs-ai-tools-for-devs
+          event-type: build-mcp-images
+          client-payload: '{"ref": "${{ needs.create-metadata.outputs.version }}"}'


### PR DESCRIPTION
This PR adds one step to the release workflow to dispatch an event to request linux/arm64 and linux/amd64 images for each of the servers (tagged by release).

## Description

## Motivation and Context

This is to keep mcp server releases in sync with the tags hosted in the public dockerhub repo:  https://hub.docker.com/u/mcp

## How Has This Been Tested?

We have tested this repository dispatch event by using a test repo as a kind of "client". We will need to verify that everything worked end to end when we do the next release.

## Breaking Changes

No. However, this will create _new_ tags for users that are running mcp servers using docker.
This change does however meant that running servers like mcp/puppeteer:latest will mean that latest _changes_ after new release.  Release tags will only change if this GitHub deletes a release and builds it again with this workflow.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

This change only impacts the release workflow (GitHub actions).