### PR TITLE
Windows filesystem MCP enhancements

### DIFF
--- a/src/filesystem/__tests__/path-utils.test.ts
+++ b/src/filesystem/__tests__/path-utils.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from '@jest/globals';
+import { normalizePath, expandHome, convertToWindowsPath } from '../path-utils.js';
+
+describe('Path Utilities', () => {
+  describe('convertToWindowsPath', () => {
+    it('leaves Unix paths unchanged', () => {
+      expect(convertToWindowsPath('/usr/local/bin'))
+        .toBe('/usr/local/bin');
+      expect(convertToWindowsPath('/home/user/some path'))
+        .toBe('/home/user/some path');
+    });
+
+    it('converts WSL paths to Windows format', () => {
+      expect(convertToWindowsPath('/mnt/c/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('converts Unix-style Windows paths to Windows format', () => {
+      expect(convertToWindowsPath('/c/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('leaves Windows paths unchanged but ensures backslashes', () => {
+      expect(convertToWindowsPath('C:\\NS\\MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+      expect(convertToWindowsPath('C:/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('handles Windows paths with spaces', () => {
+      expect(convertToWindowsPath('C:\\Program Files\\Some App'))
+        .toBe('C:\\Program Files\\Some App');
+      expect(convertToWindowsPath('C:/Program Files/Some App'))
+        .toBe('C:\\Program Files\\Some App');
+    });
+
+    it('handles uppercase and lowercase drive letters', () => {
+      expect(convertToWindowsPath('/mnt/d/some/path'))
+        .toBe('D:\\some\\path');
+      expect(convertToWindowsPath('/d/some/path'))
+        .toBe('D:\\some\\path');
+    });
+  });
+
+  describe('normalizePath', () => {
+    it('preserves Unix paths', () => {
+      expect(normalizePath('/usr/local/bin'))
+        .toBe('/usr/local/bin');
+      expect(normalizePath('/home/user/some path'))
+        .toBe('/home/user/some path');
+      expect(normalizePath('"/usr/local/some app/"'))
+        .toBe('/usr/local/some app');
+    });
+
+    it('removes surrounding quotes', () => {
+      expect(normalizePath('"C:\\NS\\My Kindle Content"'))
+        .toBe('C:\\NS\\My Kindle Content');
+    });
+
+    it('normalizes backslashes', () => {
+      expect(normalizePath('C:\\\\NS\\\\MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('converts forward slashes to backslashes on Windows', () => {
+      expect(normalizePath('C:/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('handles WSL paths', () => {
+      expect(normalizePath('/mnt/c/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('handles Unix-style Windows paths', () => {
+      expect(normalizePath('/c/NS/MyKindleContent'))
+        .toBe('C:\\NS\\MyKindleContent');
+    });
+
+    it('handles paths with spaces and mixed slashes', () => {
+      expect(normalizePath('C:/NS/My Kindle Content'))
+        .toBe('C:\\NS\\My Kindle Content');
+      expect(normalizePath('/mnt/c/NS/My Kindle Content'))
+        .toBe('C:\\NS\\My Kindle Content');
+      expect(normalizePath('C:\\Program Files (x86)\\App Name'))
+        .toBe('C:\\Program Files (x86)\\App Name');
+      expect(normalizePath('"C:\\Program Files\\App Name"'))
+        .toBe('C:\\Program Files\\App Name');
+      expect(normalizePath('  C:\\Program Files\\App Name  '))
+        .toBe('C:\\Program Files\\App Name');
+    });
+
+    it('preserves spaces in all path formats', () => {
+      expect(normalizePath('/mnt/c/Program Files/App Name'))
+        .toBe('C:\\Program Files\\App Name');
+      expect(normalizePath('/c/Program Files/App Name'))
+        .toBe('C:\\Program Files\\App Name');
+      expect(normalizePath('C:/Program Files/App Name'))
+        .toBe('C:\\Program Files\\App Name');
+    });
+  });
+
+  describe('expandHome', () => {
+    it('expands ~ to home directory', () => {
+      const result = expandHome('~/test');
+      expect(result).toContain('test');
+      expect(result).not.toContain('~');
+    });
+
+    it('leaves other paths unchanged', () => {
+      expect(expandHome('C:/test')).toBe('C:/test');
+    });
+  });
+});

--- a/src/filesystem/path-utils.ts
+++ b/src/filesystem/path-utils.ts
@@ -1,0 +1,70 @@
+import path from "path";
+import os from 'os';
+
+/**
+ * Converts WSL or Unix-style Windows paths to Windows format
+ * @param p The path to convert
+ * @returns Converted Windows path
+ */
+export function convertToWindowsPath(p: string): string {
+  // Handle WSL paths (/mnt/c/...)
+  if (p.startsWith('/mnt/')) {
+    const driveLetter = p.charAt(5).toUpperCase();
+    const pathPart = p.slice(6).replace(/\//g, '\\');
+    return `${driveLetter}:${pathPart}`;
+  }
+  
+  // Handle Unix-style Windows paths (/c/...)
+  if (p.match(/^\/[a-zA-Z]\//)) {
+    const driveLetter = p.charAt(1).toUpperCase();
+    const pathPart = p.slice(2).replace(/\//g, '\\');
+    return `${driveLetter}:${pathPart}`;
+  }
+
+  // Handle standard Windows paths, ensuring backslashes
+  if (p.match(/^[a-zA-Z]:/)) {
+    return p.replace(/\//g, '\\');
+  }
+
+  // Leave non-Windows paths unchanged
+  return p;
+}
+
+/**
+ * Normalizes path by standardizing format while preserving OS-specific behavior
+ * @param p The path to normalize
+ * @returns Normalized path
+ */
+export function normalizePath(p: string): string {
+  // Remove any surrounding quotes and whitespace
+  p = p.trim().replace(/^["']|["']$/g, '');
+  
+  // Convert WSL or Unix-style paths to Windows format
+  p = convertToWindowsPath(p);
+  
+  // Handle double backslashes and ensure proper escaping
+  p = p.replace(/\\\\/g, '\\');
+  
+  // Use Node's path normalization, which handles . and .. segments
+  const normalized = path.normalize(p);
+  
+  // Only convert slashes to backslashes for Windows paths
+  if (normalized.match(/^[a-zA-Z]:|^\/mnt\/[a-z]\/|^\/[a-z]\//i)) {
+    return normalized.replace(/\//g, '\\');
+  }
+  
+  // Leave Unix paths unchanged
+  return normalized;
+}
+
+/**
+ * Expands home directory tildes in paths
+ * @param filepath The path to expand
+ * @returns Expanded path
+ */
+export function expandHome(filepath: string): string {
+  if (filepath.startsWith('~/') || filepath === '~') {
+    return path.join(os.homedir(), filepath.slice(1));
+  }
+  return filepath;
+}


### PR DESCRIPTION
## Description
Added support for Windows file paths with spaces in them.  Also added support for linked directories. 

## Server Details
- Server: filesystem
- Changes to: server implementation and path resolution logic

## Motivation and Context
I ran into this bug: https://github.com/modelcontextprotocol/servers/issues/447 when trying to use the claude desktop app.

## How Has This Been Tested?
Tested extensively with Claude desktop client on Windows using multiple scenarios:
1. Basic directory access (Desktop folder)
2. Access to program files (I used my World of Warcraft directory - C:\Program Files (x86)\World of Warcraft)
3. Confirmed proper security boundaries (access denied for non-allowed paths)
4. Verified directory/file type differentiation is maintained through symbolic links
5. Added tests to address the scenarios in the open bug

## Breaking Changes
No breaking changes. Existing configurations should continue to work as before - I tested locally with my desktop and downloads folders

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
I don't have a mac - the code shouldn't affect mac paths - however was not able to test that locally