### PR TITLE
Add git init command support to mcp-git-server and update README

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -67,18 +67,23 @@ Please note that mcp-server-git is currently in early development. The functiona
      - `branch_name` (string): Name of the new branch
      - `start_point` (string, optional): Starting point for the new branch
    - Returns: Confirmation of branch creation
-8. `git_checkout`
+10. `git_checkout`
    - Switches branches
    - Inputs:
      - `repo_path` (string): Path to Git repository
      - `branch_name` (string): Name of branch to checkout
    - Returns: Confirmation of branch switch
-9. `git_show`
+11. `git_show`
    - Shows the contents of a commit
    - Inputs:
      - `repo_path` (string): Path to Git repository
      - `revision` (string): The revision (commit hash, branch name, tag) to show
    - Returns: Contents of the specified commit
+12. `git_init`
+   - Initializes a Git repository
+   - Inputs:
+     - `repo_path` (string): Path to directory to initialize git repo
+   - Returns: Confirmation of repository initialization
 
 ## Installation
 

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -56,6 +56,9 @@ class GitShow(BaseModel):
     repo_path: str
     revision: str
 
+class GitInit(BaseModel):
+    repo_path: str
+
 class GitTools(str, Enum):
     STATUS = "git_status"
     DIFF_UNSTAGED = "git_diff_unstaged"
@@ -68,6 +71,7 @@ class GitTools(str, Enum):
     CREATE_BRANCH = "git_create_branch"
     CHECKOUT = "git_checkout"
     SHOW = "git_show"
+    INIT = "git_init"
 
 def git_status(repo: git.Repo) -> str:
     return repo.git.status()
@@ -117,6 +121,13 @@ def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None 
 def git_checkout(repo: git.Repo, branch_name: str) -> str:
     repo.git.checkout(branch_name)
     return f"Switched to branch '{branch_name}'"
+
+def git_init(repo_path: str) -> str:
+    try:
+        repo = git.Repo.init(path=repo_path, mkdir=True)
+        return f"Initialized empty Git repository in {repo.git_dir}"
+    except Exception as e:
+        return f"Error initializing repository: {str(e)}"
 
 def git_show(repo: git.Repo, revision: str) -> str:
     commit = repo.commit(revision)
@@ -206,6 +217,11 @@ async def serve(repository: Path | None) -> None:
                 name=GitTools.SHOW,
                 description="Shows the contents of a commit",
                 inputSchema=GitShow.schema(),
+            ),
+            Tool(
+                name=GitTools.INIT,
+                description="Initialize a new Git repository",
+                inputSchema=GitInit.schema(),
             )
         ]
 
@@ -241,6 +257,16 @@ async def serve(repository: Path | None) -> None:
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         repo_path = Path(arguments["repo_path"])
+        
+        # Handle git init separately since it doesn't require an existing repo
+        if name == GitTools.INIT:
+            result = git_init(str(repo_path))
+            return [TextContent(
+                type="text",
+                text=result
+            )]
+            
+        # For all other commands, we need an existing repo
         repo = git.Repo(repo_path)
 
         match name:


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
Added support for the git init command in the Git server. This allows LLM clients to initialize new Git repositories through the MCP protocol.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: git
- Changes to: server.py and README.md

## Motivation and Context
This functionality was required to work on creating new git repositories when using filesystem mcp server. One can directly resume working with git when creating project from filesystem mcp server without needing to switch to terminal to initiate git repo.

## How Has This Been Tested?
- Tested with Claude client to initialize new repositories
- Verified successful repository creation with directory structure

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
