### PR TITLE
feat: add GitHub releases listing support

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -9,6 +9,7 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
 - **Git History Preservation**: Operations maintain proper Git history without force pushing
 - **Batch Operations**: Support for both single-file and multi-file operations
 - **Advanced Search**: Support for searching code, issues/PRs, and users
+- **Get Repo Releases**: Retrieve the latest releases of a repository to assist with dependency management
 
 
 ## Tools
@@ -276,6 +277,24 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `repo` (string): Repository name
      - `pull_number` (number): Pull request number
    - Returns: Array of pull request reviews with details like the review state (APPROVED, CHANGES_REQUESTED, etc.), reviewer, and review body
+
+27. `list_releases`
+   - List releases for a GitHub repository
+   - Inputs:
+     - `owner` (string): Repository owner
+     - `repo` (string): Repository name
+     - `page` (optional number): Page number for pagination
+     - `perPage` (optional number): Results per page (max 100)
+     - `includeAssets` (optional boolean): Whether to include release assets (default: false)
+   - Returns: Array of repository releases with metadata (and optionally assets)
+
+28. `get_latest_release`
+   - Get the latest release for a GitHub repository
+   - Inputs:
+     - `owner` (string): Repository owner
+     - `repo` (string): Repository name
+     - `includeAssets` (optional boolean): Whether to include release assets (default: false)
+   - Returns: Latest release with metadata (and optionally assets)
 
 ## Search Query Syntax
 

--- a/src/github/common/types.ts
+++ b/src/github/common/types.ts
@@ -286,11 +286,17 @@ export const GitHubReleaseSchema = z.object({
   prerelease: z.boolean(),
   created_at: z.string(),
   published_at: z.string().nullable(),
-  assets: z.array(GitHubReleaseAssetSchema),
+  assets: z.array(GitHubReleaseAssetSchema).optional(),
   tarball_url: z.string(),
   zipball_url: z.string(),
   body: z.string().nullable(),
   author: GitHubOwnerSchema
+}).transform(data => {
+  // Ensure assets is always an array even if not included
+  return {
+    ...data,
+    assets: data.assets || []
+  };
 });
 
 export type GitHubRelease = z.infer<typeof GitHubReleaseSchema>;

--- a/src/github/common/types.ts
+++ b/src/github/common/types.ts
@@ -256,4 +256,43 @@ export type GitHubMilestone = z.infer<typeof GitHubMilestoneSchema>;
 export type GitHubIssue = z.infer<typeof GitHubIssueSchema>;
 export type GitHubSearchResponse = z.infer<typeof GitHubSearchResponseSchema>;
 export type GitHubPullRequest = z.infer<typeof GitHubPullRequestSchema>;
+// Release schemas
+export const GitHubReleaseAssetSchema = z.object({
+  url: z.string(),
+  id: z.number(),
+  node_id: z.string(),
+  name: z.string(),
+  label: z.string().nullable(),
+  content_type: z.string(),
+  state: z.string(),
+  size: z.number(),
+  download_count: z.number(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  browser_download_url: z.string()
+});
+
+export const GitHubReleaseSchema = z.object({
+  url: z.string(),
+  assets_url: z.string(),
+  upload_url: z.string(),
+  html_url: z.string(),
+  id: z.number(),
+  node_id: z.string(),
+  tag_name: z.string(),
+  target_commitish: z.string(),
+  name: z.string().nullable(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  created_at: z.string(),
+  published_at: z.string().nullable(),
+  assets: z.array(GitHubReleaseAssetSchema),
+  tarball_url: z.string(),
+  zipball_url: z.string(),
+  body: z.string().nullable(),
+  author: GitHubOwnerSchema
+});
+
+export type GitHubRelease = z.infer<typeof GitHubReleaseSchema>;
+export type GitHubReleaseAsset = z.infer<typeof GitHubReleaseAssetSchema>;
 export type GitHubPullRequestRef = z.infer<typeof GitHubPullRequestRefSchema>;

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -15,6 +15,7 @@ import * as pulls from './operations/pulls.js';
 import * as branches from './operations/branches.js';
 import * as search from './operations/search.js';
 import * as commits from './operations/commits.js';
+import * as releases from './operations/releases.js';
 import {
   GitHubError,
   GitHubValidationError,
@@ -148,6 +149,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
+      },
+      {
+        name: "list_releases",
+        description: "List releases for a GitHub repository",
+        inputSchema: zodToJsonSchema(releases.ListReleasesOptionsSchema)
       }
     ],
   };
@@ -331,6 +337,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        };
+      }
+
+      case "list_releases": {
+        const args = releases.ListReleasesOptionsSchema.parse(request.params.arguments);
+        const releasesList = await releases.listReleases(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(releasesList, null, 2) }],
         };
       }
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -154,6 +154,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "list_releases",
         description: "List releases for a GitHub repository",
         inputSchema: zodToJsonSchema(releases.ListReleasesOptionsSchema)
+      },
+      {
+        name: "get_latest_release",
+        description: "Get the latest release for a GitHub repository",
+        inputSchema: zodToJsonSchema(releases.GetLatestReleaseSchema)
       }
     ],
   };
@@ -345,6 +350,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const releasesList = await releases.listReleases(args);
         return {
           content: [{ type: "text", text: JSON.stringify(releasesList, null, 2) }],
+        };
+      }
+
+      case "get_latest_release": {
+        const args = releases.GetLatestReleaseSchema.parse(request.params.arguments);
+        const latestRelease = await releases.getLatestRelease(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(latestRelease, null, 2) }],
         };
       }
 

--- a/src/github/operations/releases.ts
+++ b/src/github/operations/releases.ts
@@ -8,11 +8,13 @@ export const ListReleasesOptionsSchema = z.object({
   repo: z.string().describe("Repository name"),
   page: z.number().optional().describe("Page number for pagination (default: 1)"),
   perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)"),
+  includeAssets: z.boolean().optional().describe("Whether to include release assets in the response (default: false)")
 });
 
 export const GetLatestReleaseSchema = z.object({
   owner: z.string().describe("Repository owner (username or organization)"),
   repo: z.string().describe("Repository name"),
+  includeAssets: z.boolean().optional().describe("Whether to include release assets in the response (default: false)")
 });
 
 export type ListReleasesOptions = z.infer<typeof ListReleasesOptionsSchema>;
@@ -24,6 +26,7 @@ export async function listReleases({
   repo,
   page = 1,
   perPage = 30,
+  includeAssets = false
 }: ListReleasesOptions) {
   const url = buildUrl(`https://api.github.com/repos/${owner}/${repo}/releases`, {
     page: page.toString(),
@@ -31,14 +34,31 @@ export async function listReleases({
   });
 
   const response = await githubRequest(url);
-  return z.array(GitHubReleaseSchema).parse(response);
+  const releases = z.array(GitHubReleaseSchema).parse(response);
+  
+  if (!includeAssets) {
+    return releases.map(release => {
+      const { assets, ...rest } = release;
+      return { ...rest, assets: [] };
+    });
+  }
+  
+  return releases;
 }
 
 export async function getLatestRelease({
   owner,
   repo,
+  includeAssets = false
 }: GetLatestReleaseOptions) {
   const url = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
   const response = await githubRequest(url);
-  return GitHubReleaseSchema.parse(response);
+  const release = GitHubReleaseSchema.parse(response);
+  
+  if (!includeAssets) {
+    const { assets, ...rest } = release;
+    return { ...rest, assets: [] };
+  }
+  
+  return release;
 }

--- a/src/github/operations/releases.ts
+++ b/src/github/operations/releases.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { buildUrl, githubRequest } from "../common/utils.js";
+import { GitHubReleaseSchema } from "../common/types.js";
+
+// Schema definitions
+export const ListReleasesOptionsSchema = z.object({
+  owner: z.string().describe("Repository owner (username or organization)"),
+  repo: z.string().describe("Repository name"),
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+  perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)"),
+});
+
+export type ListReleasesOptions = z.infer<typeof ListReleasesOptionsSchema>;
+
+// Function implementations
+export async function listReleases({
+  owner,
+  repo,
+  page = 1,
+  perPage = 30,
+}: ListReleasesOptions) {
+  const url = buildUrl(`https://api.github.com/repos/${owner}/${repo}/releases`, {
+    page: page.toString(),
+    per_page: perPage.toString(),
+  });
+
+  const response = await githubRequest(url);
+  return z.array(GitHubReleaseSchema).parse(response);
+}

--- a/src/github/operations/releases.ts
+++ b/src/github/operations/releases.ts
@@ -10,7 +10,13 @@ export const ListReleasesOptionsSchema = z.object({
   perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)"),
 });
 
+export const GetLatestReleaseSchema = z.object({
+  owner: z.string().describe("Repository owner (username or organization)"),
+  repo: z.string().describe("Repository name"),
+});
+
 export type ListReleasesOptions = z.infer<typeof ListReleasesOptionsSchema>;
+export type GetLatestReleaseOptions = z.infer<typeof GetLatestReleaseSchema>;
 
 // Function implementations
 export async function listReleases({
@@ -26,4 +32,13 @@ export async function listReleases({
 
   const response = await githubRequest(url);
   return z.array(GitHubReleaseSchema).parse(response);
+}
+
+export async function getLatestRelease({
+  owner,
+  repo,
+}: GetLatestReleaseOptions) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+  const response = await githubRequest(url);
+  return GitHubReleaseSchema.parse(response);
 }


### PR DESCRIPTION
Adds new MCP tool to list releases for a GitHub repository with:
- Release and asset schemas in types.ts
- List releases operation implementation
- Tool registration in index.ts<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: tools

## Motivation and Context
Add methods to get releases from GitHub and get the latest release, with or without assets list included.

## How Has This Been Tested?
I have tested this MCP server with Roo Code.

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
N/A