### PR TITLE
Add MSSQL MCP server to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[mcp-k8s-go](https://github.com/strowk/mcp-k8s-go)** - Golang-based Kubernetes server for MCP to browse pods and their logs, events, namespaces and more. Built to be extensible.
 - **[MSSQL](https://github.com/aekanun2020/mcp-server/)** - MSSQL database integration with configurable access controls and schema inspection
+- **[MSSQL](https://github.com/JexinSam/mssql_mcp_server)** (by jexin) - MCP Server for MSSQL database in Python
 - **[Markdownify](https://github.com/zcaceres/mcp-markdownify-server)** - MCP to convert almost anything to Markdown (PPTX, HTML, PDF, Youtube Transcripts and more)
 - **[Minima](https://github.com/dmayboroda/minima)** - MCP server for RAG on local files
 - **[MongoDB](https://github.com/kiliczsh/mcp-mongo-server)** - A Model Context Protocol Server for MongoDB.


### PR DESCRIPTION
## Description
Adding MSSQL MCP server implementation to Community Servers section in README.md

## Server Details
- Server: mssql-mcp-server (new addition to community servers)
- Changes to: README.md only - adding entry to Community Servers list

## Motivation and Context
Adding reference to a new community implementation of an MCP server that provides MSSQL database integration. This addition increases the visibility of available MCP servers and provides another database integration option for the community.

## How Has This Been Tested?
This is a documentation update only - adding a reference to an existing, tested implementation.

The referenced MSSQL MCP server itself has been thoroughly tested:

- Automated testing via GitHub Actions workflow
- Tests run against MSSQL 2019 Express in a containerized environment
- Tested with Python 3.11 and 3.12
- Full test suite runs with pytest
- Integration tested with Claude Desktop as the LLM client
- Includes verification of module installation and dependencies

## Breaking Changes
None - this is a documentation addition only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

