### PR TITLE
feat: add missing pull request operations to GitHub server

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -150,7 +150,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
       },
-      // Adding missing pull request operations
       {
         name: "get_pull_request",
         description: "Get details of a specific pull request",
@@ -381,7 +380,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      // Adding handlers for missing pull request operations
       case "get_pull_request": {
         const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
         const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -148,6 +148,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
+      },
+      // Adding missing pull request operations
+      {
+        name: "get_pull_request",
+        description: "Get details of a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
+      },
+      {
+        name: "list_pull_requests",
+        description: "List and filter repository pull requests",
+        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
+      },
+      {
+        name: "create_pull_request_review",
+        description: "Create a review on a pull request",
+        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the list of files changed in a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the combined status of all status checks for a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get the review comments on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get the reviews on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
       }
     ],
   };
@@ -331,6 +377,87 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        };
+      }
+
+      // Adding handlers for missing pull request operations
+      case "get_pull_request": {
+        const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
+        const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
+        };
+      }
+
+      case "list_pull_requests": {
+        const args = pulls.ListPullRequestsSchema.parse(request.params.arguments);
+        const { owner, repo, ...options } = args;
+        const pullRequests = await pulls.listPullRequests(owner, repo, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequests, null, 2) }],
+        };
+      }
+
+      case "create_pull_request_review": {
+        const args = pulls.CreatePullRequestReviewSchema.parse(request.params.arguments);
+        const { owner, repo, pull_number, ...options } = args;
+        const review = await pulls.createPullRequestReview(owner, repo, pull_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(review, null, 2) }],
+        };
+      }
+
+      case "merge_pull_request": {
+        const args = pulls.MergePullRequestSchema.parse(request.params.arguments);
+        const { owner, repo, pull_number, ...options } = args;
+        const result = await pulls.mergePullRequest(owner, repo, pull_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_files": {
+        const args = pulls.GetPullRequestFilesSchema.parse(request.params.arguments);
+        const files = await pulls.getPullRequestFiles(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_status": {
+        const args = pulls.GetPullRequestStatusSchema.parse(request.params.arguments);
+        const status = await pulls.getPullRequestStatus(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+        };
+      }
+
+      case "update_pull_request_branch": {
+        const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
+        await pulls.updatePullRequestBranch(
+          args.owner,
+          args.repo,
+          args.pull_number,
+          args.expected_head_sha
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: true }, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_comments": {
+        const args = pulls.GetPullRequestCommentsSchema.parse(request.params.arguments);
+        const comments = await pulls.getPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_reviews": {
+        const args = pulls.GetPullRequestReviewsSchema.parse(request.params.arguments);
+        const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
         };
       }
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -101,6 +101,51 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: zodToJsonSchema(pulls.CreatePullRequestSchema),
       },
       {
+        name: "get_pull_request",
+        description: "Get details of a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
+      },
+      {
+        name: "list_pull_requests",
+        description: "List and filter repository pull requests",
+        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
+      },
+      {
+        name: "create_pull_request_review",
+        description: "Create a review on a pull request",
+        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the list of files changed in a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the combined status of all status checks for a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get the review comments on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get the reviews on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
+      },
+      {
         name: "fork_repository",
         description: "Fork a GitHub repository to your account or specified organization",
         inputSchema: zodToJsonSchema(repository.ForkRepositorySchema),
@@ -149,51 +194,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
-      },
-      {
-        name: "get_pull_request",
-        description: "Get details of a specific pull request",
-        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
-      },
-      {
-        name: "list_pull_requests",
-        description: "List and filter repository pull requests",
-        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
-      },
-      {
-        name: "create_pull_request_review",
-        description: "Create a review on a pull request",
-        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
-      },
-      {
-        name: "merge_pull_request",
-        description: "Merge a pull request",
-        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
-      },
-      {
-        name: "get_pull_request_files",
-        description: "Get the list of files changed in a pull request",
-        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
-      },
-      {
-        name: "get_pull_request_status",
-        description: "Get the combined status of all status checks for a pull request",
-        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
-      },
-      {
-        name: "update_pull_request_branch",
-        description: "Update a pull request branch with the latest changes from the base branch",
-        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
-      },
-      {
-        name: "get_pull_request_comments",
-        description: "Get the review comments on a pull request",
-        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
-      },
-      {
-        name: "get_pull_request_reviews",
-        description: "Get the reviews on a pull request",
-        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
       }
     ],
   };
@@ -307,79 +307,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case "search_code": {
-        const args = search.SearchCodeSchema.parse(request.params.arguments);
-        const results = await search.searchCode(args);
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
-      }
-
-      case "search_issues": {
-        const args = search.SearchIssuesSchema.parse(request.params.arguments);
-        const results = await search.searchIssues(args);
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
-      }
-
-      case "search_users": {
-        const args = search.SearchUsersSchema.parse(request.params.arguments);
-        const results = await search.searchUsers(args);
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
-      }
-
-      case "list_issues": {
-        const args = issues.ListIssuesOptionsSchema.parse(request.params.arguments);
-        const { owner, repo, ...options } = args;
-        const result = await issues.listIssues(owner, repo, options);
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      case "update_issue": {
-        const args = issues.UpdateIssueOptionsSchema.parse(request.params.arguments);
-        const { owner, repo, issue_number, ...options } = args;
-        const result = await issues.updateIssue(owner, repo, issue_number, options);
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      case "add_issue_comment": {
-        const args = issues.IssueCommentSchema.parse(request.params.arguments);
-        const { owner, repo, issue_number, body } = args;
-        const result = await issues.addIssueComment(owner, repo, issue_number, body);
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      }
-
-      case "list_commits": {
-        const args = commits.ListCommitsSchema.parse(request.params.arguments);
-        const results = await commits.listCommits(
-          args.owner,
-          args.repo,
-          args.page,
-          args.perPage,
-          args.sha
-        );
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
-      }
-
-      case "get_issue": {
-        const args = issues.GetIssueSchema.parse(request.params.arguments);
-        const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
-        return {
-          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
-        };
-      }
-
       case "get_pull_request": {
         const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
         const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);
@@ -457,6 +384,79 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
         return {
           content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+        };
+      }
+
+      case "search_code": {
+        const args = search.SearchCodeSchema.parse(request.params.arguments);
+        const results = await search.searchCode(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      case "search_issues": {
+        const args = search.SearchIssuesSchema.parse(request.params.arguments);
+        const results = await search.searchIssues(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      case "search_users": {
+        const args = search.SearchUsersSchema.parse(request.params.arguments);
+        const results = await search.searchUsers(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      case "list_issues": {
+        const args = issues.ListIssuesOptionsSchema.parse(request.params.arguments);
+        const { owner, repo, ...options } = args;
+        const result = await issues.listIssues(owner, repo, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "update_issue": {
+        const args = issues.UpdateIssueOptionsSchema.parse(request.params.arguments);
+        const { owner, repo, issue_number, ...options } = args;
+        const result = await issues.updateIssue(owner, repo, issue_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "add_issue_comment": {
+        const args = issues.IssueCommentSchema.parse(request.params.arguments);
+        const { owner, repo, issue_number, body } = args;
+        const result = await issues.addIssueComment(owner, repo, issue_number, body);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "list_commits": {
+        const args = commits.ListCommitsSchema.parse(request.params.arguments);
+        const results = await commits.listCommits(
+          args.owner,
+          args.repo,
+          args.page,
+          args.perPage,
+          args.sha
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+        };
+      }
+
+      case "get_issue": {
+        const args = issues.GetIssueSchema.parse(request.params.arguments);
+        const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Description
This PR adds missing pull request operations that were already implemented in `operations/pulls.ts` but not exposed in `index.ts`. The added operations are:

- get_pull_request
- list_pull_requests 
- create_pull_request_review
- merge_pull_request
- get_pull_request_files
- get_pull_request_status
- update_pull_request_branch
- get_pull_request_comments
- get_pull_request_reviews

## Server Details
- Server: github
- Changes to: tools (exposing existing operations)

## Motivation and Context
The GitHub server already had these pull request operations implemented in `operations/pulls.ts`, but they weren't exposed in `index.ts`. This change makes these useful operations available to users of the GitHub MCP server.

## How Has This Been Tested?
[ ] These operations were already implemented and tested in the pulls.ts file. Additional testing would be beneficial.

## Breaking Changes
No breaking changes. This PR only adds new operations.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
This PR was created by Claude Desktop (Claude 3.5 Sonnet) to expose existing functionality that was already implemented but not exposed through the server's interface.