### PR TITLE
Include meaningful `User-Agent` header in requests to the GitHub UI

### DIFF
--- a/src/github/common/utils.ts
+++ b/src/github/common/utils.ts
@@ -1,10 +1,12 @@
+import { getUserAgent } from "universal-user-agent";
 import { createGitHubError } from "./errors.js";
+import { VERSION } from "./version.js";
 
 type RequestOptions = {
   method?: string;
   body?: unknown;
   headers?: Record<string, string>;
-};
+}
 
 async function parseResponseBody(response: Response): Promise<unknown> {
   const contentType = response.headers.get("content-type");
@@ -24,6 +26,8 @@ export function buildUrl(baseUrl: string, params: Record<string, string | number
   return url.toString();
 }
 
+const USER_AGENT = `modelcontextprotocol/servers/github/v${VERSION} ${getUserAgent()}`;
+
 export async function githubRequest(
   url: string,
   options: RequestOptions = {}
@@ -31,6 +35,7 @@ export async function githubRequest(
   const headers: Record<string, string> = {
     "Accept": "application/vnd.github.v3+json",
     "Content-Type": "application/json",
+    "User-Agent": USER_AGENT,
     ...options.headers,
   };
 

--- a/src/github/common/version.ts
+++ b/src/github/common/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.6.2";

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -25,11 +25,12 @@ import {
   GitHubConflictError,
   isGitHubError,
 } from './common/errors.js';
+import { VERSION } from "./common/version.js";
 
 const server = new Server(
   {
     name: "github-mcp-server",
-    version: "0.1.0",
+    version: VERSION,
   },
   {
     capabilities: {

--- a/src/github/package.json
+++ b/src/github/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^22",
     "@types/node-fetch": "^2.6.12",
     "node-fetch": "^3.3.2",
+    "universal-user-agent": "^7.0.2",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.23.5"
   },


### PR DESCRIPTION
This adds a custom `User-Agent` header to requests from the GitHub server to the GitHub API, identifying the application, the version and key information about the environment.

This aligns with the [recommendations][1] in the GitHub Docs.

As part of this change, I have also moved the current version of the server into a constant, and fix the initialization of `Server` to use that version, taking from `package.json`.

[1]: https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#user-agent

<!-- Provide a brief description of your changes -->

## Description

Include a meaningful `User-Agent` header in requests to GitHub from the GitHub server

## Server Details

Server: GitHub
Changes to: Tools

## Motivation and Context

If we, as GitHub, are making a breaking API change or an integration is running into performance problems, it is helpful to be able to identify that API integration.

This is impossible to do with open source integrations like this where users authenticate with personal access tokens (PATs), unless there is a user agent that identifies the integration.

## How Has This Been Tested?

I connected this to Claude and ask it to fetch a pull request. A request to GitHub was made with the expected header.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My changes follows MCP security best practices
- [X] I have updated the server's README accordingly
- [X] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
