### PR TITLE
Commit `package-lock.json` with new `universal-user-agent` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,6 +4786,12 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "license": "ISC"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -5292,6 +5298,7 @@
         "@types/node": "^22",
         "@types/node-fetch": "^2.6.12",
         "node-fetch": "^3.3.2",
+        "universal-user-agent": "^7.0.2",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -5445,7 +5452,7 @@
     },
     "src/memory": {
       "name": "@modelcontextprotocol/server-memory",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.0.1"


### PR DESCRIPTION
This fixes the build, after the merge of #592, by committing an updated `/package-lock.json` file with the new `universal-user- agent` dependency.