### PR TITLE
feat(directory_tree): add excludePatterns support & documentation

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -86,6 +86,19 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - Case-insensitive matching
   - Returns full paths to matches
 
+- **directory_tree**
+  - Get recursive JSON tree structure of directory contents
+  - Inputs:
+    - `path` (string): Starting directory
+    - `excludePatterns` (string[]): Exclude any patterns. Glob formats are supported.
+  - Returns:
+    - JSON array where each entry contains:
+      - `name` (string): File/directory name
+      - `type` ('file'|'directory'): Entry type
+      - `children` (array): Present only for directories
+        - Empty array for empty directories
+        - Omitted for files
+    
 - **get_file_info**
   - Get detailed file/directory metadata
   - Input: `path` (string)


### PR DESCRIPTION
- Update documentation with directory_tree declaration
- Add excludePatterns parameter to DirectoryTreeArgsSchema
- Implement pattern exclusion in buildTree function using minimatch
- Pass excludePatterns through recursive calls
- Support both simple and glob patterns for exclusion
- Maintain consistent behavior with search_files implementation


## Description

## Motivation and Context
launching directory_tree inside a code project is a pain. adding exclusion pattern is my solution.

## How Has This Been Tested?
Tested locally

## Breaking Changes
No breaking changes. `excludePatterns` is empty by default.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices 
- [X] I have updated the server's README accordingly
- [X] I have tested this with an LLM client
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options


