### PR TITLE
Add annotated message example to everything-server

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -45,6 +45,24 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
    - No inputs required
    - Returns: JSON string of all environment variables
 
+7. `annotatedMessage`
+   - Demonstrates how annotations can be used to provide metadata about content
+   - Inputs:
+     - `messageType` (enum: "error" | "success" | "debug"): Type of message to demonstrate different annotation patterns
+     - `includeImage` (boolean, default: false): Whether to include an example image
+   - Returns: Content with varying annotations:
+     - Error messages: High priority (1.0), visible to both user and assistant
+     - Success messages: Medium priority (0.7), user-focused
+     - Debug messages: Low priority (0.3), assistant-focused
+     - Optional image: Medium priority (0.5), user-focused
+   - Example annotations:
+     ```json
+     {
+       "priority": 1.0,
+       "audience": ["user", "assistant"]
+     }
+     ```
+
 ### Resources
 
 The server provides 100 test resources in two formats:


### PR DESCRIPTION
## Description
Adds `ANNOTATED_MESSAGE` tool example in the `everything` MCP server to better demonstrate how [Annotated](https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.json#L4) can be used with content like messages.

## Server Details
- Server: everything
- Changes to: tools (adds ANNOTATED_MESSAGE example) and documentation

## Motivation and Context
These changes improve the documentation and examples of how to use annotations, making it easier for developers to understand how and when to use annotations. The examples demonstrate both priority levels and audience targeting.

## How Has This Been Tested?
I've tested the following scenarios in Inspector using a modified version from this PR: https://github.com/modelcontextprotocol/inspector/pull/150

For messageType, try one of these values:

- "error" - Will show a high-priority message visible to both user and assistant
- "success" - Will show a medium-priority message focused on the user
- "debug" - Will show a low-priority message focused on the assistant

For includeImage:

- true - Will include the MCP tiny image with medium priority for user visualization
- false - Will only show the text message

Some example combinations tested, with screenshots:

### Test error message:

- messageType: "error"
- includeImage: false This will show how high-priority error messages are handled.

![annotated_message_1](https://github.com/user-attachments/assets/467b6c1f-7966-4b33-bacf-fd0c1a3cfade)

### Test debug with image:

- messageType: "debug"
- includeImage: true This will demonstrate both assistant-focused debug info and user-focused image handling.

![annotated_message_2](https://github.com/user-attachments/assets/d1898ffc-6f08-4775-b11d-67f5616c0d24)

### Test success message:

- messageType: "success"
- includeImage: false This will show how user-focused success messages are handled.

![annotated_message_3](https://github.com/user-attachments/assets/5d044889-ad6b-4c90-b366-d1628b122f9c)

## Breaking Changes
No breaking changes. This is an enhancement to existing example code and documentation.

## Types of changes
- [ ] Bug fix
- [x] New feature (enhanced example implementation)
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
