### PR TITLE
feat: register all pull request tools in github server

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -149,6 +149,64 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the files of a pull request in a GitHub repository.",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }))
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the combined status of all status checks for a pull request",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }))
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number(),
+          expected_head_sha: z.string().optional()
+        }))
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get the review comments on a pull request",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }))
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get the reviews on a pull request",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }))
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number(),
+          commit_title: z.string().optional(),
+          commit_message: z.string().optional(),
+          merge_method: z.enum(['merge', 'squash', 'rebase']).optional()
+        }))
       }
     ],
   };
@@ -332,6 +390,82 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_files": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }).parse(request.params.arguments);
+        const files = await pulls.getPullRequestFiles(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_status": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }).parse(request.params.arguments);
+        const status = await pulls.getPullRequestStatus(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+        };
+      }
+
+      case "update_pull_request_branch": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number(),
+          expected_head_sha: z.string().optional()
+        }).parse(request.params.arguments);
+        await pulls.updatePullRequestBranch(args.owner, args.repo, args.pull_number, args.expected_head_sha);
+        return {
+          content: [{ type: "text", text: "Branch updated successfully" }],
+        };
+      }
+
+      case "get_pull_request_comments": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }).parse(request.params.arguments);
+        const comments = await pulls.getPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_reviews": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number()
+        }).parse(request.params.arguments);
+        const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+        };
+      }
+
+      case "merge_pull_request": {
+        const args = z.object({
+          owner: z.string(),
+          repo: z.string(),
+          pull_number: z.number(),
+          commit_title: z.string().optional(),
+          commit_message: z.string().optional(),
+          merge_method: z.enum(['merge', 'squash', 'rebase']).optional()
+        }).parse(request.params.arguments);
+        const result = await pulls.mergePullRequest(args.owner, args.repo, args.pull_number, args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Description

Some of the pull request operations listed in the README never had tool registrations or handlers. The implementations looked fine; just closing the last mile for:
- get_pull_request_status
- update_pull_request_branch
- get_pull_request_comments
- get_pull_request_reviews
- merge_pull_request

## Server Details
- Server: github 
- Changes to: tools

## Motivation and Context
We want MCP Clients using this server to be able to use all of the tools that we list in the documentation.

## How Has This Been Tested?

Built with:
```bash
➜  servers git:(register-all-tools) ✗ docker build -t mcp/github -f src/github/Dockerfile .
[+] Building 12.7s (15/15) FINISHED                       docker:desktop-linux
...
 => => exporting manifest list sha256:98865d3d57046c173e22b7d1391619eb06  0.0s
 => => naming to docker.io/mcp/github:latest                              0.0s
 => => unpacking to docker.io/mcp/github:latest                           0.2s
```

Addes to Claude Desktop with:
```
{
    "mcpServers": {
      "github": {
        "command": "docker",
        "args": [
          "run",
          "-i",
          "--rm",
          "-e",
          "GITHUB_PERSONAL_ACCESS_TOKEN",
          "mcp/github"
        ],
        "env": {
          "GITHUB_PERSONAL_ACCESS_TOKEN": "<REDACTED_FROM_PR>"
        }
      },
    }
  }
```

Created a prompt that uses the tools. Verified that tool calls succeed.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

