### PR TITLE
Add query validator and Windows UTF-8 encoding fix

### DIFF
--- a/src/sqlite/encoding_fix.py
+++ b/src/sqlite/encoding_fix.py
@@ -1,0 +1,15 @@
+"""SQLite MCP UTF-8 Encoding Fix
+
+This module fixes UTF-8 encoding issues on Windows by ensuring proper 
+stream encoding configuration.
+"""
+
+import sys
+import codecs
+
+def configure_utf8_encoding():
+    """Configure UTF-8 encoding for stdin/stdout on Windows."""
+    if sys.platform == 'win32':
+        # Set up UTF-8 encoding for stdout/stderr
+        sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer)
+        sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer)

--- a/src/sqlite/query_validator.py
+++ b/src/sqlite/query_validator.py
@@ -1,0 +1,48 @@
+"""SQLite MCP Query Validator
+
+This module provides query validation to ensure stability and performance
+by enforcing query restrictions:
+- SELECT queries only for read operations
+- No CTEs (Common Table Expressions)
+- No nested subqueries
+"""
+
+import sqlparse
+from sqlparse.sql import Token
+from sqlparse.tokens import DML, Keyword
+
+class QueryValidationError(Exception):
+    """Raised when a query fails validation."""
+    pass
+
+class SQLiteQueryValidator:
+    """Validates SQLite queries against restrictions."""
+    
+    @staticmethod
+    def validate_query(query: str) -> None:
+        """
+        Validates a SQL query against restrictions.
+        
+        Args:
+            query: The SQL query to validate
+            
+        Raises:
+            QueryValidationError: If the query violates any restrictions
+        """
+        parsed = sqlparse.parse(query.strip())[0]
+        
+        # Check query type
+        if parsed.get_type() != 'SELECT':
+            raise QueryValidationError("Only SELECT queries are allowed")
+            
+        # Count SELECT statements
+        selects = len([token for token in parsed.flatten() 
+                      if token.ttype == DML 
+                      and token.value.upper() == 'SELECT'])
+        if selects > 1:
+            raise QueryValidationError("Nested subqueries are not allowed")
+            
+        # Check for CTEs
+        if any(token.value.upper() == 'WITH' for token in parsed.flatten() 
+               if token.ttype == Keyword):
+            raise QueryValidationError("Common Table Expressions (CTEs) are not allowed")


### PR DESCRIPTION
This PR adds two key enhancements to the SQLite MCP server:

1. Query validation to enforce stability best practices:
   - SELECT queries only for read operations 
   - No CTEs (Common Table Expressions)
   - No nested subqueries

2. UTF-8 encoding fix for Windows systems

The changes are focused and modular:
- query_validator.py: Query restriction enforcement
- encoding_fix.py: Windows UTF-8 handling fix

Both features are optional and can be enabled independently.

Benefits:
- Improved stability through query restrictions
- Better Windows compatibility
- Clear error messages
- No breaking changes

Signed-off-by: Mike <mike@adamic.ai>