### PR TITLE
feat: add GitHub env var to support Enterprise onprem

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -11,6 +11,10 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
 - **Advanced Search**: Support for searching code, issues/PRs, and users
 
 
+## Environment Variables
+
+- `GITHUB_API_URL`: GitHub API URL (default: 'https://api.github.com')
+
 ## Tools
 
 1. `create_or_update_file`
@@ -329,14 +333,13 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
         "mcp/github"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        // Optional:
+        // "GITHUB_API_URL": "https://api.github.com"
       }
     }
   }
 }
-```
-
-### NPX
 
 ```json
 {
@@ -348,7 +351,9 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
         "@modelcontextprotocol/server-github"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        // Optional:
+        // "GITHUB_API_URL": "https://api.github.com"
       }
     }
   }

--- a/src/github/common/config.ts
+++ b/src/github/common/config.ts
@@ -1,0 +1,1 @@
+export const GITHUB_API_URL = process.env.GITHUB_API_URL || 'https://api.github.com';

--- a/src/github/common/utils.ts
+++ b/src/github/common/utils.ts
@@ -1,4 +1,5 @@
 import { getUserAgent } from "universal-user-agent";
+import { GITHUB_API_URL } from "./config.js";
 import { createGitHubError } from "./errors.js";
 import { VERSION } from "./version.js";
 
@@ -114,7 +115,7 @@ export async function checkBranchExists(
 ): Promise<boolean> {
   try {
     await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/branches/${branch}`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/branches/${branch}`
     );
     return true;
   } catch (error) {
@@ -127,7 +128,7 @@ export async function checkBranchExists(
 
 export async function checkUserExists(username: string): Promise<boolean> {
   try {
-    await githubRequest(`https://api.github.com/users/${username}`);
+    await githubRequest(`${GITHUB_API_URL}/users/${username}`);
     return true;
   } catch (error) {
     if (error && typeof error === "object" && "status" in error && error.status === 404) {

--- a/src/github/operations/branches.ts
+++ b/src/github/operations/branches.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 import { GitHubReferenceSchema } from "../common/types.js";
 
 // Schema definitions
@@ -22,13 +23,13 @@ export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 export async function getDefaultBranchSHA(owner: string, repo: string): Promise<string> {
   try {
     const response = await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/main`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/main`
     );
     const data = GitHubReferenceSchema.parse(response);
     return data.object.sha;
   } catch (error) {
     const masterResponse = await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/master`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/master`
     );
     if (!masterResponse) {
       throw new Error("Could not find default branch (tried 'main' and 'master')");
@@ -46,7 +47,7 @@ export async function createBranch(
   const fullRef = `refs/heads/${options.ref}`;
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs`,
     {
       method: "POST",
       body: {
@@ -65,7 +66,7 @@ export async function getBranchSHA(
   branch: string
 ): Promise<string> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`
   );
 
   const data = GitHubReferenceSchema.parse(response);
@@ -98,7 +99,7 @@ export async function updateBranch(
   sha: string
 ): Promise<z.infer<typeof GitHubReferenceSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`,
     {
       method: "PATCH",
       body: {

--- a/src/github/operations/commits.ts
+++ b/src/github/operations/commits.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest, buildUrl } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 
 export const ListCommitsSchema = z.object({
   owner: z.string(),
@@ -17,7 +18,7 @@ export async function listCommits(
   sha?: string
 ) {
   return githubRequest(
-    buildUrl(`https://api.github.com/repos/${owner}/${repo}/commits`, {
+    buildUrl(`${GITHUB_API_URL}/repos/${owner}/${repo}/commits`, {
       page: page?.toString(),
       per_page: perPage?.toString(),
       sha

--- a/src/github/operations/files.ts
+++ b/src/github/operations/files.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 import {
   GitHubContentSchema,
   GitHubAuthorSchema,
@@ -75,7 +76,7 @@ export async function getFileContents(
   path: string,
   branch?: string
 ) {
-  let url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  let url = `${GITHUB_API_URL}/repos/${owner}/${repo}/contents/${path}`;
   if (branch) {
     url += `?ref=${branch}`;
   }
@@ -114,7 +115,7 @@ export async function createOrUpdateFile(
     }
   }
 
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  const url = `${GITHUB_API_URL}/repos/${owner}/${repo}/contents/${path}`;
   const body = {
     message,
     content: encodedContent,
@@ -144,7 +145,7 @@ async function createTree(
   }));
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/trees`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/trees`,
     {
       method: "POST",
       body: {
@@ -165,7 +166,7 @@ async function createCommit(
   parents: string[]
 ) {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/commits`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/commits`,
     {
       method: "POST",
       body: {
@@ -186,7 +187,7 @@ async function updateReference(
   sha: string
 ) {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/${ref}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/${ref}`,
     {
       method: "PATCH",
       body: {
@@ -207,7 +208,7 @@ export async function pushFiles(
   message: string
 ) {
   const refResponse = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`
   );
 
   const ref = GitHubReferenceSchema.parse(refResponse);

--- a/src/github/operations/issues.ts
+++ b/src/github/operations/issues.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest, buildUrl } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 
 export const GetIssueSchema = z.object({
   owner: z.string(),
@@ -53,7 +54,7 @@ export const UpdateIssueOptionsSchema = z.object({
 });
 
 export async function getIssue(owner: string, repo: string, issue_number: number) {
-  return githubRequest(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}`);
+  return githubRequest(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}`);
 }
 
 export async function addIssueComment(
@@ -62,7 +63,7 @@ export async function addIssueComment(
   issue_number: number,
   body: string
 ) {
-  return githubRequest(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}/comments`, {
+  return githubRequest(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}/comments`, {
     method: "POST",
     body: { body },
   });
@@ -74,7 +75,7 @@ export async function createIssue(
   options: z.infer<typeof CreateIssueOptionsSchema>
 ) {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/issues`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/issues`,
     {
       method: "POST",
       body: options,
@@ -98,7 +99,7 @@ export async function listIssues(
   };
 
   return githubRequest(
-    buildUrl(`https://api.github.com/repos/${owner}/${repo}/issues`, urlParams)
+    buildUrl(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues`, urlParams)
   );
 }
 
@@ -109,7 +110,7 @@ export async function updateIssue(
   options: Omit<z.infer<typeof UpdateIssueOptionsSchema>, "owner" | "repo" | "issue_number">
 ) {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}`,
     {
       method: "PATCH",
       body: options,

--- a/src/github/operations/pulls.ts
+++ b/src/github/operations/pulls.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 import {
   GitHubPullRequestSchema,
   GitHubIssueAssigneeSchema,
@@ -166,7 +167,7 @@ export async function createPullRequest(
   const { owner, repo, ...options } = CreatePullRequestSchema.parse(params);
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls`,
     {
       method: "POST",
       body: options,
@@ -182,7 +183,7 @@ export async function getPullRequest(
   pullNumber: number
 ): Promise<z.infer<typeof GitHubPullRequestSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}`
   );
   return GitHubPullRequestSchema.parse(response);
 }
@@ -192,7 +193,7 @@ export async function listPullRequests(
   repo: string,
   options: Omit<z.infer<typeof ListPullRequestsSchema>, 'owner' | 'repo'>
 ): Promise<z.infer<typeof GitHubPullRequestSchema>[]> {
-  const url = new URL(`https://api.github.com/repos/${owner}/${repo}/pulls`);
+  const url = new URL(`${GITHUB_API_URL}/repos/${owner}/${repo}/pulls`);
   
   if (options.state) url.searchParams.append('state', options.state);
   if (options.head) url.searchParams.append('head', options.head);
@@ -213,7 +214,7 @@ export async function createPullRequestReview(
   options: Omit<z.infer<typeof CreatePullRequestReviewSchema>, 'owner' | 'repo' | 'pull_number'>
 ): Promise<z.infer<typeof PullRequestReviewSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
     {
       method: 'POST',
       body: options,
@@ -229,7 +230,7 @@ export async function mergePullRequest(
   options: Omit<z.infer<typeof MergePullRequestSchema>, 'owner' | 'repo' | 'pull_number'>
 ): Promise<any> {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
     {
       method: 'PUT',
       body: options,
@@ -243,7 +244,7 @@ export async function getPullRequestFiles(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestFileSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/files`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/files`
   );
   return z.array(PullRequestFileSchema).parse(response);
 }
@@ -255,7 +256,7 @@ export async function updatePullRequestBranch(
   expectedHeadSha?: string
 ): Promise<void> {
   await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/update-branch`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/update-branch`,
     {
       method: "PUT",
       body: expectedHeadSha ? { expected_head_sha: expectedHeadSha } : undefined,
@@ -269,7 +270,7 @@ export async function getPullRequestComments(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestCommentSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/comments`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/comments`
   );
   return z.array(PullRequestCommentSchema).parse(response);
 }
@@ -280,7 +281,7 @@ export async function getPullRequestReviews(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestReviewSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`
   );
   return z.array(PullRequestReviewSchema).parse(response);
 }
@@ -296,7 +297,7 @@ export async function getPullRequestStatus(
 
   // Then get the combined status for that SHA
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/commits/${sha}/status`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/commits/${sha}/status`
   );
   return CombinedStatusSchema.parse(response);
 }

--- a/src/github/operations/repository.ts
+++ b/src/github/operations/repository.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { githubRequest } from "../common/utils.js";
 import { GitHubRepositorySchema, GitHubSearchResponseSchema } from "../common/types.js";
+import { GITHUB_API_URL } from "../common/config.js";
 
 // Schema definitions
 export const CreateRepositoryOptionsSchema = z.object({
@@ -27,7 +28,7 @@ export type CreateRepositoryOptions = z.infer<typeof CreateRepositoryOptionsSche
 
 // Function implementations
 export async function createRepository(options: CreateRepositoryOptions) {
-  const response = await githubRequest("https://api.github.com/user/repos", {
+  const response = await githubRequest(`${GITHUB_API_URL}/user/repos`, {
     method: "POST",
     body: options,
   });
@@ -39,7 +40,7 @@ export async function searchRepositories(
   page: number = 1,
   perPage: number = 30
 ) {
-  const url = new URL("https://api.github.com/search/repositories");
+  const url = new URL(`${GITHUB_API_URL}/search/repositories`);
   url.searchParams.append("q", query);
   url.searchParams.append("page", page.toString());
   url.searchParams.append("per_page", perPage.toString());
@@ -54,8 +55,8 @@ export async function forkRepository(
   organization?: string
 ) {
   const url = organization
-    ? `https://api.github.com/repos/${owner}/${repo}/forks?organization=${organization}`
-    : `https://api.github.com/repos/${owner}/${repo}/forks`;
+    ? `${GITHUB_API_URL}/repos/${owner}/${repo}/forks?organization=${organization}`
+    : `${GITHUB_API_URL}/repos/${owner}/${repo}/forks`;
 
   const response = await githubRequest(url, { method: "POST" });
   return GitHubRepositorySchema.extend({

--- a/src/github/operations/search.ts
+++ b/src/github/operations/search.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { githubRequest, buildUrl } from "../common/utils.js";
+import { GITHUB_API_URL } from "../common/config.js";
 
 export const SearchOptions = z.object({
   q: z.string(),
@@ -33,13 +34,13 @@ export const SearchUsersSchema = SearchUsersOptions;
 export const SearchIssuesSchema = SearchIssuesOptions;
 
 export async function searchCode(params: z.infer<typeof SearchCodeSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/code", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/code`, params));
 }
 
 export async function searchIssues(params: z.infer<typeof SearchIssuesSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/issues", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/issues`, params));
 }
 
 export async function searchUsers(params: z.infer<typeof SearchUsersSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/users", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/users`, params));
 }


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

This tweak allows the user to pass a custom URL for the GitHub instance, supporting onprem enterprise instances.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: resources

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Currently this server is incompatible with users that work with GitHub Enterprise onprem. Swapping the API url as a variable allows for values such as "git.mycompany.com/api/v3/"

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

Tested with [goose](https://github.com/block/goose)

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
