### PR TITLE
Add ServiceNow MCP server to list of community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Salesforce MCP](https://github.com/smn2gnt/MCP-Salesforce)** - Interact with Salesforce Data and Metadata
 - **[Scholarly](https://github.com/adityak74/mcp-scholarly)** - A MCP server to search for scholarly and academic articles.
 - **[SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng)** - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
+- **[ServiceNow](https://github.com/osomai/servicenow-mcp)** - A MCP server to interact with a ServiceNow instance
 - **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - This MCP server enables LLMs to interact with Snowflake databases, allowing for secure and controlled data operations.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify.
 - **[Stripe](https://github.com/atharvagupta2003/mcp-stripe)** - This MCP allows integration with Stripe for handling payments, customers, and refunds.


### PR DESCRIPTION
## Description
Adding ServiceNow MCP server to the community servers list.

## Server Details
- Server:  ServiceNow
- Changes to: README.md only (adding to community servers list)

## Motivation and Context
Allows interactions with a ServiceNow instance via MCP clients.

## How Has This Been Tested?
Tested all scenarios via automated scripts + via Claude desktop

![image](https://github.com/user-attachments/assets/5641e552-eeeb-40f3-87fa-b1ee3cbe314f)
![image](https://github.com/user-attachments/assets/16102aa2-c966-44ce-95d3-d1b686722cd1)


## Breaking Changes
None. This is just adding a reference to the community servers list.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Starts with just the incident management module. Will be adding more modules in there soon.
