### PR TITLE
Expose all declared GitHub tools

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -149,6 +149,70 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
+      },
+      {
+        name: "get_pull_request",
+        description: "Get details of a specific pull request in a GitHub repository",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
+      },
+      {
+        name: "list_pull_requests",
+        description: "List pull requests in a GitHub repository with filtering options",
+        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the list of files changed in a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get comments on a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get reviews for a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
+      },
+      {
+        name: "create_pull_request_review",
+        description: "Create a review for a pull request",
+        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the status checks for a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
+      },
+      {
+        name: "update_branch",
+        description: "Update a branch to point to a specific commit SHA",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string().describe("Repository owner (username or organization)"),
+          repo: z.string().describe("Repository name"),
+          branch: z.string().describe("Branch name to update"),
+          sha: z.string().describe("SHA of the commit to point the branch to"),
+        })),
+      },
+      {
+        name: "get_branch_sha",
+        description: "Get the SHA of the latest commit on a branch",
+        inputSchema: zodToJsonSchema(z.object({
+          owner: z.string().describe("Repository owner (username or organization)"),
+          repo: z.string().describe("Repository name"),
+          branch: z.string().describe("Branch name"),
+        })),
       }
     ],
   };
@@ -332,6 +396,107 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        };
+      }
+
+      case "get_pull_request": {
+        const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
+        const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
+        };
+      }
+
+      case "list_pull_requests": {
+        const args = pulls.ListPullRequestsSchema.parse(request.params.arguments);
+        const { owner, repo, ...options } = args;
+        const pullRequests = await pulls.listPullRequests(owner, repo, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequests, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_files": {
+        const args = pulls.GetPullRequestFilesSchema.parse(request.params.arguments);
+        const files = await pulls.getPullRequestFiles(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_comments": {
+        const args = pulls.GetPullRequestCommentsSchema.parse(request.params.arguments);
+        const comments = await pulls.getPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_reviews": {
+        const args = pulls.GetPullRequestReviewsSchema.parse(request.params.arguments);
+        const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+        };
+      }
+
+      case "create_pull_request_review": {
+        const args = pulls.CreatePullRequestReviewSchema.parse(request.params.arguments);
+        const { owner, repo, pull_number, ...options } = args;
+        const review = await pulls.createPullRequestReview(owner, repo, pull_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(review, null, 2) }],
+        };
+      }
+
+      case "merge_pull_request": {
+        const args = pulls.MergePullRequestSchema.parse(request.params.arguments);
+        const { owner, repo, pull_number, ...options } = args;
+        const result = await pulls.mergePullRequest(owner, repo, pull_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "update_pull_request_branch": {
+        const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
+        const { owner, repo, pull_number, expected_head_sha } = args;
+        const result = await pulls.updatePullRequestBranch(owner, repo, pull_number, expected_head_sha);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_status": {
+        const args = pulls.GetPullRequestStatusSchema.parse(request.params.arguments);
+        const status = await pulls.getPullRequestStatus(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+        };
+      }
+
+      case "update_branch": {
+        const args = z.object({
+          owner: z.string().describe("Repository owner (username or organization)"),
+          repo: z.string().describe("Repository name"),
+          branch: z.string().describe("Branch name to update"),
+          sha: z.string().describe("SHA of the commit to point the branch to"),
+        }).parse(request.params.arguments);
+        const result = await branches.updateBranch(args.owner, args.repo, args.branch, args.sha);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_branch_sha": {
+        const args = z.object({
+          owner: z.string().describe("Repository owner (username or organization)"),
+          repo: z.string().describe("Repository name"),
+          branch: z.string().describe("Branch name"),
+        }).parse(request.params.arguments);
+        const sha = await branches.getBranchSHA(args.owner, args.repo, args.branch);
+        return {
+          content: [{ type: "text", text: JSON.stringify(sha, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Description
There are a lot of commands declared in Github server readme, that were not exposed.
It caused clients ignoring the tools.

## Server Details
- Server: github
- Changes to: index.ts

## Motivation and Context
This change allows client to call additional tools that were already implemented, but not exposed, like get_pull_request_comments

## How Has This Been Tested?
I've tested the added tools via Cursor, it works as expected

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
