### PR TITLE
Fix behaviour of search_files tool

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -78,12 +78,12 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - Fails if destination exists
 
 - **search_files**
-  - Recursively search for files/directories
+  - Recursively search for files/directories that match or do not match patterns
   - Inputs:
     - `path` (string): Starting directory
     - `pattern` (string): Search pattern
-    - `excludePatterns` (string[]): Exclude any patterns. Glob formats are supported.
-  - Case-insensitive matching
+    - `excludePatterns` (string[]): Exclude any patterns.
+  - Glob-style pattern matching
   - Returns full paths to matches
 
 - **get_file_info**


### PR DESCRIPTION
The `search_files` tool currently has inconsistent and unexpected behaviour. 
Issue: https://github.com/modelcontextprotocol/servers/issues/735

## Description

For some reason, glob pattern matching was only supported for `excludePatterns` argument and not `patterns`, which is unexpected and causes LLMs to get confused and waste a lot of tokens and request cycles figuring out how to use the tool. 

This change improves and standardises the behaviour by:

- Support  glob-style pattern matching in `pattern` argument. The full path to each item is checked (not just the item name like before), so a pattern like `**/*.ext` is required to recursively match files in sub-directories
- No longer automatically convert `excludePatterns` patterns to `**/<pattern>/**` format when no wildcard/* provided
- Update tool description so models can use it properly

## Server Details

- Server:  filesystem
- Changes to: search_files tool

## Motivation and Context
See above

## How Has This Been Tested?
Tested  directly and with Gemini model, with many combinations of `pattern` and `excludePatterns`

## Breaking Changes
Possibly, there is a change in behaviour (not change in tool interface). 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ x] My changes follows MCP security best practices
- [x ] I have updated the server's README accordingly
- [x ] I have tested this with an LLM client
- [ x] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [ x] I have documented all environment variables and configuration options

