### PR TITLE
Update mount arguments for docker commands

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -120,9 +120,9 @@ Note: all directories must be mounted to `/projects` by default.
         "run",
         "-i",
         "--rm",
-        "--mount", "type=bind,src=/Users/username/Desktop,dst=/projects/Desktop",
-        "--mount", "type=bind,src=/path/to/other/allowed/dir,dst=/projects/other/allowed/dir,ro",
-        "--mount", "type=bind,src=/path/to/file.txt,dst=/projects/path/to/file.txt",
+        "--mount", "type=bind,source=/Users/username/Desktop,target=/projects/Desktop",
+        "--mount", "type=bind,source=/path/to/other/allowed/dir,target=/projects/other/allowed/dir,ro",
+        "--mount", "type=bind,source=/path/to/file.txt,target=/projects/path/to/file.txt",
         "mcp/filesystem",
         "/projects"
       ]


### PR DESCRIPTION
…
modified:   src/filesystem/README.md

- According to Claude, it should be source, not src, and target, not dst.

## Description

## Server Details

- Server: filesystem
- Changes to: README.md

## Motivation and Context

Without this change, I observe, "Could not attach to MCP server filesystem".

## Types of changes
- [X ] Documentation update

## Checklist
- [X ] I have updated the server's README accordingly

