### PR TITLE
Feature(github): add proxy support

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -326,10 +326,13 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
         "--rm",
         "-e",
         "GITHUB_PERSONAL_ACCESS_TOKEN",
+        // "-e", // OPTIONAL
+        // "PROXY",
         "mcp/github"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        "PROXY": "<IF_YOU_NEED_PROXY>"
       }
     }
   }
@@ -348,7 +351,8 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
         "@modelcontextprotocol/server-github"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        "PROXY": "<IF_YOU_NEED_PROXY>"
       }
     }
   }

--- a/src/github/package.json
+++ b/src/github/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",
     "@types/node": "^22",
-    "@types/node-fetch": "^2.6.12",
     "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
     "universal-user-agent": "^7.0.2",

--- a/src/github/package.json
+++ b/src/github/package.json
@@ -22,6 +22,7 @@
     "@modelcontextprotocol/sdk": "1.0.1",
     "@types/node": "^22",
     "@types/node-fetch": "^2.6.12",
+    "https-proxy-agent": "^7.0.6",
     "node-fetch": "^3.3.2",
     "universal-user-agent": "^7.0.2",
     "zod": "^3.22.4",


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->
A feature for VPN user.
## Description
For some reason, there are some users(for example, china mainland) need to use VPN to visit Github, `global proxy` is not a good idea in some case.
So there should be a way to set `proxy` separately.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: utils.ts

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
See above.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
all tests with `cline`:
- no proxy env
- set proxy env 
- set proxy env but not a valid url schema

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
If you don't need proxy, you don't need to change anything.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
