### PR TITLE
Add Template MCP Server to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[FastMCP](https://github.com/punkpeye/fastmcp)** (TypeScript)
 * **[Foxy Contexts](https://github.com/strowk/foxy-contexts)** – A library to build MCP servers in Golang by **[strowk](https://github.com/strowk)**
 * **[Quarkus MCP Server SDK](https://github.com/quarkiverse/quarkus-mcp-server)** (Java)
+* **[Template MCP Server](https://github.com/mcpdotdirect/template-mcp-server)** - A CLI tool to create a new Model Context Protocol server project with TypeScript support, dual transport options, and an extensible structure
 
 ### For clients
 


### PR DESCRIPTION
## Description
This PR adds the Template MCP Server to the Frameworks section of the README.md. The Template MCP Server is a CLI tool to create new Model Context Protocol server projects with TypeScript support, dual transport options, and an extensible structure.

## Server Details
- Server: **Template MCP Server**
- Changes to: Adding reference in README.md under Frameworks

## Motivation and Context
The Template MCP Server provides developers with a quick starting point for creating their own MCP servers. It simplifies the development process by providing a well-structured template with both STDIO and HTTP transport support. Adding this tool to the README will help new developers more easily create MCP servers that follow best practices.

## How Has This Been Tested?
The template has been tested by:
- Creating new projects with the CLI tool
- Verifying the generated projects work with Claude Desktop
- Testing both STDIO and HTTP transport options
- Validating that the template follows MCP protocol specifications

## Breaking Changes
None. This is only adding a reference to the README.md.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The Template MCP Server provides:
- TypeScript project structure with proper typing
- Support for both STDIO and HTTP/SSE transport
- Example implementation of tools and resources
- Built-in tests and configuration
- CLI to quickly scaffold new projects

This tool helps standardize MCP server development and reduces the barrier to entry for new developers wanting to create their own servers.