### PR TITLE
Add EVM MCP Server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Elasticsearch](https://github.com/cr7258/elasticsearch-mcp-server)** - MCP server implementation that provides Elasticsearch interaction.
 - **[ElevenLabs](https://github.com/mamertofabian/elevenlabs-mcp-server)** - A server that integrates with ElevenLabs text-to-speech API capable of generating full voiceovers with multiple voices.
 - **[Eunomia](https://github.com/whataboutyou-ai/eunomia-MCP-server)** - Extension of the Eunomia framework that connects Eunomia instruments with MCP servers
+- **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[Everything Search](https://github.com/mamertofabian/mcp-everything-search)** - Fast file searching capabilities across Windows (using [Everything SDK](https://www.voidtools.com/support/everything/sdk/)), macOS (using mdfind command), and Linux (using locate/plocate command).
 - **[Fetch](https://github.com/zcaceres/fetch-mcp)** - A server that flexibly fetches HTML, JSON, Markdown, or plaintext.
 - **[FireCrawl](https://github.com/vrknetha/mcp-server-firecrawl)** - Advanced web scraping with JavaScript rendering, PDF support, and smart rate limiting


### PR DESCRIPTION
## Description
This PR adds the EVM MCP Server to the Community Servers section of the README.md. The EVM MCP Server provides comprehensive blockchain services for 30+ EVM-compatible networks, enabling AI agents to interact with various blockchain functionalities through a unified interface.

## Server Details
- Server: **EVM MCP Server**
- Changes to: Adding reference in README.md

## Motivation and Context
The EVM MCP Server provides unique blockchain capabilities that aren't currently available in the MCP ecosystem. It enables LLMs to interact with Ethereum, Optimism, Arbitrum, Base, Polygon, and many other EVM chains with a consistent interface. Adding this server to the README will help users discover this capability and integrate blockchain functionality into their AI agents.

## How Has This Been Tested?
The server has been tested with Claude Desktop across multiple EVM networks, including:
- Ethereum mainnet (balance queries, token transfers, smart contract interactions)
- Base (token and NFT operations)
- Optimism (transaction status and token queries)
- Polygon (NFT and smart contract interactions)

## Breaking Changes
None. This is only adding a reference to the README.md.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The EVM MCP Server supports 30+ EVM networks including all major L1s and L2s. It handles native tokens, ERC20, ERC721, and ERC1155 tokens. One unique feature is ENS name resolution support for all address parameters - allowing LLMs to use human-readable addresses (like 'vitalik.eth') instead of hexadecimal addresses.