### PR TITLE
fix: Uplift AWS Knowledge Base MCP Server

### DIFF
--- a/src/aws-kb-retrieval-server/README.md
+++ b/src/aws-kb-retrieval-server/README.md
@@ -15,35 +15,86 @@ An MCP server implementation for retrieving information from the AWS Knowledge B
     - `query` (string): The search query for retrieval.
     - `knowledgeBaseId` (string): The ID of the AWS Knowledge Base.
     - `n` (number, optional): Number of results to retrieve (default: 3).
+  - Response format:
+    - The response now returns two separate content items:
+      - A text item containing the raw context from the knowledge base.
+      - A JSON item containing the structured RAG sources with metadata (id, fileName, snippet, and score).
+    - This separation allows for more flexible processing of the results.
 
 ## Configuration
 
 ### Setting up AWS Credentials
 
+You have two options for configuring AWS credentials:
+
+#### Option 1: IAM Access Keys
+
 1. Obtain AWS access key ID, secret access key, and region from the AWS Management Console.
 2. Ensure these credentials have appropriate permissions for Bedrock Agent Runtime operations.
+3. Set the environment variables as shown in the configuration examples below.
+4. For temporary credentials, you can also provide a session token using the `AWS_SESSION_TOKEN` environment variable.
+
+#### Option 2: AWS SSO (Single Sign-On)
+
+The server now supports AWS SSO credentials:
+
+1. Configure AWS CLI with your SSO profile: `aws configure sso`
+2. Set only the AWS_REGION environment variable in the MCP server configuration.
+3. The server will use the default credential provider chain, which includes SSO credentials.
+
+### Optional: Configure Default Knowledge Base IDs
+
+You can optionally specify one or more knowledge base IDs to use by default:
+
+1. Create an array of knowledge base IDs in JSON format.
+2. Set this as the AWS_KB_IDS environment variable in your configuration.
+3. When this is configured, the `knowledgeBaseId` parameter becomes optional in the tool.
 
 ### Usage with Claude Desktop
 
 Add this to your `claude_desktop_config.json`:
 
-#### Docker
+#### Docker with IAM Access Keys
 
 ```json
 {
   "mcpServers": {
     "aws-kb-retrieval": {
       "command": "docker",
-      "args": [ "run", "-i", "--rm", "-e", "AWS_ACCESS_KEY_ID", "-e", "AWS_SECRET_ACCESS_KEY", "-e", "AWS_REGION", "mcp/aws-kb-retrieval-server" ],
+      "args": [ "run", "-i", "--rm", "-e", "AWS_ACCESS_KEY_ID", "-e", "AWS_SECRET_ACCESS_KEY", "-e", "AWS_REGION", "-e", "AWS_KB_IDS", "mcp/aws-kb-retrieval-server" ],
       "env": {
         "AWS_ACCESS_KEY_ID": "YOUR_ACCESS_KEY_HERE",
         "AWS_SECRET_ACCESS_KEY": "YOUR_SECRET_ACCESS_KEY_HERE",
-        "AWS_REGION": "YOUR_AWS_REGION_HERE"
+        "AWS_SESSION_TOKEN": "YOUR_OPTIONAL_SESSION_ID_FOR_SSO_TEMPORARY_CREDENTIALS_HERE",
+        "AWS_REGION": "YOUR_AWS_REGION_HERE",
+        "AWS_KB_IDS": "[\"kb-12345\", \"kb-67890\"]"
       }
     }
   }
 }
 ```
+
+#### Docker with AWS SSO
+
+```json
+{
+  "mcpServers": {
+    "aws-kb-retrieval": {
+      "command": "docker",
+      "args": [ "run", "-i", "--rm", "-e", "AWS_REGION", "-e", "AWS_KB_IDS", "-v", "${HOME}/.aws:/root/.aws", "mcp/aws-kb-retrieval-server" ],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "YOUR_ACCESS_KEY_HERE",
+        "AWS_SECRET_ACCESS_KEY": "YOUR_SECRET_ACCESS_KEY_HERE",
+        "AWS_SESSION_TOKEN": "YOUR_OPTIONAL_SESSION_ID_FOR_SSO_TEMPORARY_CREDENTIALS_HERE",
+        "AWS_REGION": "YOUR_AWS_REGION_HERE",
+        "AWS_KB_IDS": "[\"kb-12345\", \"kb-67890\"]"
+      }
+    }
+  }
+}
+```
+
+#### NPX with IAM Access Keys
 
 ```json
 {
@@ -57,8 +108,60 @@ Add this to your `claude_desktop_config.json`:
       "env": {
         "AWS_ACCESS_KEY_ID": "YOUR_ACCESS_KEY_HERE",
         "AWS_SECRET_ACCESS_KEY": "YOUR_SECRET_ACCESS_KEY_HERE",
-        "AWS_REGION": "YOUR_AWS_REGION_HERE"
+        "AWS_SESSION_TOKEN": "YOUR_OPTIONAL_SESSION_ID_FOR_SSO_TEMPORARY_CREDENTIALS_HERE",
+        "AWS_REGION": "YOUR_AWS_REGION_HERE",
+        "AWS_KB_IDS": "[\"kb-12345\", \"kb-67890\"]"
       }
+    }
+  }
+}
+```
+
+#### NPX with AWS SSO
+
+```json
+{
+  "mcpServers": {
+    "aws-kb-retrieval": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-aws-kb-retrieval"
+      ],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "YOUR_ACCESS_KEY_HERE",
+        "AWS_SECRET_ACCESS_KEY": "YOUR_SECRET_ACCESS_KEY_HERE",
+        "AWS_SESSION_TOKEN": "YOUR_OPTIONAL_SESSION_ID_FOR_SSO_TEMPORARY_CREDENTIALS_HERE",
+        "AWS_REGION": "YOUR_AWS_REGION_HERE",
+        "AWS_KB_IDS": "[\"kb-12345\", \"kb-67890\"]"
+      }
+    }
+  }
+}
+```
+
+#### Local Repository (from cloned/built repo)
+
+```json
+{
+  "mcpServers": {
+    "aws-kb": {
+      "command": "node",
+      "args": [
+        "/path/to/mcp-aws-kb/dist/index.js"
+      ],
+      "env": {
+        "AWS_ACCESS_KEY_ID": "YOUR_ACCESS_KEY_HERE",
+        "AWS_SECRET_ACCESS_KEY": "YOUR_SECRET_ACCESS_KEY_HERE",
+        "AWS_SESSION_TOKEN": "YOUR_OPTIONAL_SESSION_ID_FOR_SSO_TEMPORARY_CREDENTIALS_HERE",
+        "AWS_REGION": "YOUR_AWS_REGION_HERE",
+        "AWS_KB_IDS": "[\"kb-12345\", \"kb-67890\"]"
+      },
+      "disabled": false,
+      "autoApprove": [
+        "retrieve_from_aws_kb"
+      ],
+      "timeout": 120
     }
   }
 }
@@ -66,10 +169,10 @@ Add this to your `claude_desktop_config.json`:
 
 ## Building
 
-Docker: 
+Docker:
 
 ```sh
-docker build -t mcp/aws-kb-retrieval -f src/aws-kb-retrieval-server/Dockerfile . 
+docker build -t mcp/aws-kb-retrieval -f src/aws-kb-retrieval-server/Dockerfile .
 ```
 
 ## License

--- a/src/aws-kb-retrieval-server/package.json
+++ b/src/aws-kb-retrieval-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/server-aws-kb-retrieval",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "MCP server for AWS Knowledge Base retrieval using Bedrock Agent Runtime",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",
@@ -19,12 +19,13 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "0.5.0",
-    "@aws-sdk/client-bedrock-agent-runtime": "^3.0.0"
+    "@modelcontextprotocol/sdk": "1.7.0",
+    "@aws-sdk/client-bedrock-agent-runtime": "^3.765.0"
   },
   "devDependencies": {
-    "@types/node": "^22",
+    "@types/node": "^22.13.10",
     "shx": "^0.3.4",
-    "typescript": "^5.6.2"
-  }
+    "typescript": "^5.8.2"
+  },
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }

--- a/src/aws-kb-retrieval-server/tsconfig.json
+++ b/src/aws-kb-retrieval-server/tsconfig.json
@@ -1,11 +1,19 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
     "outDir": "./dist",
     "rootDir": ".",
+    "declaration": true,
     "composite": true,
     "incremental": true,
-    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "lib": ["ES2020", "DOM"]
   },
   "include": [
     "./**/*.ts"


### PR DESCRIPTION
Minor rewrite of the AWS Knowledge Base MCP Server with improvements and fixes

## Description

## Server Details
- Server: aws-kb-retrieval-server
- Changes to: envs, tools

## Motivation and Context

Previously the MCP server:

- Failed if you use SSO (which many (most?) users of AWS do)
- Required you to provide the ID of a single knowledge base every time you used it
- Had poor formatting of the response with the metadata included in the body of the knowledge retrieved
- Used outdated Typescript conventions that broke linting with modern Typescript
- Used outdated package versions

## How Has This Been Tested?

Tested with Cline and an AWS KB

## Breaking Changes

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
