### PR TITLE
feat: Add URL and title fields to RAG results from AWS KB retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+CLAUDE.md


### PR DESCRIPTION
## Description
Added URL and title fields to RAG results from AWS KB retrieval, enabling users to access the original source documents directly.

## Server Details
- Server: aws-kb-retrieval
- Changes to: The RAGSource interface and retrieval function to extract and return additional metadata

## Motivation and Context
This enhancement improves the usefulness of the RAG results by providing additional context about the source documents, including their original URL (for Confluence sources) and document title, making it easier for users to navigate to the original sources.

## How Has This Been Tested?
Tested with the AWS Bedrock Agent Runtime API to ensure the new fields are correctly extracted from the response.

## Breaking Changes
No breaking changes. The new fields are optional and backward compatible.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options