### PR TITLE
Add support for taking postgres URI from environment variable

### DIFF
--- a/src/postgres/README.md
+++ b/src/postgres/README.md
@@ -28,6 +28,7 @@ To use this server with the Claude Desktop app, add the following configuration 
 
 * when running docker on macos, use host.docker.internal if the server is running on the host network (eg localhost)
 * username/password can be added to the postgresql url with `postgresql://user:password@host:port/db-name`
+* Alternatively the postgresql connection string or URI can be specified in the POSTGRES_URI environment variable.
 
 ```json
 {

--- a/src/postgres/index.ts
+++ b/src/postgres/index.ts
@@ -23,13 +23,19 @@ const server = new Server(
   },
 );
 
-const args = process.argv.slice(2);
-if (args.length === 0) {
-  console.error("Please provide a database URL as a command-line argument");
+function getPostgresConnectionUri(): string {
+  const args = process.argv.slice(2);
+  if (args.length !== 0) {
+    return args[0];
+  }
+  if (process.env.POSTGRES_URI) {
+    return process.env.POSTGRES_URI;
+  }
+  console.error("Please provide a database URL as a command-line argument or an environment variable");
   process.exit(1);
 }
 
-const databaseUrl = args[0];
+const databaseUrl = getPostgresConnectionUri();
 
 const resourceBaseUrl = new URL(databaseUrl);
 resourceBaseUrl.protocol = "postgres:";


### PR DESCRIPTION
Add support for specifying the postgres connection string from environment variable.

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: postgres
- Changes to: Startup configuration

## Motivation and Context
Issue #842
Also it's better to have credentials in the environment variable as it doesn't show up in ps.

## How Has This Been Tested?
`npx tsc` then `POSTGRES_URI="postgresql://127.0.0.1:port/db_name" node dist/index.js`

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [N/A] I have tested this with an LLM client
  * I've tested that the same connection to the postgres is made.
- [x] My code follows the repository's style guidelines
- [N/A] New and existing tests pass locally
  * Did not see any tests
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
