### PR TITLE
Add Google Search Console MCP server

### DIFF
--- a/mcp-gsc/README.md
+++ b/mcp-gsc/README.md
@@ -1,0 +1,132 @@
+# Google Search Console MCP
+
+An MCP server implementation that integrates [Google Search Console](https://search.google.com/search-console/about) (GSC). This server exposes read-only GSC data and tools for property management, sitemaps, site details, indexing inspections, and more.
+
+---
+
+## Features
+
+1. **Property Management**  
+   - `list_properties`: Enumerate your GSC properties.  
+   - `get_site_details`: Inspect a GSC property’s basic data and verification info.
+
+2. **Analytics & Reporting**  
+   - `get_search_analytics`: Retrieve aggregated search performance metrics (queries, impressions, CTR, etc.).  
+   - `get_performance_overview`: Summarized performance and daily trends.  
+   - `get_advanced_search_analytics`: Advanced filters, sorting, and pagination for deeper insights.  
+
+3. **Indexing & URL Inspection**  
+   - `check_indexing_issues`: Evaluate potential indexing or canonical issues across multiple URLs.  
+   - `inspect_url_enhanced`: Detailed URL inspection (indexing coverage, last crawl, etc.).  
+   - `batch_url_inspection`: Inspect multiple URLs in one operation.
+
+4. **Sitemap Management**  
+   - `manage_sitemaps`: All-in-one approach to list, get details, submit, or delete sitemaps.  
+   - `get_sitemaps`: Quick listing of sitemaps for a property.  
+   - `list_sitemaps_enhanced`: More in-depth listing (index vs. child sitemaps, error/warning details).
+
+5. **Creator Info**  
+   - `get_creator_info`: Quick reference about Amin Foroutan, the creator of this GSC tool.
+
+---
+
+## Tools
+
+Below is a short summary of each tool exposed by MCP-GSC. For full usage instructions, call `list_tools` in your MCP client or see the docstrings in [gsc_server.py](gsc_server.py).
+
+| **Tool Name**                   | **Purpose**                                                   | **Key Parameters**                                                 |
+|---------------------------------|---------------------------------------------------------------|---------------------------------------------------------------------|
+| `list_properties`               | List your GSC properties.                                    | *(none)*                                                            |
+| `get_site_details`              | Get property-level details and verification info.            | `site_url`                                                          |
+| `get_search_analytics`          | Fetch top queries/pages plus metrics in a given date window. | `site_url`, `days`, `dimensions`                                    |
+| `get_performance_overview`      | Summarized performance and daily trend.                      | `site_url`, `days`                                                 |
+| `check_indexing_issues`         | Diagnose indexing issues across multiple URLs.               | `site_url`, `urls (newline-separated)`                              |
+| `inspect_url_enhanced`          | Enhanced URL inspection (coverage state, last crawl, etc.).  | `site_url`, `page_url`                                              |
+| `batch_url_inspection`          | Inspect multiple URLs (limit 10).                            | `site_url`, `urls (newline-separated)`                              |
+| `get_sitemaps`                  | List sitemaps for a property.                                | `site_url`                                                          |
+| `list_sitemaps_enhanced`        | Advanced listing for sitemap index vs. child sitemaps.       | `site_url`, `sitemap_index` (optional)                              |
+| `manage_sitemaps`               | All-in-one submit/delete/list sitemaps.                      | `site_url`, `action`, `sitemap_url` (varies by action)              |
+| `get_sitemap_details`           | Detailed info about a specific sitemap.                      | `site_url`, `sitemap_url`                                           |
+| `submit_sitemap`                | Submit (or re-submit) a sitemap to GSC.                      | `site_url`, `sitemap_url`                                           |
+| `delete_sitemap`                | Remove (unsubmit) a sitemap from GSC.                        | `site_url`, `sitemap_url`                                           |
+| `get_search_by_page_query`      | Queries and metrics for a specific page.                     | `site_url`, `page_url`, `days`                                      |
+| `get_advanced_search_analytics` | Advanced analytics filtering, sorting, pagination, etc.      | `site_url`, `start_date`, `end_date`, `dimensions`, … (see doc)     |
+| `compare_search_periods`        | Compare search analytics data between two date ranges.       | `site_url`, `period1_start`, `period1_end`, `period2_start`, …      |
+| `get_creator_info`              | Info about Amin Foroutan, creator of the MCP-GSC tool.       | *(none)*                                                            |
+
+---
+
+## Configuration
+
+### 1. Credentials Setup
+
+This server requires a **service account JSON** (or user OAuth credentials). Typically:
+
+1. Create a service account in your Google Cloud Console.  
+2. Download the **JSON key** (e.g., `service_account_credentials.json`).  
+3. Either place it alongside `gsc_server.py` **or** set an environment variable:
+   ```bash
+   export GSC_CREDENTIALS_PATH="/absolute/path/to/service_account_credentials.json"
+   ```
+4. Make sure your service account has been granted access to relevant GSC properties.
+
+### 2. Python Requirements
+
+- Python 3.11 or higher
+- Install dependencies:
+
+```bash
+uv install  # Recommended
+
+# OR using pip
+pip install -r requirements.txt
+```
+
+### 3. Running Locally
+
+```bash
+python mcp-gsc/gsc_server.py
+```
+
+Or using [`uv`](https://astral.sh/uv/):
+
+```bash
+uv run gsc_server.py
+```
+
+---
+
+## Usage with Claude Desktop
+
+To integrate this server with Claude Desktop:
+
+1. Ensure `service_account_credentials.json` is available or use an env variable.
+2. Edit `claude_desktop_config.json` (MacOS: `~/Library/Application Support/Claude`, Windows: `%APPDATA%/Claude`):
+
+   ```json
+   {
+     "mcpServers": {
+       "gscServer": {
+         "command": "python",
+         "args": ["/ABSOLUTE/PATH/TO/mcp-gsc/gsc_server.py"],
+         "env": {
+           "GSC_CREDENTIALS_PATH": "/ABSOLUTE/PATH/TO/service_account_credentials.json"
+         }
+       }
+     }
+   }
+   ```
+
+3. Restart Claude for Desktop and check the MCP tools.
+
+---
+
+## Contributing
+
+PRs are welcome! If you find a bug or want to add a new GSC endpoint, open an issue or submit a pull request.
+
+---
+
+## License
+
+This MCP-GSC project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/mcp-gsc/gsc_server.py
+++ b/mcp-gsc/gsc_server.py
@@ -1,0 +1,1284 @@
+from typing import Any, Dict, List, Optional
+import os
+import json
+from datetime import datetime, timedelta
+
+import google.auth
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# MCP
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("gsc-server")
+
+# Path to your service account JSON or user credentials JSON
+# First check if GSC_CREDENTIALS_PATH environment variable is set
+# Then try looking in the script directory and current working directory as fallbacks
+GSC_CREDENTIALS_PATH = os.environ.get("GSC_CREDENTIALS_PATH")
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+POSSIBLE_CREDENTIAL_PATHS = [
+    GSC_CREDENTIALS_PATH,  # First try the environment variable if set
+    os.path.join(SCRIPT_DIR, "service_account_credentials.json"),
+    os.path.join(os.getcwd(), "service_account_credentials.json"),
+    # Add any other potential paths here
+]
+
+SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
+
+def get_gsc_service():
+    """
+    Returns an authorized Search Console service object.
+    Checks for credentials in environment variable first, then fallback locations.
+    """
+    for cred_path in POSSIBLE_CREDENTIAL_PATHS:
+        if cred_path and os.path.exists(cred_path):
+            try:
+                creds = service_account.Credentials.from_service_account_file(
+                    cred_path, scopes=SCOPES
+                )
+                return build("searchconsole", "v1", credentials=creds)
+            except Exception as e:
+                continue  # Try the next path if this one fails
+    
+    # If we get here, none of the paths worked
+    raise FileNotFoundError(
+        f"Credentials file not found. Please set the GSC_CREDENTIALS_PATH environment variable "
+        f"or place credentials file in one of these locations: "
+        f"{', '.join([p for p in POSSIBLE_CREDENTIAL_PATHS[1:] if p])}"
+    )
+
+@mcp.tool()
+async def list_properties() -> str:
+    """
+    Retrieves and returns the user's Search Console properties.
+    """
+    try:
+        service = get_gsc_service()
+        site_list = service.sites().list().execute()
+
+        # site_list is typically something like:
+        # {
+        #   "siteEntry": [
+        #       {"siteUrl": "...", "permissionLevel": "..."},
+        #       ...
+        #   ]
+        # }
+        sites = site_list.get("siteEntry", [])
+
+        if not sites:
+            return "No Search Console properties found."
+
+        # Format the results for easy reading
+        lines = []
+        for site in sites:
+            site_url = site.get("siteUrl", "Unknown")
+            permission = site.get("permissionLevel", "Unknown permission")
+            lines.append(f"- {site_url} ({permission})")
+
+        return "\n".join(lines)
+    except FileNotFoundError as e:
+        return (
+            "Error: Service account credentials file not found.\n\n"
+            "To access Google Search Console, please:\n"
+            "1. Create a service account in Google Cloud Console\n"
+            "2. Download the JSON credentials file\n"
+            "3. Save it as 'service_account_credentials.json' in the same directory as this script\n"
+            "4. Share your GSC properties with the service account email"
+        )
+    except Exception as e:
+        return f"Error retrieving properties: {str(e)}"
+
+@mcp.tool()
+async def get_search_analytics(site_url: str, days: int = 28, dimensions: str = "query") -> str:
+    """
+    Get search analytics data for a specific property.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        days: Number of days to look back (default: 28)
+        dimensions: Dimensions to group by (default: query). Options: query, page, device, country, date
+                   You can provide multiple dimensions separated by comma (e.g., "query,page")
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Calculate date range
+        end_date = datetime.now().date()
+        start_date = end_date - timedelta(days=days)
+        
+        # Parse dimensions
+        dimension_list = [d.strip() for d in dimensions.split(",")]
+        
+        # Build request
+        request = {
+            "startDate": start_date.strftime("%Y-%m-%d"),
+            "endDate": end_date.strftime("%Y-%m-%d"),
+            "dimensions": dimension_list,
+            "rowLimit": 20  # Limit to top 20 results
+        }
+        
+        # Execute request
+        response = service.searchanalytics().query(siteUrl=site_url, body=request).execute()
+        
+        if not response.get("rows"):
+            return f"No search analytics data found for {site_url} in the last {days} days."
+        
+        # Format results
+        result_lines = [f"Search analytics for {site_url} (last {days} days):"]
+        result_lines.append("\n" + "-" * 80 + "\n")
+        
+        # Create header based on dimensions
+        header = []
+        for dim in dimension_list:
+            header.append(dim.capitalize())
+        header.extend(["Clicks", "Impressions", "CTR", "Position"])
+        result_lines.append(" | ".join(header))
+        result_lines.append("-" * 80)
+        
+        # Add data rows
+        for row in response.get("rows", []):
+            data = []
+            # Add dimension values
+            for dim_value in row.get("keys", []):
+                data.append(dim_value[:30])  # Truncate long values
+            
+            # Add metrics
+            data.append(str(row.get("clicks", 0)))
+            data.append(str(row.get("impressions", 0)))
+            data.append(f"{row.get('ctr', 0) * 100:.2f}%")
+            data.append(f"{row.get('position', 0):.1f}")
+            
+            result_lines.append(" | ".join(data))
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving search analytics: {str(e)}"
+
+@mcp.tool()
+async def get_site_details(site_url: str) -> str:
+    """
+    Get detailed information about a specific Search Console property.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Get site details
+        site_info = service.sites().get(siteUrl=site_url).execute()
+        
+        # Format the results
+        result_lines = [f"Site details for {site_url}:"]
+        result_lines.append("-" * 50)
+        
+        # Add basic info
+        result_lines.append(f"Permission level: {site_info.get('permissionLevel', 'Unknown')}")
+        
+        # Add verification info if available
+        if "siteVerificationInfo" in site_info:
+            verify_info = site_info["siteVerificationInfo"]
+            result_lines.append(f"Verification state: {verify_info.get('verificationState', 'Unknown')}")
+            
+            if "verifiedUser" in verify_info:
+                result_lines.append(f"Verified by: {verify_info['verifiedUser']}")
+                
+            if "verificationMethod" in verify_info:
+                result_lines.append(f"Verification method: {verify_info['verificationMethod']}")
+        
+        # Add ownership info if available
+        if "ownershipInfo" in site_info:
+            owner_info = site_info["ownershipInfo"]
+            result_lines.append("\nOwnership Information:")
+            result_lines.append(f"Owner: {owner_info.get('owner', 'Unknown')}")
+            
+            if "verificationMethod" in owner_info:
+                result_lines.append(f"Ownership verification: {owner_info['verificationMethod']}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving site details: {str(e)}"
+
+@mcp.tool()
+async def get_sitemaps(site_url: str) -> str:
+    """
+    List all sitemaps for a specific Search Console property.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Get sitemaps list
+        sitemaps = service.sitemaps().list(siteUrl=site_url).execute()
+        
+        if not sitemaps.get("sitemap"):
+            return f"No sitemaps found for {site_url}."
+        
+        # Format the results
+        result_lines = [f"Sitemaps for {site_url}:"]
+        result_lines.append("-" * 80)
+        
+        # Header
+        result_lines.append("Path | Last Downloaded | Status | Indexed URLs | Errors")
+        result_lines.append("-" * 80)
+        
+        # Add each sitemap
+        for sitemap in sitemaps.get("sitemap", []):
+            path = sitemap.get("path", "Unknown")
+            last_downloaded = sitemap.get("lastDownloaded", "Never")
+            
+            # Format last downloaded date if it exists
+            if last_downloaded != "Never":
+                try:
+                    # Convert to more readable format
+                    dt = datetime.fromisoformat(last_downloaded.replace('Z', '+00:00'))
+                    last_downloaded = dt.strftime("%Y-%m-%d %H:%M")
+                except:
+                    pass
+            
+            status = "Valid"
+            if "errors" in sitemap and sitemap["errors"] > 0:
+                status = "Has errors"
+            
+            # Get counts
+            warnings = sitemap.get("warnings", 0)
+            errors = sitemap.get("errors", 0)
+            
+            # Get contents if available
+            indexed_urls = "N/A"
+            if "contents" in sitemap:
+                for content in sitemap["contents"]:
+                    if content.get("type") == "web":
+                        indexed_urls = content.get("submitted", "0")
+                        break
+            
+            result_lines.append(f"{path} | {last_downloaded} | {status} | {indexed_urls} | {errors}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving sitemaps: {str(e)}"
+
+@mcp.tool()
+async def inspect_url_enhanced(site_url: str, page_url: str) -> str:
+    """
+    Enhanced URL inspection to check indexing status and rich results in Google.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match, for domain properties use format: sc-domain:example.com)
+        page_url: The specific URL to inspect
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Build request
+        request = {
+            "inspectionUrl": page_url,
+            "siteUrl": site_url
+        }
+        
+        # Execute request
+        response = service.urlInspection().index().inspect(body=request).execute()
+        
+        if not response or "inspectionResult" not in response:
+            return f"No inspection data found for {page_url}."
+        
+        inspection = response["inspectionResult"]
+        
+        # Format the results
+        result_lines = [f"URL Inspection for {page_url}:"]
+        result_lines.append("-" * 80)
+        
+        # Add inspection result link if available
+        if "inspectionResultLink" in inspection:
+            result_lines.append(f"Search Console Link: {inspection['inspectionResultLink']}")
+            result_lines.append("-" * 80)
+        
+        # Indexing status section
+        index_status = inspection.get("indexStatusResult", {})
+        verdict = index_status.get("verdict", "UNKNOWN")
+        
+        result_lines.append(f"Indexing Status: {verdict}")
+        
+        # Coverage state
+        if "coverageState" in index_status:
+            result_lines.append(f"Coverage: {index_status['coverageState']}")
+        
+        # Last crawl
+        if "lastCrawlTime" in index_status:
+            try:
+                crawl_time = datetime.fromisoformat(index_status["lastCrawlTime"].replace('Z', '+00:00'))
+                result_lines.append(f"Last Crawled: {crawl_time.strftime('%Y-%m-%d %H:%M')}")
+            except:
+                result_lines.append(f"Last Crawled: {index_status['lastCrawlTime']}")
+        
+        # Page fetch
+        if "pageFetchState" in index_status:
+            result_lines.append(f"Page Fetch: {index_status['pageFetchState']}")
+        
+        # Robots.txt status
+        if "robotsTxtState" in index_status:
+            result_lines.append(f"Robots.txt: {index_status['robotsTxtState']}")
+        
+        # Indexing state
+        if "indexingState" in index_status:
+            result_lines.append(f"Indexing State: {index_status['indexingState']}")
+        
+        # Canonical information
+        if "googleCanonical" in index_status:
+            result_lines.append(f"Google Canonical: {index_status['googleCanonical']}")
+        
+        if "userCanonical" in index_status and index_status.get("userCanonical") != index_status.get("googleCanonical"):
+            result_lines.append(f"User Canonical: {index_status['userCanonical']}")
+        
+        # Crawled as
+        if "crawledAs" in index_status:
+            result_lines.append(f"Crawled As: {index_status['crawledAs']}")
+        
+        # Referring URLs
+        if "referringUrls" in index_status and index_status["referringUrls"]:
+            result_lines.append("\nReferring URLs:")
+            for url in index_status["referringUrls"][:5]:  # Limit to 5 examples
+                result_lines.append(f"- {url}")
+            
+            if len(index_status["referringUrls"]) > 5:
+                result_lines.append(f"... and {len(index_status['referringUrls']) - 5} more")
+        
+        # Rich results
+        if "richResultsResult" in inspection:
+            rich = inspection["richResultsResult"]
+            result_lines.append(f"\nRich Results: {rich.get('verdict', 'UNKNOWN')}")
+            
+            if "detectedItems" in rich and rich["detectedItems"]:
+                result_lines.append("Detected Rich Result Types:")
+                
+                for item in rich["detectedItems"]:
+                    rich_type = item.get("richResultType", "Unknown")
+                    result_lines.append(f"- {rich_type}")
+                    
+                    # If there are items with names, show them
+                    if "items" in item and item["items"]:
+                        for i, subitem in enumerate(item["items"][:3]):  # Limit to 3 examples
+                            if "name" in subitem:
+                                result_lines.append(f"  • {subitem['name']}")
+                        
+                        if len(item["items"]) > 3:
+                            result_lines.append(f"  • ... and {len(item['items']) - 3} more items")
+            
+            # Check for issues
+            if "richResultsIssues" in rich and rich["richResultsIssues"]:
+                result_lines.append("\nRich Results Issues:")
+                for issue in rich["richResultsIssues"]:
+                    severity = issue.get("severity", "Unknown")
+                    message = issue.get("message", "Unknown issue")
+                    result_lines.append(f"- [{severity}] {message}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error inspecting URL: {str(e)}"
+
+@mcp.tool()
+async def batch_url_inspection(site_url: str, urls: str) -> str:
+    """
+    Inspect multiple URLs in batch (within API limits).
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match, for domain properties use format: sc-domain:example.com)
+        urls: List of URLs to inspect, one per line
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Parse URLs
+        url_list = [url.strip() for url in urls.split('\n') if url.strip()]
+        
+        if not url_list:
+            return "No URLs provided for inspection."
+        
+        if len(url_list) > 10:
+            return f"Too many URLs provided ({len(url_list)}). Please limit to 10 URLs per batch to avoid API quota issues."
+        
+        # Process each URL
+        results = []
+        
+        for page_url in url_list:
+            # Build request
+            request = {
+                "inspectionUrl": page_url,
+                "siteUrl": site_url
+            }
+            
+            try:
+                # Execute request with a small delay to avoid rate limits
+                response = service.urlInspection().index().inspect(body=request).execute()
+                
+                if not response or "inspectionResult" not in response:
+                    results.append(f"{page_url}: No inspection data found")
+                    continue
+                
+                inspection = response["inspectionResult"]
+                index_status = inspection.get("indexStatusResult", {})
+                
+                # Get key information
+                verdict = index_status.get("verdict", "UNKNOWN")
+                coverage = index_status.get("coverageState", "Unknown")
+                last_crawl = "Never"
+                
+                if "lastCrawlTime" in index_status:
+                    try:
+                        crawl_time = datetime.fromisoformat(index_status["lastCrawlTime"].replace('Z', '+00:00'))
+                        last_crawl = crawl_time.strftime('%Y-%m-%d')
+                    except:
+                        last_crawl = index_status["lastCrawlTime"]
+                
+                # Check for rich results
+                rich_results = "None"
+                if "richResultsResult" in inspection:
+                    rich = inspection["richResultsResult"]
+                    if rich.get("verdict") == "PASS" and "detectedItems" in rich and rich["detectedItems"]:
+                        rich_types = [item.get("richResultType", "Unknown") for item in rich["detectedItems"]]
+                        rich_results = ", ".join(rich_types)
+                
+                # Format result
+                results.append(f"{page_url}:\n  Status: {verdict} - {coverage}\n  Last Crawl: {last_crawl}\n  Rich Results: {rich_results}\n")
+            
+            except Exception as e:
+                results.append(f"{page_url}: Error - {str(e)}")
+        
+        # Combine results
+        return f"Batch URL Inspection Results for {site_url}:\n\n" + "\n".join(results)
+    
+    except Exception as e:
+        return f"Error performing batch inspection: {str(e)}"
+
+@mcp.tool()
+async def check_indexing_issues(site_url: str, urls: str) -> str:
+    """
+    Check for specific indexing issues across multiple URLs.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match, for domain properties use format: sc-domain:example.com)
+        urls: List of URLs to check, one per line
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Parse URLs
+        url_list = [url.strip() for url in urls.split('\n') if url.strip()]
+        
+        if not url_list:
+            return "No URLs provided for inspection."
+        
+        if len(url_list) > 10:
+            return f"Too many URLs provided ({len(url_list)}). Please limit to 10 URLs per batch to avoid API quota issues."
+        
+        # Track issues by category
+        issues_summary = {
+            "not_indexed": [],
+            "canonical_issues": [],
+            "robots_blocked": [],
+            "fetch_issues": [],
+            "indexed": []
+        }
+        
+        # Process each URL
+        for page_url in url_list:
+            # Build request
+            request = {
+                "inspectionUrl": page_url,
+                "siteUrl": site_url
+            }
+            
+            try:
+                # Execute request
+                response = service.urlInspection().index().inspect(body=request).execute()
+                
+                if not response or "inspectionResult" not in response:
+                    issues_summary["not_indexed"].append(f"{page_url} - No inspection data found")
+                    continue
+                
+                inspection = response["inspectionResult"]
+                index_status = inspection.get("indexStatusResult", {})
+                
+                # Check indexing status
+                verdict = index_status.get("verdict", "UNKNOWN")
+                coverage = index_status.get("coverageState", "Unknown")
+                
+                if verdict != "PASS" or "not indexed" in coverage.lower() or "excluded" in coverage.lower():
+                    issues_summary["not_indexed"].append(f"{page_url} - {coverage}")
+                else:
+                    issues_summary["indexed"].append(page_url)
+                
+                # Check canonical issues
+                google_canonical = index_status.get("googleCanonical", "")
+                user_canonical = index_status.get("userCanonical", "")
+                
+                if google_canonical and user_canonical and google_canonical != user_canonical:
+                    issues_summary["canonical_issues"].append(
+                        f"{page_url} - Google chose: {google_canonical} instead of user-declared: {user_canonical}"
+                    )
+                
+                # Check robots.txt status
+                robots_state = index_status.get("robotsTxtState", "")
+                if robots_state == "BLOCKED":
+                    issues_summary["robots_blocked"].append(page_url)
+                
+                # Check fetch issues
+                fetch_state = index_status.get("pageFetchState", "")
+                if fetch_state != "SUCCESSFUL":
+                    issues_summary["fetch_issues"].append(f"{page_url} - {fetch_state}")
+            
+            except Exception as e:
+                issues_summary["not_indexed"].append(f"{page_url} - Error: {str(e)}")
+        
+        # Format results
+        result_lines = [f"Indexing Issues Report for {site_url}:"]
+        result_lines.append("-" * 80)
+        
+        # Summary counts
+        result_lines.append(f"Total URLs checked: {len(url_list)}")
+        result_lines.append(f"Indexed: {len(issues_summary['indexed'])}")
+        result_lines.append(f"Not indexed: {len(issues_summary['not_indexed'])}")
+        result_lines.append(f"Canonical issues: {len(issues_summary['canonical_issues'])}")
+        result_lines.append(f"Robots.txt blocked: {len(issues_summary['robots_blocked'])}")
+        result_lines.append(f"Fetch issues: {len(issues_summary['fetch_issues'])}")
+        result_lines.append("-" * 80)
+        
+        # Detailed issues
+        if issues_summary["not_indexed"]:
+            result_lines.append("\nNot Indexed URLs:")
+            for issue in issues_summary["not_indexed"]:
+                result_lines.append(f"- {issue}")
+        
+        if issues_summary["canonical_issues"]:
+            result_lines.append("\nCanonical Issues:")
+            for issue in issues_summary["canonical_issues"]:
+                result_lines.append(f"- {issue}")
+        
+        if issues_summary["robots_blocked"]:
+            result_lines.append("\nRobots.txt Blocked URLs:")
+            for url in issues_summary["robots_blocked"]:
+                result_lines.append(f"- {url}")
+        
+        if issues_summary["fetch_issues"]:
+            result_lines.append("\nFetch Issues:")
+            for issue in issues_summary["fetch_issues"]:
+                result_lines.append(f"- {issue}")
+        
+        return "\n".join(result_lines)
+    
+    except Exception as e:
+        return f"Error checking indexing issues: {str(e)}"
+
+@mcp.tool()
+async def get_performance_overview(site_url: str, days: int = 28) -> str:
+    """
+    Get a performance overview for a specific property.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        days: Number of days to look back (default: 28)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Calculate date range
+        end_date = datetime.now().date()
+        start_date = end_date - timedelta(days=days)
+        
+        # Get total metrics
+        total_request = {
+            "startDate": start_date.strftime("%Y-%m-%d"),
+            "endDate": end_date.strftime("%Y-%m-%d"),
+            "dimensions": [],  # No dimensions for totals
+            "rowLimit": 1
+        }
+        
+        total_response = service.searchanalytics().query(siteUrl=site_url, body=total_request).execute()
+        
+        # Get by date for trend
+        date_request = {
+            "startDate": start_date.strftime("%Y-%m-%d"),
+            "endDate": end_date.strftime("%Y-%m-%d"),
+            "dimensions": ["date"],
+            "rowLimit": days
+        }
+        
+        date_response = service.searchanalytics().query(siteUrl=site_url, body=date_request).execute()
+        
+        # Format results
+        result_lines = [f"Performance Overview for {site_url} (last {days} days):"]
+        result_lines.append("-" * 80)
+        
+        # Add total metrics
+        if total_response.get("rows"):
+            row = total_response["rows"][0]
+            result_lines.append(f"Total Clicks: {row.get('clicks', 0):,}")
+            result_lines.append(f"Total Impressions: {row.get('impressions', 0):,}")
+            result_lines.append(f"Average CTR: {row.get('ctr', 0) * 100:.2f}%")
+            result_lines.append(f"Average Position: {row.get('position', 0):.1f}")
+        else:
+            result_lines.append("No data available for the selected period.")
+            return "\n".join(result_lines)
+        
+        # Add trend data
+        if date_response.get("rows"):
+            result_lines.append("\nDaily Trend:")
+            result_lines.append("Date | Clicks | Impressions | CTR | Position")
+            result_lines.append("-" * 80)
+            
+            # Sort by date
+            sorted_rows = sorted(date_response["rows"], key=lambda x: x["keys"][0])
+            
+            for row in sorted_rows:
+                date_str = row["keys"][0]
+                # Format date from YYYY-MM-DD to MM/DD
+                try:
+                    date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+                    date_formatted = date_obj.strftime("%m/%d")
+                except:
+                    date_formatted = date_str
+                
+                clicks = row.get("clicks", 0)
+                impressions = row.get("impressions", 0)
+                ctr = row.get("ctr", 0) * 100
+                position = row.get("position", 0)
+                
+                result_lines.append(f"{date_formatted} | {clicks:.0f} | {impressions:.0f} | {ctr:.2f}% | {position:.1f}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving performance overview: {str(e)}"
+
+@mcp.tool()
+async def get_advanced_search_analytics(
+    site_url: str, 
+    start_date: str = None, 
+    end_date: str = None, 
+    dimensions: str = "query", 
+    search_type: str = "WEB",
+    row_limit: int = 1000,
+    start_row: int = 0,
+    sort_by: str = "clicks",
+    sort_direction: str = "descending",
+    filter_dimension: str = None,
+    filter_operator: str = "contains", 
+    filter_expression: str = None
+) -> str:
+    """
+    Get advanced search analytics data with sorting, filtering, and pagination.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        start_date: Start date in YYYY-MM-DD format (defaults to 28 days ago)
+        end_date: End date in YYYY-MM-DD format (defaults to today)
+        dimensions: Dimensions to group by, comma-separated (e.g., "query,page,device")
+        search_type: Type of search results (WEB, IMAGE, VIDEO, NEWS, DISCOVER)
+        row_limit: Maximum number of rows to return (max 25000)
+        start_row: Starting row for pagination
+        sort_by: Metric to sort by (clicks, impressions, ctr, position)
+        sort_direction: Sort direction (ascending or descending)
+        filter_dimension: Dimension to filter on (query, page, country, device)
+        filter_operator: Filter operator (contains, equals, notContains, notEquals)
+        filter_expression: Filter expression value
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Calculate date range if not provided
+        if not end_date:
+            end_date = datetime.now().date().strftime("%Y-%m-%d")
+        if not start_date:
+            start_date = (datetime.now().date() - timedelta(days=28)).strftime("%Y-%m-%d")
+        
+        # Parse dimensions
+        dimension_list = [d.strip() for d in dimensions.split(",")]
+        
+        # Build request
+        request = {
+            "startDate": start_date,
+            "endDate": end_date,
+            "dimensions": dimension_list,
+            "rowLimit": min(row_limit, 25000),  # Cap at API maximum
+            "startRow": start_row,
+            "searchType": search_type.upper()
+        }
+        
+        # Add sorting
+        if sort_by:
+            metric_map = {
+                "clicks": "CLICK_COUNT",
+                "impressions": "IMPRESSION_COUNT",
+                "ctr": "CTR",
+                "position": "POSITION"
+            }
+            
+            if sort_by in metric_map:
+                request["orderBy"] = [{
+                    "metric": metric_map[sort_by],
+                    "direction": sort_direction.lower()
+                }]
+        
+        # Add filtering if provided
+        if filter_dimension and filter_expression:
+            filter_group = {
+                "filters": [{
+                    "dimension": filter_dimension,
+                    "operator": filter_operator,
+                    "expression": filter_expression
+                }]
+            }
+            request["dimensionFilterGroups"] = [filter_group]
+        
+        # Execute request
+        response = service.searchanalytics().query(siteUrl=site_url, body=request).execute()
+        
+        if not response.get("rows"):
+            return (f"No search analytics data found for {site_url} with the specified parameters.\n\n"
+                   f"Parameters used:\n"
+                   f"- Date range: {start_date} to {end_date}\n"
+                   f"- Dimensions: {dimensions}\n"
+                   f"- Search type: {search_type}\n"
+                   f"- Filter: {filter_dimension} {filter_operator} '{filter_expression}'" if filter_dimension else "- No filter applied")
+        
+        # Format results
+        result_lines = [f"Search analytics for {site_url}:"]
+        result_lines.append(f"Date range: {start_date} to {end_date}")
+        result_lines.append(f"Search type: {search_type}")
+        if filter_dimension:
+            result_lines.append(f"Filter: {filter_dimension} {filter_operator} '{filter_expression}'")
+        result_lines.append(f"Showing rows {start_row+1} to {start_row+len(response.get('rows', []))} (sorted by {sort_by} {sort_direction})")
+        result_lines.append("\n" + "-" * 80 + "\n")
+        
+        # Create header based on dimensions
+        header = []
+        for dim in dimension_list:
+            header.append(dim.capitalize())
+        header.extend(["Clicks", "Impressions", "CTR", "Position"])
+        result_lines.append(" | ".join(header))
+        result_lines.append("-" * 80)
+        
+        # Add data rows
+        for row in response.get("rows", []):
+            data = []
+            # Add dimension values
+            for dim_value in row.get("keys", []):
+                data.append(dim_value[:30])  # Truncate long values
+            
+            # Add metrics
+            data.append(str(row.get("clicks", 0)))
+            data.append(str(row.get("impressions", 0)))
+            data.append(f"{row.get('ctr', 0) * 100:.2f}%")
+            data.append(f"{row.get('position', 0):.1f}")
+            
+            result_lines.append(" | ".join(data))
+        
+        # Add pagination info if there might be more results
+        if len(response.get("rows", [])) == row_limit:
+            next_start = start_row + row_limit
+            result_lines.append("\nThere may be more results available. To see the next page, use:")
+            result_lines.append(f"start_row: {next_start}, row_limit: {row_limit}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving advanced search analytics: {str(e)}"
+
+@mcp.tool()
+async def compare_search_periods(
+    site_url: str,
+    period1_start: str,
+    period1_end: str,
+    period2_start: str,
+    period2_end: str,
+    dimensions: str = "query",
+    limit: int = 10
+) -> str:
+    """
+    Compare search analytics data between two time periods.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        period1_start: Start date for period 1 (YYYY-MM-DD)
+        period1_end: End date for period 1 (YYYY-MM-DD)
+        period2_start: Start date for period 2 (YYYY-MM-DD)
+        period2_end: End date for period 2 (YYYY-MM-DD)
+        dimensions: Dimensions to group by (default: query)
+        limit: Number of top results to compare (default: 10)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Parse dimensions
+        dimension_list = [d.strip() for d in dimensions.split(",")]
+        
+        # Build requests for both periods
+        period1_request = {
+            "startDate": period1_start,
+            "endDate": period1_end,
+            "dimensions": dimension_list,
+            "rowLimit": 1000  # Get more to ensure we can match items between periods
+        }
+        
+        period2_request = {
+            "startDate": period2_start,
+            "endDate": period2_end,
+            "dimensions": dimension_list,
+            "rowLimit": 1000
+        }
+        
+        # Execute requests
+        period1_response = service.searchanalytics().query(siteUrl=site_url, body=period1_request).execute()
+        period2_response = service.searchanalytics().query(siteUrl=site_url, body=period2_request).execute()
+        
+        period1_rows = period1_response.get("rows", [])
+        period2_rows = period2_response.get("rows", [])
+        
+        if not period1_rows and not period2_rows:
+            return f"No data found for either period for {site_url}."
+        
+        # Create dictionaries for easy lookup
+        period1_data = {tuple(row.get("keys", [])): row for row in period1_rows}
+        period2_data = {tuple(row.get("keys", [])): row for row in period2_rows}
+        
+        # Find common keys and calculate differences
+        all_keys = set(period1_data.keys()) | set(period2_data.keys())
+        comparison_data = []
+        
+        for key in all_keys:
+            p1_row = period1_data.get(key, {"clicks": 0, "impressions": 0, "ctr": 0, "position": 0})
+            p2_row = period2_data.get(key, {"clicks": 0, "impressions": 0, "ctr": 0, "position": 0})
+            
+            # Calculate differences
+            click_diff = p2_row.get("clicks", 0) - p1_row.get("clicks", 0)
+            click_pct = (click_diff / p1_row.get("clicks", 1)) * 100 if p1_row.get("clicks", 0) > 0 else float('inf')
+            
+            imp_diff = p2_row.get("impressions", 0) - p1_row.get("impressions", 0)
+            imp_pct = (imp_diff / p1_row.get("impressions", 1)) * 100 if p1_row.get("impressions", 0) > 0 else float('inf')
+            
+            ctr_diff = p2_row.get("ctr", 0) - p1_row.get("ctr", 0)
+            pos_diff = p1_row.get("position", 0) - p2_row.get("position", 0)  # Note: lower position is better
+            
+            comparison_data.append({
+                "key": key,
+                "p1_clicks": p1_row.get("clicks", 0),
+                "p2_clicks": p2_row.get("clicks", 0),
+                "click_diff": click_diff,
+                "click_pct": click_pct,
+                "p1_impressions": p1_row.get("impressions", 0),
+                "p2_impressions": p2_row.get("impressions", 0),
+                "imp_diff": imp_diff,
+                "imp_pct": imp_pct,
+                "p1_ctr": p1_row.get("ctr", 0),
+                "p2_ctr": p2_row.get("ctr", 0),
+                "ctr_diff": ctr_diff,
+                "p1_position": p1_row.get("position", 0),
+                "p2_position": p2_row.get("position", 0),
+                "pos_diff": pos_diff
+            })
+        
+        # Sort by absolute click difference (can change to other metrics)
+        comparison_data.sort(key=lambda x: abs(x["click_diff"]), reverse=True)
+        
+        # Format results
+        result_lines = [f"Search analytics comparison for {site_url}:"]
+        result_lines.append(f"Period 1: {period1_start} to {period1_end}")
+        result_lines.append(f"Period 2: {period2_start} to {period2_end}")
+        result_lines.append(f"Dimension(s): {dimensions}")
+        result_lines.append(f"Top {min(limit, len(comparison_data))} results by change in clicks:")
+        result_lines.append("\n" + "-" * 100 + "\n")
+        
+        # Create header
+        dim_header = " | ".join([d.capitalize() for d in dimension_list])
+        result_lines.append(f"{dim_header} | P1 Clicks | P2 Clicks | Change | % | P1 Pos | P2 Pos | Pos Δ")
+        result_lines.append("-" * 100)
+        
+        # Add data rows (limited to requested number)
+        for item in comparison_data[:limit]:
+            key_str = " | ".join([str(k)[:20] for k in item["key"]])
+            
+            # Format the click change with color indicators
+            click_change = item["click_diff"]
+            click_pct = item["click_pct"] if item["click_pct"] != float('inf') else "N/A"
+            click_pct_str = f"{click_pct:.1f}%" if click_pct != "N/A" else "N/A"
+            
+            # Format position change (positive is good - moving up in rankings)
+            pos_change = item["pos_diff"]
+            
+            result_lines.append(
+                f"{key_str} | {item['p1_clicks']} | {item['p2_clicks']} | "
+                f"{click_change:+d} | {click_pct_str} | "
+                f"{item['p1_position']:.1f} | {item['p2_position']:.1f} | {pos_change:+.1f}"
+            )
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error comparing search periods: {str(e)}"
+
+@mcp.tool()
+async def get_search_by_page_query(
+    site_url: str,
+    page_url: str,
+    days: int = 28
+) -> str:
+    """
+    Get search analytics data for a specific page, broken down by query.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        page_url: The specific page URL to analyze
+        days: Number of days to look back (default: 28)
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Calculate date range
+        end_date = datetime.now().date()
+        start_date = end_date - timedelta(days=days)
+        
+        # Build request with page filter
+        request = {
+            "startDate": start_date.strftime("%Y-%m-%d"),
+            "endDate": end_date.strftime("%Y-%m-%d"),
+            "dimensions": ["query"],
+            "dimensionFilterGroups": [{
+                "filters": [{
+                    "dimension": "page",
+                    "operator": "equals",
+                    "expression": page_url
+                }]
+            }],
+            "rowLimit": 20,  # Top 20 queries for this page
+            "orderBy": [{"metric": "CLICK_COUNT", "direction": "descending"}]
+        }
+        
+        # Execute request
+        response = service.searchanalytics().query(siteUrl=site_url, body=request).execute()
+        
+        if not response.get("rows"):
+            return f"No search data found for page {page_url} in the last {days} days."
+        
+        # Format results
+        result_lines = [f"Search queries for page {page_url} (last {days} days):"]
+        result_lines.append("\n" + "-" * 80 + "\n")
+        
+        # Create header
+        result_lines.append("Query | Clicks | Impressions | CTR | Position")
+        result_lines.append("-" * 80)
+        
+        # Add data rows
+        for row in response.get("rows", []):
+            query = row.get("keys", ["Unknown"])[0]
+            clicks = row.get("clicks", 0)
+            impressions = row.get("impressions", 0)
+            ctr = row.get("ctr", 0) * 100
+            position = row.get("position", 0)
+            
+            result_lines.append(f"{query[:40]} | {clicks} | {impressions} | {ctr:.2f}% | {position:.1f}")
+        
+        # Add total metrics
+        total_clicks = sum(row.get("clicks", 0) for row in response.get("rows", []))
+        total_impressions = sum(row.get("impressions", 0) for row in response.get("rows", []))
+        avg_ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0
+        
+        result_lines.append("-" * 80)
+        result_lines.append(f"TOTAL | {total_clicks} | {total_impressions} | {avg_ctr:.2f}% | -")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving page query data: {str(e)}"
+
+@mcp.tool()
+async def list_sitemaps_enhanced(site_url: str, sitemap_index: str = None) -> str:
+    """
+    List all sitemaps for a specific Search Console property with detailed information.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        sitemap_index: Optional sitemap index URL to list child sitemaps
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Get sitemaps list
+        if sitemap_index:
+            sitemaps = service.sitemaps().list(siteUrl=site_url, sitemapIndex=sitemap_index).execute()
+            source = f"child sitemaps from index: {sitemap_index}"
+        else:
+            sitemaps = service.sitemaps().list(siteUrl=site_url).execute()
+            source = "all submitted sitemaps"
+        
+        if not sitemaps.get("sitemap"):
+            return f"No sitemaps found for {site_url}" + (f" in index {sitemap_index}" if sitemap_index else ".")
+        
+        # Format the results
+        result_lines = [f"Sitemaps for {site_url} ({source}):"]
+        result_lines.append("-" * 100)
+        
+        # Header
+        result_lines.append("Path | Last Submitted | Last Downloaded | Type | URLs | Errors | Warnings")
+        result_lines.append("-" * 100)
+        
+        # Add each sitemap
+        for sitemap in sitemaps.get("sitemap", []):
+            path = sitemap.get("path", "Unknown")
+            
+            # Format dates
+            last_submitted = sitemap.get("lastSubmitted", "Never")
+            if last_submitted != "Never":
+                try:
+                    dt = datetime.fromisoformat(last_submitted.replace('Z', '+00:00'))
+                    last_submitted = dt.strftime("%Y-%m-%d %H:%M")
+                except:
+                    pass
+            
+            last_downloaded = sitemap.get("lastDownloaded", "Never")
+            if last_downloaded != "Never":
+                try:
+                    dt = datetime.fromisoformat(last_downloaded.replace('Z', '+00:00'))
+                    last_downloaded = dt.strftime("%Y-%m-%d %H:%M")
+                except:
+                    pass
+            
+            # Determine type
+            sitemap_type = "Index" if sitemap.get("isSitemapsIndex", False) else "Sitemap"
+            
+            # Get counts
+            errors = sitemap.get("errors", 0)
+            warnings = sitemap.get("warnings", 0)
+            
+            # Get URL counts
+            url_count = "N/A"
+            if "contents" in sitemap:
+                for content in sitemap["contents"]:
+                    if content.get("type") == "web":
+                        url_count = content.get("submitted", "0")
+                        break
+            
+            result_lines.append(f"{path} | {last_submitted} | {last_downloaded} | {sitemap_type} | {url_count} | {errors} | {warnings}")
+        
+        # Add processing status if available
+        pending_count = sum(1 for sitemap in sitemaps.get("sitemap", []) if sitemap.get("isPending", False))
+        if pending_count > 0:
+            result_lines.append(f"\nNote: {pending_count} sitemaps are still pending processing by Google.")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving sitemaps: {str(e)}"
+
+@mcp.tool()
+async def get_sitemap_details(site_url: str, sitemap_url: str) -> str:
+    """
+    Get detailed information about a specific sitemap.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        sitemap_url: The full URL of the sitemap to inspect
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Get sitemap details
+        details = service.sitemaps().get(siteUrl=site_url, feedpath=sitemap_url).execute()
+        
+        if not details:
+            return f"No details found for sitemap {sitemap_url}."
+        
+        # Format the results
+        result_lines = [f"Sitemap Details for {sitemap_url}:"]
+        result_lines.append("-" * 80)
+        
+        # Basic info
+        is_index = details.get("isSitemapsIndex", False)
+        result_lines.append(f"Type: {'Sitemap Index' if is_index else 'Sitemap'}")
+        
+        # Status
+        is_pending = details.get("isPending", False)
+        result_lines.append(f"Status: {'Pending processing' if is_pending else 'Processed'}")
+        
+        # Dates
+        if "lastSubmitted" in details:
+            try:
+                dt = datetime.fromisoformat(details["lastSubmitted"].replace('Z', '+00:00'))
+                result_lines.append(f"Last Submitted: {dt.strftime('%Y-%m-%d %H:%M')}")
+            except:
+                result_lines.append(f"Last Submitted: {details['lastSubmitted']}")
+        
+        if "lastDownloaded" in details:
+            try:
+                dt = datetime.fromisoformat(details["lastDownloaded"].replace('Z', '+00:00'))
+                result_lines.append(f"Last Downloaded: {dt.strftime('%Y-%m-%d %H:%M')}")
+            except:
+                result_lines.append(f"Last Downloaded: {details['lastDownloaded']}")
+        
+        # Errors and warnings
+        result_lines.append(f"Errors: {details.get('errors', 0)}")
+        result_lines.append(f"Warnings: {details.get('warnings', 0)}")
+        
+        # Content breakdown
+        if "contents" in details and details["contents"]:
+            result_lines.append("\nContent Breakdown:")
+            for content in details["contents"]:
+                content_type = content.get("type", "Unknown").upper()
+                submitted = content.get("submitted", 0)
+                indexed = content.get("indexed", "N/A")
+                
+                result_lines.append(f"- {content_type}: {submitted} submitted, {indexed} indexed")
+        
+        # If it's an index, suggest how to list child sitemaps
+        if is_index:
+            result_lines.append("\nThis is a sitemap index. To list child sitemaps, use:")
+            result_lines.append(f"list_sitemaps_enhanced with sitemap_index={sitemap_url}")
+        
+        return "\n".join(result_lines)
+    except Exception as e:
+        return f"Error retrieving sitemap details: {str(e)}"
+
+@mcp.tool()
+async def submit_sitemap(site_url: str, sitemap_url: str) -> str:
+    """
+    Submit a new sitemap or resubmit an existing one to Google.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        sitemap_url: The full URL of the sitemap to submit
+    """
+    try:
+        service = get_gsc_service()
+        
+        # Submit the sitemap
+        service.sitemaps().submit(siteUrl=site_url, feedpath=sitemap_url).execute()
+        
+        # Verify submission by getting details
+        try:
+            details = service.sitemaps().get(siteUrl=site_url, feedpath=sitemap_url).execute()
+            
+            # Format response
+            result_lines = [f"Successfully submitted sitemap: {sitemap_url}"]
+            
+            # Add submission time if available
+            if "lastSubmitted" in details:
+                try:
+                    dt = datetime.fromisoformat(details["lastSubmitted"].replace('Z', '+00:00'))
+                    result_lines.append(f"Submission time: {dt.strftime('%Y-%m-%d %H:%M')}")
+                except:
+                    result_lines.append(f"Submission time: {details['lastSubmitted']}")
+            
+            # Add processing status
+            is_pending = details.get("isPending", True)
+            result_lines.append(f"Status: {'Pending processing' if is_pending else 'Processing started'}")
+            
+            # Add note about processing time
+            result_lines.append("\nNote: Google may take some time to process the sitemap. Check back later for full details.")
+            
+            return "\n".join(result_lines)
+        except:
+            # If we can't get details, just return basic success message
+            return f"Successfully submitted sitemap: {sitemap_url}\n\nGoogle will queue it for processing."
+    
+    except Exception as e:
+        return f"Error submitting sitemap: {str(e)}"
+
+@mcp.tool()
+async def delete_sitemap(site_url: str, sitemap_url: str) -> str:
+    """
+    Delete (unsubmit) a sitemap from Google Search Console.
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        sitemap_url: The full URL of the sitemap to delete
+    """
+    try:
+        service = get_gsc_service()
+        
+        # First check if the sitemap exists
+        try:
+            service.sitemaps().get(siteUrl=site_url, feedpath=sitemap_url).execute()
+        except Exception as e:
+            if "404" in str(e):
+                return f"Sitemap not found: {sitemap_url}. It may have already been deleted or was never submitted."
+            else:
+                raise e
+        
+        # Delete the sitemap
+        service.sitemaps().delete(siteUrl=site_url, feedpath=sitemap_url).execute()
+        
+        return f"Successfully deleted sitemap: {sitemap_url}\n\nNote: This only removes the sitemap from Search Console. Any URLs already indexed will remain in Google's index."
+    
+    except Exception as e:
+        return f"Error deleting sitemap: {str(e)}"
+
+@mcp.tool()
+async def manage_sitemaps(site_url: str, action: str, sitemap_url: str = None, sitemap_index: str = None) -> str:
+    """
+    All-in-one tool to manage sitemaps (list, get details, submit, delete).
+    
+    Args:
+        site_url: The URL of the site in Search Console (must be exact match)
+        action: The action to perform (list, details, submit, delete)
+        sitemap_url: The full URL of the sitemap (required for details, submit, delete)
+        sitemap_index: Optional sitemap index URL for listing child sitemaps (only used with 'list' action)
+    """
+    try:
+        # Validate inputs
+        action = action.lower().strip()
+        valid_actions = ["list", "details", "submit", "delete"]
+        
+        if action not in valid_actions:
+            return f"Invalid action: {action}. Please use one of: {', '.join(valid_actions)}"
+        
+        if action in ["details", "submit", "delete"] and not sitemap_url:
+            return f"The {action} action requires a sitemap_url parameter."
+        
+        # Perform the requested action
+        if action == "list":
+            return await list_sitemaps_enhanced(site_url, sitemap_index)
+        elif action == "details":
+            return await get_sitemap_details(site_url, sitemap_url)
+        elif action == "submit":
+            return await submit_sitemap(site_url, sitemap_url)
+        elif action == "delete":
+            return await delete_sitemap(site_url, sitemap_url)
+    
+    except Exception as e:
+        return f"Error managing sitemaps: {str(e)}"
+
+@mcp.tool()
+async def get_creator_info() -> str:
+    """
+    Provides information about Amin Foroutan, the creator of the MCP-GSC tool.
+    """
+    creator_info = """
+# About the Creator: Amin Foroutan
+
+Amin Foroutan is an SEO consultant with over a decade of experience, specializing in technical SEO, Python-driven tools, and data analysis for SEO performance.
+
+## Connect with Amin:
+
+- **LinkedIn**: [Amin Foroutan](https://www.linkedin.com/in/ma-foroutan/)
+- **Personal Website**: [aminforoutan.com](https://aminforoutan.com/)
+- **YouTube**: [Amin Forout](https://www.youtube.com/channel/UCW7tPXg-rWdH4YzLrcAdBIw)
+- **X (Twitter)**: [@aminfseo](https://x.com/aminfseo)
+
+## Notable Projects:
+
+Amin has created several popular SEO tools including:
+- Advanced GSC Visualizer (6.4K+ users)
+- SEO Render Insight Tool (3.5K+ users)
+- Google AI Overview Impact Analysis (1.2K+ users)
+- Google AI Overview Citation Analysis (900+ users)
+- SEMRush Enhancer (570+ users)
+- SEO Page Inspector (115+ users)
+
+## Expertise:
+
+Amin combines technical SEO knowledge with programming skills to create innovative solutions for SEO challenges.
+"""
+    return creator_info
+
+if __name__ == "__main__":
+    # Start the MCP server on stdio transport
+    mcp.run(transport="stdio")

--- a/mcp-gsc/pyproject.toml
+++ b/mcp-gsc/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "mcp-gsc"
+version = "0.1.0"
+description = "Google Search Console integration for Model Context Protocol (MCP)"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Amin Foroutan", email = "aio@aminforoutan.com"}
+]
+keywords = ["mcp", "google search console", "seo", "claude", "search analytics"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+dependencies = [
+    "google-api-python-client>=2.163.0",
+    "google-auth-httplib2>=0.2.0",
+    "google-auth-oauthlib>=1.2.1",
+    "mcp[cli]>=1.3.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/aminfseo/mcp-gsc"
+"Bug Tracker" = "https://github.com/aminfseo/mcp-gsc/issues"
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["mcp_gsc"]

--- a/mcp-gsc/uv.lock
+++ b/mcp-gsc/uv.lock
@@ -1,0 +1,647 @@
+version = 1
+revision = 1
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "anyio"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+]
+
+[[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.1.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/80/41ef5d5a7935d2d3a773e3eaebf0a9350542f2cab4eac59a7a4741fbbbbe/charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125", size = 194995 },
+    { url = "https://files.pythonhosted.org/packages/7a/28/0b9fefa7b8b080ec492110af6d88aa3dea91c464b17d53474b6e9ba5d2c5/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1", size = 139471 },
+    { url = "https://files.pythonhosted.org/packages/71/64/d24ab1a997efb06402e3fc07317e94da358e2585165930d9d59ad45fcae2/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3", size = 149831 },
+    { url = "https://files.pythonhosted.org/packages/37/ed/be39e5258e198655240db5e19e0b11379163ad7070962d6b0c87ed2c4d39/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd", size = 142335 },
+    { url = "https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00", size = 143862 },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/32da20821cf387b759ad24627a9aca289d2822de929b8a41b6241767b461/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12", size = 145673 },
+    { url = "https://files.pythonhosted.org/packages/68/85/f4288e96039abdd5aeb5c546fa20a37b50da71b5cf01e75e87f16cd43304/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77", size = 140211 },
+    { url = "https://files.pythonhosted.org/packages/28/a3/a42e70d03cbdabc18997baf4f0227c73591a08041c149e710045c281f97b/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146", size = 148039 },
+    { url = "https://files.pythonhosted.org/packages/85/e4/65699e8ab3014ecbe6f5c71d1a55d810fb716bbfd74f6283d5c2aa87febf/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd", size = 151939 },
+    { url = "https://files.pythonhosted.org/packages/b1/82/8e9fe624cc5374193de6860aba3ea8070f584c8565ee77c168ec13274bd2/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6", size = 149075 },
+    { url = "https://files.pythonhosted.org/packages/3d/7b/82865ba54c765560c8433f65e8acb9217cb839a9e32b42af4aa8e945870f/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8", size = 144340 },
+    { url = "https://files.pythonhosted.org/packages/b5/b6/9674a4b7d4d99a0d2df9b215da766ee682718f88055751e1e5e753c82db0/charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b", size = 95205 },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/45b180e175de4402dcf7547e4fb617283bae54ce35c27930a6f35b6bef15/charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76", size = 102441 },
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
+]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/5c/085bcb872556934bb119e5e09de54daa07873f6866b8f0303c49e72287f7/google_api_core-2.24.2.tar.gz", hash = "sha256:81718493daf06d96d6bc76a91c23874dbf2fac0adbbf542831b805ee6e974696", size = 163516 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/95/f472d85adab6e538da2025dfca9e976a0d125cc0af2301f190e77b76e51c/google_api_core-2.24.2-py3-none-any.whl", hash = "sha256:810a63ac95f3c441b7c0e43d344e372887f62ce9071ba972eacf32672e072de9", size = 160061 },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.163.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/9f/535346bb1469ec91139c38f0438ad70bd229a6b11452367065fe49303860/google_api_python_client-2.163.0.tar.gz", hash = "sha256:88dee87553a2d82176e2224648bf89272d536c8f04dcdda37ef0a71473886dd7", size = 12588615 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/3d/203d1c18cb239313ac125721f284e94c01c7eee947adb2ef2d9a85ac8d66/google_api_python_client-2.163.0-py2.py3-none-any.whl", hash = "sha256:080e8bc0669cb4c1fb8efb8da2f5b91a2625d8f0e7796cfad978f33f7016c6c4", size = 13097882 },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/eb/d504ba1daf190af6b204a9d4714d457462b486043744901a6eeea711f913/google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4", size = 270866 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/47/603554949a37bca5b7f894d51896a9c534b9eab808e2520a748e081669d0/google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a", size = 210770 },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/8a/fe34d2f3f9470a27b01c9e76226965863f153d5fbe276f83608562e49c04/google_auth_httplib2-0.2.0-py2.py3-none-any.whl", hash = "sha256:b65a0a2123300dd71281a7bf6e64d65a0759287df52729bdd1ae2e47dc311a3d", size = 9253 },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/0f/1772edb8d75ecf6280f1c7f51cbcebe274e8b17878b382f63738fd96cee5/google_auth_oauthlib-1.2.1.tar.gz", hash = "sha256:afd0cad092a2eaa53cd8e8298557d6de1034c6cb4a740500b5357b648af97263", size = 24970 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/8e/22a28dfbd218033e4eeaf3a0533b2b54852b6530da0c0fe934f0cc494b29/google_auth_oauthlib-1.2.1-py2.py3-none-any.whl", hash = "sha256:2d58a27262d55aa1b87678c3ba7142a080098cbc2024f903c62355deb235d91f", size = 24930 },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.69.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/4f/d8be74b88621131dfd1ed70e5aff2c47f2bdf2289a70736bbf3eb0e7bc70/googleapis_common_protos-1.69.1.tar.gz", hash = "sha256:e20d2d8dda87da6fe7340afbbdf4f0bcb4c8fae7e6cadf55926c31f946b0b9b1", size = 144514 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/cb/2f4aa605b16df1e031dd7c322c597613eef933e8dd5b6a4414330b21e791/googleapis_common_protos-1.69.1-py2.py3-none-any.whl", hash = "sha256:4077f27a6900d5946ee5a369fab9c8ded4c0ef1c6e880458ea2f70c14f7b70d5", size = 293229 },
+]
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ad/2371116b22d616c194aa25ec410c9c6c37f23599dcd590502b74db197584/httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81", size = 351116 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/6c/d2fbdaaa5959339d53ba38e94c123e4e84b8fbc4b84beb0e70d7c1608486/httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc", size = 96854 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mcp"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b6/81e5f2490290351fc97bf46c24ff935128cb7d34d68e3987b522f26f7ada/mcp-1.3.0.tar.gz", hash = "sha256:f409ae4482ce9d53e7ac03f3f7808bcab735bdfc0fba937453782efb43882d45", size = 150235 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/d2/a9e87b506b2094f5aa9becc1af5178842701b27217fa43877353da2577e3/mcp-1.3.0-py3-none-any.whl", hash = "sha256:2829d67ce339a249f803f22eba5e90385eafcac45c94b00cab6cef7e8f217211", size = 70672 },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
+[[package]]
+name = "mcp-gsc"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+    { name = "mcp", extra = ["cli"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "google-api-python-client", specifier = ">=2.163.0" },
+    { name = "google-auth-httplib2", specifier = ">=0.2.0" },
+    { name = "google-auth-oauthlib", specifier = ">=1.2.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688 },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163 },
+]
+
+[[package]]
+name = "protobuf"
+version = "5.29.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/d1/e0a911544ca9993e0f17ce6d3cc0932752356c1b0a834397f28e63479344/protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620", size = 424945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/7a/1e38f3cafa022f477ca0f57a1f49962f21ad25850c3ca0acd3b9d0091518/protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888", size = 422708 },
+    { url = "https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a", size = 434508 },
+    { url = "https://files.pythonhosted.org/packages/dd/04/3eaedc2ba17a088961d0e3bd396eac764450f431621b58a04ce898acd126/protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e", size = 417825 },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7c467744d23c3979ce250397e26d8ad8eeb2bea7b18ca12ad58313c1b8d5/protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84", size = 319573 },
+    { url = "https://files.pythonhosted.org/packages/a8/45/2ebbde52ad2be18d3675b6bee50e68cd73c9e0654de77d595540b5129df8/protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f", size = 319672 },
+    { url = "https://files.pythonhosted.org/packages/fd/b2/ab07b09e0f6d143dfb839693aa05765257bceaa13d03bf1a696b78323e7a/protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f", size = 172550 },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/67/6afbf0d507f73c32d21084a79946bfcfca5fbc62a72057e9c23797a737c9/pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c", size = 310028 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/89/bc88a6711935ba795a679ea6ebee07e128050d6382eaa35a0a47c8032bdc/pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd", size = 181537 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421 },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998 },
+    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167 },
+    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071 },
+    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244 },
+    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470 },
+    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291 },
+    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613 },
+    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355 },
+    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661 },
+    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261 },
+    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361 },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484 },
+    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102 },
+    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127 },
+    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340 },
+    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900 },
+    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177 },
+    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046 },
+    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386 },
+    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060 },
+    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870 },
+    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822 },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364 },
+    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064 },
+    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046 },
+    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092 },
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/3544f4f299a47911c2ab3710f534e52fea62a633c96806995da5d25be4b2/pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a", size = 1067694 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/a7/c8a2d361bf89c0d9577c934ebb7421b25dc84bf3a8e3ac0a40aed9acc547/pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1", size = 107716 },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21", size = 29711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7", size = 34315 },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
+]
+
+[[package]]
+name = "starlette"
+version = "0.46.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995 },
+]
+
+[[package]]
+name = "typer"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/5a/4742fdba39cd02a56226815abfa72fe0aa81c33bed16ed045647d6000eba/uritemplate-4.1.1.tar.gz", hash = "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0", size = 273898 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c0/7461b49cd25aeece13766f02ee576d1db528f1c37ce69aee300e075b485b/uritemplate-4.1.1-py2.py3-none-any.whl", hash = "sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e", size = 10356 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+]


### PR DESCRIPTION
## Description
Adding a reference to MCP-GSC, a Google Search Console integration for MCP.  
The repository provides tools for retrieving search analytics, inspecting URLs, and managing sitemaps via MCP.

## Server Details
- Server: **N/A (New External Server Reference)**
- Changes to: **README.md (Added link to community servers section)**

## Motivation and Context
MCP-GSC allows users to connect Google Search Console to MCP, enabling programmatic access to search analytics, indexing status, and sitemap management. Adding this reference makes it easier for developers to find and use it.

## How Has This Been Tested?
- This is a documentation update, no code changes were made.
- The repository [https://github.com/AminForou/mcp-gsc](https://github.com/AminForou/mcp-gsc) contains working implementation tested with Google Search Console API.

## Breaking Changes
- **No breaking changes** (Only added a README reference).

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follow MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client _(Optional but not required for a README update)_
- [x] My changes follow the repository's style guidelines
- [ ] New and existing tests pass locally _(Not applicable for this update)_
- [x] I have documented all environment variables and configuration options in my repository

## Additional context
MCP-GSC is an independent tool that integrates Google Search Console data with MCP for automation. This PR simply adds a reference to it in the MCP Servers README.md.
