### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Rijksmuseum](https://github.com/r-huijts/rijksmuseum-mcp)** - Interface with the Rijksmuseum API to search artworks, retrieve artwork details, access image tiles, and explore user collections.
 - **[Salesforce MCP](https://github.com/smn2gnt/MCP-Salesforce)** - Interact with Salesforce Data and Metadata
 - **[Scholarly](https://github.com/adityak74/mcp-scholarly)** - A MCP server to search for scholarly and academic articles.
+- **[scrapling-fetch](https://github.com/cyberchitta/scrapling-fetch-mcp)** - Access text content from bot-protected websites. Fetches HTML/markdown from sites with anti-automation measures using Scrapling.
 - **[SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng)** - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
 - **[ServiceNow](https://github.com/osomai/servicenow-mcp)** - A MCP server to interact with a ServiceNow instance
 - **[Siri Shortcuts](https://github.com/dvcrn/mcp-server-siri-shortcuts)** - MCP to interact with Siri Shortcuts on macOS. Exposes all Shortcuts as MCP tools.


### PR DESCRIPTION
added 'scrapling-fetch-mcp' as a fetch replacement that can access sites with anti-automation measures

## Description

## Server Details

## Motivation and Context
Felt weird that Claude couldn't fetch a URL (using mcp-fetch) that I had open in a browser window right next to it. Even weirder that I found an MCP tool for this purpose, but needed to get an API key to use it.

## How Has This Been Tested?
Tested on Claude Code and Claude Desktop

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
