### PR TITLE
Add get_all_pull_request_comments tool

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -277,6 +277,14 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `pull_number` (number): Pull request number
    - Returns: Array of pull request reviews with details like the review state (APPROVED, CHANGES_REQUESTED, etc.), reviewer, and review body
 
+27. `get_all_pull_request_comments`
+   - Get all comments (both issue and review comments) for a pull request with code context
+   - Inputs:
+     - `owner` (string): Repository owner (username or organization)
+     - `repo` (string): Repository name
+     - `pull_number` (number): Pull request number
+   - Returns: Array of comments with type discrimination ('issue_comment' or 'review_comment') and full code context for review comments, sorted chronologically
+
 ## Search Query Syntax
 
 ### Code Search

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -194,8 +194,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_pull_request_reviews",
         description: "Get the reviews on a pull request",
         inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema)
+      },
+      {
+        name: "get_all_pull_request_comments",
+        description: "Get all comments (both issue and review comments) for a pull request with code context",
+        inputSchema: zodToJsonSchema(pulls.GetAllPullRequestCommentsSchema)
       }
-    ],
+    ]
   };
 });
 
@@ -452,7 +457,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const args = pulls.GetPullRequestReviewsSchema.parse(request.params.arguments);
         const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
         return {
-          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }]
+        };
+      }
+
+      case "get_all_pull_request_comments": {
+        const args = pulls.GetAllPullRequestCommentsSchema.parse(request.params.arguments);
+        const comments = await pulls.getAllPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }]
         };
       }
 


### PR DESCRIPTION
## Description

This PR adds a new MCP tool called `get_all_pull_request_comments` to the GitHub server that combines both issue comments and review comments for a pull request, providing a chronologically sorted list with complete context for code-specific comments.

## Server Details

- Server: GitHub MCP Server
- Changes to: Added a new tool to fetch and combine PR comments

## Motivation and Context

The GitHub API separates PR comments into two distinct endpoints: issue comments (general comments on the PR) and review comments (comments on specific lines of code). This separation makes it difficult for clients to get a complete picture of the conversation around a PR. This tool solves that problem by:

1. Fetching both types of comments in parallel
2. Normalizing the data format with type discrimination
3. Adding rich code context for review comments
4. Sorting all comments chronologically in a single response

## How Has This Been Tested?

- Tested with an actual LLM client (Claude has successfully used the functionality)
- Type checking with zod schemas to validate response formats
- Error handling for API responses
- Verified with real GitHub PRs

## Breaking Changes

None. This PR adds new functionality without modifying existing behavior.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

The implementation uses Promise.all to fetch both comment types in parallel, improving performance. The type discrimination pattern ('type': 'issue_comment' | 'review_comment') makes it easy for clients to determine the comment type and access the appropriate fields.