### PR TITLE
feat(api): add support for on-premise Sentry installations

### DIFF
--- a/src/sentry/Dockerfile
+++ b/src/sentry/Dockerfile
@@ -32,6 +32,7 @@ COPY --from=uv --chown=app:app /app/.venv /app/.venv
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
-# when running the container, add --db-path and a bind mount to the host's db file
+# when running the container, add --auth-token with your Sentry token
+# for on-premise Sentry installations, add --api-domain followed by your Sentry API URL
 ENTRYPOINT ["mcp-server-sentry"]
 

--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -69,6 +69,17 @@ Add this to your `claude_desktop_config.json`:
 </details>
 
 <details>
+<summary>Using uvx with on-premise Sentry</summary>
+
+```json
+"mcpServers": {
+  "sentry": {
+    "command": "uvx",
+    "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-domain", "https://your-sentry-instance.example.com/api/0/"]
+  }
+}
+```
+</details>
 
 <details>
 <summary>Using docker</summary>
@@ -84,7 +95,19 @@ Add this to your `claude_desktop_config.json`:
 </details>
 
 <details>
+<summary>Using docker with on-premise Sentry</summary>
 
+```json
+"mcpServers": {
+  "sentry": {
+    "command": "docker",
+    "args": ["run", "-i", "--rm", "mcp/sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-domain", "https://your-sentry-instance.example.com/api/0/"]
+  }
+}
+```
+</details>
+
+<details>
 <summary>Using pip installation</summary>
 
 ```json
@@ -92,6 +115,19 @@ Add this to your `claude_desktop_config.json`:
   "sentry": {
     "command": "python",
     "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+  }
+}
+```
+</details>
+
+<details>
+<summary>Using pip installation with on-premise Sentry</summary>
+
+```json
+"mcpServers": {
+  "sentry": {
+    "command": "python",
+    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-domain", "https://your-sentry-instance.example.com/api/0/"]
   }
 }
 ```
@@ -117,6 +153,21 @@ Add to your Zed settings.json:
 </details>
 
 <details>
+<summary>Using uvx with on-premise Sentry</summary>
+
+```json
+"context_servers": [
+  "mcp-server-sentry": {
+    "command": {
+      "path": "uvx",
+      "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-domain", "https://your-sentry-instance.example.com/api/0/"]
+    }
+  }
+],
+```
+</details>
+
+<details>
 <summary>Using pip installation</summary>
 
 ```json
@@ -124,6 +175,19 @@ Add to your Zed settings.json:
   "mcp-server-sentry": {
     "command": "python",
     "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+  }
+},
+```
+</details>
+
+<details>
+<summary>Using pip installation with on-premise Sentry</summary>
+
+```json
+"context_servers": {
+  "mcp-server-sentry": {
+    "command": "python",
+    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-domain", "https://your-sentry-instance.example.com/api/0/"]
   }
 },
 ```
@@ -137,11 +201,10 @@ You can use the MCP inspector to debug the server. For uvx installations:
 npx @modelcontextprotocol/inspector uvx mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN
 ```
 
-Or if you've installed the package in a specific directory or are developing on it:
+For on-premise Sentry installations:
 
 ```
-cd path/to/servers/src/sentry
-npx @modelcontextprotocol/inspector uv run mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN
+npx @modelcontextprotocol/inspector uvx mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN --api-domain https://your-sentry-instance.example.com/api/0/
 ```
 
 ## License

--- a/src/sentry/pyproject.toml
+++ b/src/sentry/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcp-server-sentry"
-version = "0.6.2"
-description = "MCP server for retrieving issues from sentry.io"
+version = "0.7.0"
+description = "MCP server for retrieving issues from sentry.io, with support for on-premise Sentry installations"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = ["mcp>=1.0.0"]


### PR DESCRIPTION
This commit enables the MCP server to connect to custom Sentry domains for on-premise installations.
- Add --api-domain CLI option and SENTRY_API_DOMAIN environment variable support.
- Update domain validation to accept non-sentry.io domains.
- Add documentation and examples for on-premise configuration.
- Update Dockerfile with new parameter documentation
- Bump version to 0.7.0