### PR TITLE
Rename write_file to create_file and add append_to_file toole

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -30,17 +30,17 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - Input: `paths` (string[])
   - Failed reads won't stop the entire operation
 
-+ **create_file**
-+   - Create a new file or completely overwrite an existing file with new content.
-+   - Inputs:
-+     - `path` (string): File location
-+     - `content` (string): File content
-+
-+ **append_to_file**
-+   - Append new content to the end of an existing file.
-+   - Inputs:
-+     - `path` (string): File location
-+     - `content` (string): Content to append
+ **write_file**
+   - Create a new file with new content. Cannot write to existing files. Use append_to_file for that. 
+   - Inputs:
+     - `path` (string): File location
+     - `content` (string): File content
+
+ **append_to_file**
+   - Append new content to the end of an existing file.
+   - Inputs:
+     - `path` (string): File location
+     - `content` (string): Content to append
 
 - **edit_file**
   - Make selective edits using advanced pattern matching and formatting


### PR DESCRIPTION
## Description

Even though the write_file was described as overwriting existing file many times Claude used it when it meant to append data to existing file. Seems "writing to file" means to him "append if file exists". Changing the name and adding separate tool for append operation rectifies that.

## Motivation and Context
Due to missing append_file tool Clause was using write_file, missing the important part that it actually overwrites the underlying file. 
I was also considering the "append" argument or a "mode" akin to os byt separate tools seem to work better.
Moreover, I even didn't have to change the tool description as it clearly said: "Create a new file..." which strengthens the case for the rename.

## How Has This Been Tested?
tested with @modelcontextprotocol/inspector

## Breaking Changes
In some context when continuing an old session, started with old version of this mcp server, thee model might remember the old tool "write_file" and try to use it, but it my tests it always recovered. 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
