### PR TITLE
Add Azure DevOps MCP to list of community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[AWS Cost Explorer](https://github.com/aarora79/aws-cost-explorer-mcp-server)** - Optimize your AWS spend (including Amazon Bedrock spend) with this MCP server by examining spend across regions, services, instance types and foundation models ([demo video](https://www.youtube.com/watch?v=WuVOmYLRFmI&feature=youtu.be)).
 - **[AWS S3](https://github.com/aws-samples/sample-mcp-server-s3)** - A sample MCP server for AWS S3 that flexibly fetches objects from S3 such as PDF documents.
 - **[Azure ADX](https://github.com/pab1it0/adx-mcp-server)** - Query and analyze Azure Data Explorer databases.
+- **[Azure DevOps](https://github.com/Vortiago/mcp-azure-devops)** - An MCP server that provides a bridge to Azure DevOps services, enabling AI assistants to query and manage work items.
 - **[Base Free USDC Transfer](https://github.com/magnetai/mcp-free-usdc-transfer)** - Send USDC on [Base](https://base.org) for free using Claude AI! Built with [Coinbase CDP](https://docs.cdp.coinbase.com/mpc-wallet/docs/welcome).
 * **[Basic Memory](https://github.com/basicmachines-co/basic-memory)** - Local-first knowledge management system that builds a semantic graph from Markdown files, enabling persistent memory across conversations with LLMs.
 - **[BigQuery](https://github.com/LucasHild/mcp-server-bigquery)** (by LucasHild) - This server enables LLMs to inspect database schemas and execute queries on BigQuery.


### PR DESCRIPTION
## Description
This PR adds the Azure DevOps MCP server to the Community Servers section of the README.md file. The server enables AI assistants to interact with Azure DevOps through natural language.

## Motivation and Context
The Azure DevOps MCP server provides a bridge between AI assistants and Azure DevOps services, enabling users to query work items and manage DevOps workflows through conversation. This addition enhances the MCP ecosystem by offering integration with a major development platform, benefiting teams that use Azure DevOps for project management and development.

## How Has This Been Tested?
The server has been tested with Claude Desktop. Testing scenarios included querying work items using WIQL, retrieving work item details, and accessing comments.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [[MCP Protocol Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
