### PR TITLE
Add community MCP server: ios-simulator-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[InfluxDB](https://github.com/idoru/influxdb-mcp-server)** - Run queries against InfluxDB OSS API v2.
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
 - **[Intercom](https://github.com/raoulbia-ai/mcp-server-for-intercom)** - An MCP-compliant server for retrieving customer support tickets from Intercom. This tool enables AI assistants like Claude Desktop and Cline to access and analyze your Intercom support tickets.
+- **[iOS Simulator MCP](https://github.com/joshuayoes/ios-simulator-mcp/)** - A MCP server for interacting with iOS simulators. This server allows you to interact with iOS simulators by getting information about them, controlling UI interactions, and inspecting UI elements.
 - **[iTerm MCP](https://github.com/ferrislucas/iterm-mcp)** - Integration with iTerm2 terminal emulator for macOS, enabling LLMs to execute and monitor terminal commands.
 - **[JavaFX](https://github.com/mcpso/mcp-server-javafx)** - Make drawings using a JavaFX canvas
 - **[JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc)** - Connect to any JDBC-compatible database and query, insert, update, delete, and more. Supports MySQL, PostgreSQL, Oracle, SQL Server, sqllite and [more](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc#supported-jdbc-variants).


### PR DESCRIPTION
## Description

This PR adds a new Community Servers entry to the README.md for the [iOS Simulator MCP](https://github.com/joshuayoes/ios-simulator-mcp/), a MCP server for interacting with iOS simulators.

## Server Details

- Server: ios-simulator-mcp
- Changes to: README > Community Servers

## Motivation and Context

This MCP is intended to be used as a agent driven QA workflow after implementing features on iOS devices to verify they work as intended.

## How Has This Been Tested?

This has been tested in Cursor using agent mode. It seems to work best with claude-3.7-sonnet in thinking mode. See the [README](https://github.com/joshuayoes/ios-simulator-mcp/?tab=readme-ov-file#ios-simulator-mcp-server) or the [Releases page](https://github.com/joshuayoes/ios-simulator-mcp/releases) for video recordings of demos.

## Breaking Changes

N/A

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
