### PR TITLE
Add Outline MCP Server to list of community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[OpenDota](https://github.com/asusevski/opendota-mcp-server)** - Interact with OpenDota API to retrieve Dota 2 match data, player statistics, and more.
 - **[OpenRPC](https://github.com/shanejonas/openrpc-mpc-server)** - Interact with and discover JSON-RPC APIs via [OpenRPC](https://open-rpc.org).
 - **[Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools)** - Content editing codes, value map, and positioning tools for product marketing.
+- **[Outline](https://github.com/Vortiago/mcp-outline)** - MCP Server to interact with [Outline](https://www.getoutline.com) knowledge base to search, read, create, and manage documents and their content, access collections, add comments, and manage document backlinks.
 - **[Pandoc](https://github.com/vivekVells/mcp-pandoc)** - MCP server for seamless document format conversion using Pandoc, supporting Markdown, HTML, PDF, DOCX (.docx), csv and more.
 - **[PIF](https://github.com/hungryrobot1/MCP-PIF)** - A Personal Intelligence Framework (PIF), providing tools for file operations, structured reasoning, and journal-based documentation to support continuity and evolving human-AI collaboration across sessions.
 - **[Pinecone](https://github.com/sirmews/mcp-pinecone)** - MCP server for searching and uploading records to Pinecone. Allows for simple RAG features, leveraging Pinecone's Inference API.


### PR DESCRIPTION
## Description
This PR adds the Outline MCP server to the Community Servers section of the README.md file. The server enables AI assistants to interact with Outline knowledge base through natural language.

## Motivation and Context
The Outline MCP server provides a bridge between AI assistants and Outline document services, enabling users to search, read, create, and manage documents through conversation. This addition enhances the MCP ecosystem by offering integration with a popular knowledge management platform, benefiting teams that use Outline for documentation and knowledge sharing.

## How Has This Been Tested?
The server has been tested with Claude Desktop. Testing scenarios included searching documents, listing collections, reading document content, creating new documents, managing comments, and working with document backlinks.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
* [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
* [x] My changes follows MCP security best practices
* [x] I have updated the server's README accordingly
* [x] I have tested this with an LLM client
* [x] My code follows the repository's style guidelines
* [x] New and existing tests pass locally
* [x] I have added appropriate error handling
* [x] I have documented all environment variables and configuration options