### PR TITLE
Add MCP Easy Copy to Community Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[mac-messages-mcp](https://github.com/carterlasalle/mac_messages_mcp)** - An MCP server that securely interfaces with your iMessage database via the Model Context Protocol (MCP), allowing LLMs to query and analyze iMessage conversations. It includes robust phone number validation, attachment processing, contact management, group chat handling, and full support for sending and receiving messages.
 - **[MariaDB](https://github.com/abel9851/mcp-server-mariadb)** - MariaDB database integration with configurable access controls in Python.
 - **[MCP Compass](https://github.com/liuyoshio/mcp-compass)** - Suggest the right MCP server for your needs
+- **[MCP Easy Copy](https://github.com/fisheepx/mcp-easy-copy)** - A discovery tool that lists all configured MCP services in Claude Desktop for easy copying and reference
 - **[MCP Create](https://github.com/tesla0225/mcp-create)** - A dynamic MCP server management service that creates, runs, and manages Model Context Protocol servers on-the-fly.
 - **[MCP Installer](https://github.com/anaisbetts/mcp-installer)** - This server is a server that installs other MCP servers for you.
 - **[mcp-k8s-go](https://github.com/strowk/mcp-k8s-go)** - Golang-based Kubernetes server for MCP to browse pods and their logs, events, namespaces and more. Built to be extensible.


### PR DESCRIPTION
## Description
This PR adds [MCP Easy Copy](https://github.com/fisheepx/mcp-easy-copy) to the Community Servers section of the README.

## Server Details
- Server: MCP Easy Copy (new community server addition)
- Changes to: README.md Community Servers section

## Motivation and Context
MCP Easy Copy is a discovery tool that serves a unique purpose in the Claude Desktop ecosystem:

- It reads the Claude Desktop configuration file
- Extracts the names of all configured MCP services
- Presents them in an easy-to-copy format at the top of the tools list

Although Claude can now automatically select appropriate MCP services in most cases, there are still situations where users need to explicitly specify a service name. This tool bridges that gap by:

1. Using special name formatting to always appear first in the tools list
2. Providing a numbered list of all available services for easy reference
3. Requiring zero external dependencies beyond Node.js

The need for this tool becomes increasingly apparent in several scenarios:

- As users configure more MCP services, the service list becomes longer and harder to navigate
- Many MCP services provide multiple callable actions, further expanding the tools list
- These factors combined make it increasingly difficult to find and reference specific MCP service names when needed

## How Has This Been Tested?
This server has been tested with Claude Desktop on macOS. Multiple test scenarios were conducted including:
- Reading the configuration file with various MCP services
- Displaying service lists correctly in Claude
- Verifying that the listing appears at the top of the tools menu

## Breaking Changes
No breaking changes. Users can add this server to their Claude Desktop configuration without affecting existing functionality.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have tested this with an LLM client
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The server is published to npm as [@fishes/mcp-easy-copy](https://www.npmjs.com/package/@fishes/mcp-easy-copy) and can be easily added to Claude Desktop with:

```json
{
  "mcpServers": {
    "mcp-easy-copy": {
      "command": "npx",
      "args": [
        "-y",
        "@fishes/mcp-easy-copy"
      ]
    }
  }
}
```

Screenshots and more details are available in the [GitHub repository](https://github.com/fisheepx/mcp-easy-copy).