### PR TITLE
GitHub MCP: Add 'add_sub_issues' feature and update schemas to support issue types for add_issue and edit_issue

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -129,6 +129,7 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
       - `labels` (optional string[]): New labels
       - `assignees` (optional string[]): New assignees
       - `milestone` (optional number): New milestone number
+      - `type` (optional string): New issue type (e.g., 'Bug', 'Feature', 'Task')
     - Returns: Updated issue details
 
 12. `add_issue_comment`
@@ -276,6 +277,26 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `repo` (string): Repository name
      - `pull_number` (number): Pull request number
    - Returns: Array of pull request reviews with details like the review state (APPROVED, CHANGES_REQUESTED, etc.), reviewer, and review body
+
+27. `add_sub_issues`
+  - Add existing work items as sub-issues to an issue.
+  - Inputs:
+    - `owner` (string): Repository owner
+    - `repo` (string): Repository name
+    - `issue_number` (number): Parent issue number
+    - `sub_issues` (array): List of sub-issues, each with:
+      - `owner` (string): Repository owner of the sub-issue
+      - `repo` (string): Repository name of the sub-issue
+      - `issue_number` (number): Sub-issue number
+  - Returns: Updated issue details
+  - Falls back to task list implementation if API unavailable for your repository
+  - Usage examples:
+    ```
+    #add_sub_issues add issue 56 to parent issue 54 from repo my-repo of github org my-org
+    ```
+    ```
+    #add_sub_issues add issue 23, 24 to parent issue 20 from repo my-repo of github org my-org
+    ```
 
 ## Search Query Syntax
 

--- a/src/github/common/types.ts
+++ b/src/github/common/types.ts
@@ -189,12 +189,33 @@ export const GitHubIssueSchema = z.object({
   locked: z.boolean(),
   assignee: GitHubIssueAssigneeSchema.nullable(),
   assignees: z.array(GitHubIssueAssigneeSchema),
+  type: z.object({
+    id: z.number(),
+    node_id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    color: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    is_enabled: z.boolean()
+  }).optional(),
   milestone: GitHubMilestoneSchema.nullable(),
   comments: z.number(),
   created_at: z.string(),
   updated_at: z.string(),
   closed_at: z.string().nullable(),
   body: z.string().nullable(),
+});
+
+export const AddSubIssuesSchema = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  issue_number: z.number(),
+  sub_issues: z.array(z.object({
+    owner: z.string(),
+    repo: z.string(),
+    issue_number: z.number()
+  })).describe("List of sub-issues to add")
 });
 
 // Search-related schemas

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -194,7 +194,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_pull_request_reviews",
         description: "Get the reviews on a pull request",
         inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema)
-      }
+      },
+      {
+        name: "add_sub_issues",
+        description: "Add existing work items as sub-issues to an issue.",
+        inputSchema: zodToJsonSchema(issues.AddSubIssuesSchema),
+      },
     ],
   };
 });
@@ -453,6 +458,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
         return {
           content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+        };
+      }
+
+      case "add_sub_issues": {
+        const args = issues.AddSubIssuesSchema.parse(request.params.arguments);
+        const result = await issues.addSubIssues(
+          args.owner,
+          args.repo,
+          args.issue_number,
+          args.sub_issues
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
       }
 

--- a/src/github/operations/issues.ts
+++ b/src/github/operations/issues.ts
@@ -20,6 +20,7 @@ export const CreateIssueOptionsSchema = z.object({
   assignees: z.array(z.string()).optional(),
   milestone: z.number().optional(),
   labels: z.array(z.string()).optional(),
+  type: z.string().optional().describe("The name of the issue type to set"),
 });
 
 export const CreateIssueSchema = z.object({
@@ -40,6 +41,19 @@ export const ListIssuesOptionsSchema = z.object({
   state: z.enum(["open", "closed", "all"]).optional(),
 });
 
+/**
+ * UpdateIssueOptionsSchema:
+ * - owner: The owner of the repository.
+ * - repo: The name of the repository.
+ * - issue_number: The number of the issue to update.
+ * - title: (Optional) The new title for the issue.
+ * - body: (Optional) The new body content for the issue.
+ * - assignees: (Optional) An array of usernames to assign to the issue.
+ * - milestone: (Optional) The milestone to associate with the issue.
+ * - labels: (Optional) An array of labels to apply to the issue.
+ * - state: (Optional) The state of the issue (open or closed).
+ * - type: (Optional) The name of the issue type to set (e.g., Bug, Feature, Task).
+ */
 export const UpdateIssueOptionsSchema = z.object({
   owner: z.string(),
   repo: z.string(),
@@ -50,6 +64,18 @@ export const UpdateIssueOptionsSchema = z.object({
   milestone: z.number().optional(),
   labels: z.array(z.string()).optional(),
   state: z.enum(["open", "closed"]).optional(),
+  type: z.string().optional().describe("The name of the issue type to set"),
+});
+
+export const AddSubIssuesSchema = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  issue_number: z.number(),
+  sub_issues: z.array(z.object({
+    owner: z.string(),
+    repo: z.string(),
+    issue_number: z.number()
+  })).describe("List of sub-issues to add")
 });
 
 export async function getIssue(owner: string, repo: string, issue_number: number) {
@@ -115,4 +141,194 @@ export async function updateIssue(
       body: options,
     }
   );
+}
+
+export async function addSubIssues(
+  owner: string,
+  repo: string,
+  issue_number: number,
+  sub_issues: { owner: string; repo: string; issue_number: number }[]
+) {
+  const results = [];
+  
+  try {
+    // Add each sub-issue individually using the official GitHub API
+    for (const subIssue of sub_issues) {
+      try {
+        // Check if the sub-issue is in the same repository as the parent
+        if (subIssue.owner !== owner || subIssue.repo !== repo) {
+          throw new Error("Sub-issues must belong to the same repository as the parent issue");
+        }
+        
+        // We need to get the issue ID from the issue number
+        const issueDetails = await getIssue(subIssue.owner, subIssue.repo, subIssue.issue_number);
+        const subIssueId = issueDetails.id; // Get the actual ID, not the number
+        
+        // According to GitHub API docs, we need to send sub_issue_id (the ID, not the number)
+        const result = await githubRequest(
+          `https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}/sub_issues`,
+          {
+            method: "POST",
+            body: {
+              sub_issue_id: subIssueId
+            },
+            headers: {
+              "X-GitHub-Api-Version": "2022-11-28"
+            }
+          }
+        );
+        
+        results.push(result);
+      } catch (error: any) {
+        // Handle specific validation errors for sub-issues
+        if (error.status === 422) {
+          // Check for common validation errors
+          if (error.message && error.message.includes("duplicate sub-issues")) {
+            throw new Error(`Issue #${subIssue.issue_number} is already a sub-issue of issue #${issue_number}.`);
+          } else if (error.message && error.message.includes("only have one parent")) {
+            throw new Error(`Issue #${subIssue.issue_number} already has a different parent issue. An issue can only have one parent.`);
+          } else {
+            throw new Error(`Validation error when adding issue #${subIssue.issue_number} as sub-issue: ${error.message}`);
+          }
+        }
+        throw error;
+      }
+    }
+    
+    return {
+      parent_issue_number: issue_number,
+      parent_repo: `${owner}/${repo}`,
+      added_sub_issues: results
+    };
+  } catch (error: any) {
+    // Handle not found errors specifically for sub-issues feature
+    if (error.message && error.message.includes("Not Found")) {
+      // Fall back to the task list approach
+      return await addSubIssuesWithTaskList(owner, repo, issue_number, sub_issues);
+    }
+    
+    // Re-throw specific errors we've already formatted
+    if (error.message && (
+      error.message.includes("already a sub-issue") || 
+      error.message.includes("already has a different parent") ||
+      error.message.includes("Validation error when adding issue")
+    )) {
+      throw error;
+    }
+    
+    // Generic error handling
+    throw error;
+  }
+}
+
+// Fallback implementation using task lists when the API endpoint is not available
+async function addSubIssuesWithTaskList(
+  owner: string,
+  repo: string,
+  issue_number: number,
+  sub_issues: { owner: string; repo: string; issue_number: number }[]
+) {
+  // First, get the current parent issue to access its body
+  const parentIssue = await getIssue(owner, repo, issue_number);
+  
+  // Generate task list items for each sub-issue
+  const subIssueTasks = sub_issues.map((subIssue) => {
+    // Check if we're referencing an issue in the same repo or a different repo
+    const isSameRepo = subIssue.owner === owner && subIssue.repo === repo;
+    const issueRef = isSameRepo 
+      ? `#${subIssue.issue_number}`
+      : `${subIssue.owner}/${subIssue.repo}#${subIssue.issue_number}`;
+    
+    return `- [ ] ${issueRef}`;
+  }).join('\n');
+
+  // Determine the new body for parent issue
+  let newParentBody = '';
+  if (!parentIssue.body) {
+    // If the issue has no body yet, create one with the task list
+    newParentBody = `### Sub-issues\n\n${subIssueTasks}\n\n> Note: Using task list format because the GitHub sub-issues API feature is not available for this repository.`;
+  } else if (parentIssue.body.includes('### Sub-issues')) {
+    // If already has a sub-issues section, append to it
+    const bodyParts = parentIssue.body.split('### Sub-issues');
+    const firstPart = bodyParts[0];
+    const secondPart = bodyParts[1].split('\n');
+    
+    // Find where the task list ends
+    let taskListEndIndex = 0;
+    for (let i = 0; i < secondPart.length; i++) {
+      if (!secondPart[i].trim().startsWith('- [ ]') && !secondPart[i].trim().startsWith('- [x]') && secondPart[i].trim() !== '') {
+        taskListEndIndex = i;
+        break;
+      }
+    }
+    
+    // Insert new tasks before the end of the task list
+    if (taskListEndIndex > 0) {
+      const tasksPart = secondPart.slice(0, taskListEndIndex);
+      const restPart = secondPart.slice(taskListEndIndex);
+      newParentBody = firstPart + '### Sub-issues\n\n' + tasksPart.join('\n') + '\n' + subIssueTasks + '\n' + restPart.join('\n');
+    } else {
+      // If there's no clear end to the task list, just append to the end
+      newParentBody = firstPart + '### Sub-issues\n\n' + secondPart.join('\n') + '\n' + subIssueTasks;
+    }
+    
+    // Add note if not already present
+    if (!newParentBody.includes('> Note: Using task list format')) {
+      newParentBody += '\n\n> Note: Using task list format because the GitHub sub-issues API feature is not available for this repository.';
+    }
+  } else {
+    // If it has a body but no sub-issues section, append the section
+    newParentBody = parentIssue.body + '\n\n### Sub-issues\n\n' + subIssueTasks + '\n\n> Note: Using task list format because the GitHub sub-issues API feature is not available for this repository.';
+  }
+
+  // Update the parent issue with the new body
+  const updatedParentIssue = await updateIssue(owner, repo, issue_number, { body: newParentBody });
+  
+  // For each sub-issue, add a reference back to the parent issue
+  const parentIssueReference = `${owner}/${repo}#${issue_number}`;
+  
+  const updatedSubIssues = [];
+  for (const subIssue of sub_issues) {
+    try {
+      // Get the current sub-issue
+      const childIssue = await getIssue(subIssue.owner, subIssue.repo, subIssue.issue_number);
+      
+      // Create the parent reference text
+      const parentRefText = `> Part of parent issue: ${parentIssueReference}`;
+      
+      // Update the child issue body to include reference to parent
+      let newChildBody = '';
+      if (!childIssue.body) {
+        newChildBody = parentRefText;
+      } else if (!childIssue.body.includes(parentRefText)) {
+        // Only add the reference if it's not already there
+        newChildBody = `${parentRefText}\n\n${childIssue.body}`;
+      } else {
+        // Reference already exists, don't modify
+        newChildBody = childIssue.body;
+      }
+      
+      if (newChildBody !== childIssue.body) {
+        // Update the child issue with reference to parent
+        const updatedChildIssue = await updateIssue(
+          subIssue.owner, 
+          subIssue.repo, 
+          subIssue.issue_number, 
+          { body: newChildBody }
+        );
+        updatedSubIssues.push(updatedChildIssue);
+      } else {
+        updatedSubIssues.push(childIssue);
+      }
+    } catch (error) {
+      console.error(`Error updating sub-issue ${subIssue.owner}/${subIssue.repo}#${subIssue.issue_number}:`, error);
+    }
+  }
+  
+  return {
+    parent_issue: updatedParentIssue,
+    updated_sub_issues: updatedSubIssues,
+    fallback_used: true,
+    message: "The GitHub sub-issues API feature is not available for this repository. Used task list format instead."
+  };
 }


### PR DESCRIPTION
## Description
This pull request introduces enhancements to the GitHub MCP server, including the addition of a new `type` field for issues and the implementation of a new `add_sub_issues` feature. These changes involve updates to the API documentation, schema definitions, and server request handling.

## Server Details
- Server: github
- Changes to: tools, schema

## Motivation and Context
Adding tool for sub-issues - adding Type to issues

## How Has This Been Tested?
Tested: Adding and changing issues using common Types (bug, Feature, Task), Assigning issues as sub-issues to a parent issue. Tested fallback in case we couldn't create the sub issues using the preview feature: this creates the "task list" - maybe these functionalities (sub-issue, tasks) should both exist, which will clean up the code significantly. I'll add it to my todo 😇 

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ x ] I have updated the server's README accordingly
- [ x ] I have tested this with an LLM client
- [ x ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ x ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
