### PR TITLE
Support Self-Hosted Sentry

### DIFF
--- a/src/sentry/README.md
+++ b/src/sentry/README.md
@@ -62,7 +62,7 @@ Add this to your `claude_desktop_config.json`:
 "mcpServers": {
   "sentry": {
     "command": "uvx",
-    "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+    "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-base", "YOUR_SENTRY_API_BASE"]
   }
 }
 ```
@@ -77,7 +77,7 @@ Add this to your `claude_desktop_config.json`:
 "mcpServers": {
   "sentry": {
     "command": "docker",
-    "args": ["run", "-i", "--rm", "mcp/sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+    "args": ["run", "-i", "--rm", "mcp/sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-base", "YOUR_SENTRY_API_BASE"]
   }
 }
 ```
@@ -91,7 +91,7 @@ Add this to your `claude_desktop_config.json`:
 "mcpServers": {
   "sentry": {
     "command": "python",
-    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-base", "YOUR_SENTRY_API_BASE"]
   }
 }
 ```
@@ -109,7 +109,7 @@ Add to your Zed settings.json:
   "mcp-server-sentry": {
     "command": {
       "path": "uvx",
-      "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+      "args": ["mcp-server-sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-base", "YOUR_SENTRY_API_BASE"]
     }
   }
 ],
@@ -123,7 +123,7 @@ Add to your Zed settings.json:
 "context_servers": {
   "mcp-server-sentry": {
     "command": "python",
-    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN"]
+    "args": ["-m", "mcp_server_sentry", "--auth-token", "YOUR_SENTRY_TOKEN", "--api-base", "YOUR_SENTRY_API_BASE"]
   }
 },
 ```
@@ -134,14 +134,14 @@ Add to your Zed settings.json:
 You can use the MCP inspector to debug the server. For uvx installations:
 
 ```
-npx @modelcontextprotocol/inspector uvx mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN
+npx @modelcontextprotocol/inspector uvx mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN --api-base YOUR_SENTRY_API_BASE
 ```
 
 Or if you've installed the package in a specific directory or are developing on it:
 
 ```
 cd path/to/servers/src/sentry
-npx @modelcontextprotocol/inspector uv run mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN
+npx @modelcontextprotocol/inspector uv run mcp-server-sentry --auth-token YOUR_SENTRY_TOKEN --api-base YOUR_SENTRY_API_BASE
 ```
 
 ## License

--- a/src/sentry/src/mcp_server_sentry/server.py
+++ b/src/sentry/src/mcp_server_sentry/server.py
@@ -10,7 +10,7 @@ from mcp.server.models import InitializationOptions
 from mcp.shared.exceptions import McpError
 import mcp.server.stdio
 
-SENTRY_API_BASE = "https://sentry.io/api/0/"
+DEFAULT_SENTRY_API_BASE = "https://sentry.io/api/0/"
 MISSING_AUTH_TOKEN_MESSAGE = (
     """Sentry authentication token not found. Please specify your Sentry auth token."""
 )
@@ -188,9 +188,9 @@ async def handle_sentry_issue(
         raise McpError(f"An error occurred: {str(e)}")
 
 
-async def serve(auth_token: str) -> Server:
+async def serve(auth_token: str, api_base: str) -> Server:
     server = Server("sentry")
-    http_client = httpx.AsyncClient(base_url=SENTRY_API_BASE)
+    http_client = httpx.AsyncClient(base_url=api_base)
 
     @server.list_prompts()
     async def handle_list_prompts() -> list[types.Prompt]:
@@ -265,10 +265,16 @@ async def serve(auth_token: str) -> Server:
     required=True,
     help="Sentry authentication token",
 )
-def main(auth_token: str):
+@click.option(
+    "--api-base",
+    envvar="SENTRY_API_BASE",
+    default=DEFAULT_SENTRY_API_BASE,
+    help="Sentry API base URL (default: https://sentry.io/api/0/)",
+)
+def main(auth_token: str, api_base: str):
     async def _run():
         async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-            server = await serve(auth_token)
+            server = await serve(auth_token, api_base)
             await server.run(
                 read_stream,
                 write_stream,


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

This PR adds the ability to specify a custom Sentry API base URL using the --api-base option. This is useful for users who are using a self - hosted instance of Sentry.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update


## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

https://develop.sentry.dev/self-hosted/