### PR TITLE
Add chess.com mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[CFBD API](https://github.com/lenwood/cfbd-mcp-server)** - An MCP server for the [College Football Data API](https://collegefootballdata.com/).
 - **[ChatMCP](https://github.com/AI-QL/chat-mcp)** – An Open Source Cross-platform GUI Desktop application compatible with Linux, macOS, and Windows, enabling seamless interaction with MCP servers across dynamically selectable LLMs, by **[AIQL](https://github.com/AI-QL)**
 - **[ChatSum](https://github.com/mcpso/mcp-server-chatsum)** - Query and Summarize chat messages with LLM. by [mcpso](https://mcp.so)
+- **[Chess.com](https://github.com/pab1it0/chess-mcp)** - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 - **[Chroma](https://github.com/privetin/chroma)** - Vector database server for semantic document search and metadata filtering, built on Chroma
 - **[ClaudePost](https://github.com/ZilongXue/claude-post)** - ClaudePost enables seamless email management for Gmail, offering secure features like email search, reading, and sending.
 - **[Cloudinary](https://github.com/felores/cloudinary-mcp-server)** - Cloudinary Model Context Protocol Server to upload media to Cloudinary and get back the media link and details.


### PR DESCRIPTION
## Description
Updated the README.md file to include my Chess.com MCP server in the Community Servers section, providing access to Chess.com player data, game records, and other public information through standardized MCP interfaces.

## Server Details
- Server: Chess.com
- Changes to: documentation reference 

## Motivation and Context
Adding my Chess.com MCP server to the community servers list helps users discover tools for accessing and analyzing chess information through AI assistants. This integration enables AI assistants to search, retrieve, and analyze chess player data effectively.

## How Has This Been Tested?
The Chess.com MCP server has been thoroughly tested with Claude Desktop. Testing included player profile retrieval, game history analysis, statistical data extraction, and online status checking.

## Breaking Changes
No breaking changes. This is a documentation update to include a reference to a new community server.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The Chess.com MCP server provides a comprehensive set of tools to interact with the Chess.com API, allowing AI assistants to access player profiles, statistics, game archives, and online status information in a structured and secure manner.