### PR TITLE
docs: Add Slidespeak MCP Server to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[SearXNG](https://github.com/ihor-sokoliuk/mcp-searxng)** - A Model Context Protocol Server for [SearXNG](https://docs.searxng.org)
 - **[ServiceNow](https://github.com/osomai/servicenow-mcp)** - A MCP server to interact with a ServiceNow instance
 - **[Siri Shortcuts](https://github.com/dvcrn/mcp-server-siri-shortcuts)** - MCP to interact with Siri Shortcuts on macOS. Exposes all Shortcuts as MCP tools.
+- **[Slidespeak](https://github.com/SlideSpeak/slidespeak-mcp)** - 🦜 Create PowerPoint presentations using the [Slidespeak](https://slidespeak.com/) API.
 - **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - This MCP server enables LLMs to interact with Snowflake databases, allowing for secure and controlled data operations.
 - **[Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit/tree/main/examples/agent-kit-mcp-server)** - This MCP server enables LLMs to interact with the Solana blockchain with help of Solana Agent Kit by SendAI, allowing for 40+ protcool actions and growing
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify.


### PR DESCRIPTION
Add Slidespeak MCP Server to README.md

## Description

There are 2 endpoints. One for getting all available templates and one to generate the PowerPoint. It works based on plain text allowing the LLM to define the style, layout and content.

## Server Details

- Server: [Slidespeak](https://github.com/SlideSpeak/slidespeak-mcp)
Changes to: Added to the README.md

## Motivation and Context

Adds the functionality to create PowerPoint presentations using the Slidespeak API.

## How Has This Been Tested?

It was tested locally using Claude Desktop.

## Breaking Changes

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

None