### PR TITLE
feat: only list channels the slack app is in

### DIFF
--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -53,7 +53,7 @@ interface GetUserProfileArgs {
 // Tool definitions
 const listChannelsTool: Tool = {
   name: "slack_list_channels",
-  description: "List public channels in the workspace with pagination",
+  description: "List channels the app has access to with pagination",
   inputSchema: {
     type: "object",
     properties: {
@@ -222,7 +222,7 @@ class SlackClient {
 
   async getChannels(limit: number = 100, cursor?: string): Promise<any> {
     const params = new URLSearchParams({
-      types: "public_channel",
+      types: "public_channel,private_channel",
       exclude_archived: "true",
       limit: Math.min(limit, 200).toString(),
       team_id: process.env.SLACK_TEAM_ID!,
@@ -233,7 +233,7 @@ class SlackClient {
     }
 
     const response = await fetch(
-      `https://slack.com/api/conversations.list?${params}`,
+      `https://slack.com/api/users.conversations?${params}`,
       { headers: this.botHeaders },
     );
 


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

The current slack mcp server gives a list of every available channel in the workspace but excludes private channels that the bot may have been added too. In very large organizations getting the full list could quickly fill the model's context window and rate limit the app. I propose only fetching channels the bot has been added to including private channels which will enhance privacy and functionality for the users since they can only send messages to channels they are in.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: Slack
- Changes to: tools

## Motivation and Context

In very large organizations getting the full list could quickly fill the model's context window and rate limit the app. I propose only fetching channels the bot has been added to including private channels which will enhance privacy and functionality for the users since they can only send messages to channels they are in.

## How Has This Been Tested?

This has been validated with the slack api via https://github.com/wong2/mcp-cli

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

User's won't need to update anything but it could potentially break a workflow of searching for new channels. It is more likely to be a benefit though.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options