### PR TITLE
feat(ignore): add MCP_FILESYSTEM_IGNORE_PATTERNS for excluding direct…

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -151,6 +151,22 @@ Docker build:
 docker build -t mcp/filesystem -f src/filesystem/Dockerfile .
 ```
 
+## Exclude directories
+Exclude dirs like `.venv`, `.git` with `MCP_FILESYSTEM_IGNORE_PATTERNS` env variable   
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      ...
+      "env": {
+          "MCP_FILESYSTEM_IGNORE_PATTERNS": ".venv,.git,",
+      }
+    }
+  }
+}
+```
+
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
Exclude dirs like `.venv`, `.git` with `MCP_FILESYSTEM_IGNORE_PATTERNS` env variable   

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: filesystem
- Changes to: added support for directories exclusion 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
I found that .git, .venv folders get into the output of list_directory and directory_tree methods and clutter the context for llm, wasting a lot of users' money

## How Has This Been Tested?
mcp inspector 

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
yes, clients like vscode can add MCP_FILESYSTEM_IGNORE_PATTERNS env and exlude dirs like .git, .venv

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
