### PR TITLE
Add missing capabilities and improve connection handling for server-redis

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -189,7 +189,7 @@ const knowledgeGraphManager = new KnowledgeGraphManager();
 // The server instance and tools exposed to Claude
 const server = new Server({
   name: "memory-server",
-  version: "1.0.0",
+  version: "0.6.3",
 },    {
     capabilities: {
       tools: {},

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -189,7 +189,7 @@ const knowledgeGraphManager = new KnowledgeGraphManager();
 // The server instance and tools exposed to Claude
 const server = new Server({
   name: "memory-server",
-  version: "0.6.3",
+  version: "1.0.0",
 },    {
     capabilities: {
       tools: {},

--- a/src/redis/README.md
+++ b/src/redis/README.md
@@ -2,6 +2,31 @@
 
 A Model Context Protocol server that provides access to Redis databases. This server enables LLMs to interact with Redis key-value stores through a set of standardized tools.
 
+## Prerequisites
+
+1. Redis server must be installed and running
+   - [Download Redis](https://redis.io/download)
+   - For Windows users: Use [Windows Subsystem for Linux (WSL)](https://redis.io/docs/getting-started/installation/install-redis-on-windows/) or [Memurai](https://www.memurai.com/) (Redis-compatible Windows server)
+   - Default port: 6379
+
+## Common Issues & Solutions
+
+### Connection Errors
+
+**ECONNREFUSED**
+  - **Cause**: Redis server is not running or unreachable
+  - **Solution**: 
+    - Verify Redis is running: `redis-cli ping` should return "PONG"
+    - Check Redis service status: `systemctl status redis` (Linux) or `brew services list` (macOS)
+    - Ensure correct port (default 6379) is not blocked by firewall
+    - Verify Redis URL format: `redis://hostname:port`
+
+### Server Behavior
+
+- The server implements exponential backoff with a maximum of 5 retries
+- Initial retry delay: 1 second, maximum delay: 30 seconds
+- Server will exit after max retries to prevent infinite reconnection loops
+
 ## Components
 
 ### Tools

--- a/src/redis/src/index.ts
+++ b/src/redis/src/index.ts
@@ -7,10 +7,26 @@ import {
 import { z } from "zod";
 import { createClient } from 'redis';
 
-// Get Redis URL from command line args or use default
+// Configuration
 const REDIS_URL = process.argv[2] || "redis://localhost:6379";
+const MAX_RETRIES = 5;
+const MIN_RETRY_DELAY = 1000; // 1 second
+const MAX_RETRY_DELAY = 30000; // 30 seconds
+
+// Create Redis client with retry strategy
 const redisClient = createClient({
-    url: REDIS_URL
+    url: REDIS_URL,
+    socket: {
+        reconnectStrategy: (retries) => {
+            if (retries >= MAX_RETRIES) {
+                console.error(`Maximum retries (${MAX_RETRIES}) reached. Giving up.`);
+                return new Error('Max retries reached');
+            }
+            const delay = Math.min(Math.pow(2, retries) * MIN_RETRY_DELAY, MAX_RETRY_DELAY);
+            console.error(`Reconnection attempt ${retries + 1}/${MAX_RETRIES} in ${delay}ms`);
+            return delay;
+        }
+    }
 });
 
 // Define Zod schemas for validation
@@ -37,6 +53,11 @@ const server = new Server(
     {
         name: "redis",
         version: "0.0.1"
+    },
+    {
+        capabilities: {
+            tools: {}
+        }
     }
 );
 
@@ -215,22 +236,51 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 // Start the server
 async function main() {
     try {
-        // Connect to Redis
-        redisClient.on('error', (err: Error) => console.error('Redis Client Error', err));
-        await redisClient.connect();
-        console.error(`Connected to Redis successfully at ${REDIS_URL}`);
+        // Set up Redis event handlers
+        redisClient.on('error', (err: Error) => {
+            console.error('Redis Client Error:', err);
+        });
 
+        redisClient.on('connect', () => {
+            console.error(`Connected to Redis at ${REDIS_URL}`);
+        });
+
+        redisClient.on('reconnecting', () => {
+            console.error('Attempting to reconnect to Redis...');
+        });
+
+        redisClient.on('end', () => {
+            console.error('Redis connection closed');
+        });
+
+        // Connect to Redis
+        await redisClient.connect();
+
+        // Set up MCP server
         const transport = new StdioServerTransport();
         await server.connect(transport);
         console.error("Redis MCP Server running on stdio");
     } catch (error) {
         console.error("Error during startup:", error);
-        await redisClient.quit();
-        process.exit(1);
+        await cleanup();
     }
 }
 
+// Cleanup function
+async function cleanup() {
+    try {
+        await redisClient.quit();
+    } catch (error) {
+        console.error("Error during cleanup:", error);
+    }
+    process.exit(1);
+}
+
+// Handle process termination
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
 main().catch((error) => {
     console.error("Fatal error in main():", error);
-    redisClient.quit().finally(() => process.exit(1));
+    cleanup();
 });

--- a/src/redis/src/index.ts
+++ b/src/redis/src/index.ts
@@ -36,7 +36,7 @@ const ListArgumentsSchema = z.object({
 const server = new Server(
     {
         name: "redis",
-        version: "1.0.0"
+        version: "0.0.1"
     }
 );
 


### PR DESCRIPTION
## Description
This PR adds the missing `tools` capability and improves connection and error handling for the reference Redis MCP server.

## Server Details
- Server: server-redis

## Motivation and Context
Was not able to start or use server-redis tools.   After adding missing capabilities, if there was no redis host running then Claude Desktop got spammed with error logs.

## How Has This Been Tested?
Tested with Claude Desktop on Windows with Memurai, screenshots below:

![redis-test-1](https://github.com/user-attachments/assets/fe05a088-e5c4-4ce2-8060-29ef69b0f6f7)
![redis-test-2](https://github.com/user-attachments/assets/df52d423-649c-4f65-9397-797a780436d9)
![redis-test-3](https://github.com/user-attachments/assets/ee6baa50-e8b7-4856-85e1-60d653e1258e)

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
This should also solve this issue since the typescript changes should trigger a new tag and npm version to get published: https://github.com/modelcontextprotocol/servers/issues/856

