### PR TITLE
fix(github): downgrade node-fetch to v2 for CommonJS compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5561,7 +5561,7 @@
         "@modelcontextprotocol/sdk": "1.0.1",
         "@types/node": "^22",
         "@types/node-fetch": "^2.6.12",
-        "node-fetch": "^3.3.2",
+        "node-fetch": "2",
         "universal-user-agent": "^7.0.2",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.23.5"

--- a/src/github/package.json
+++ b/src/github/package.json
@@ -22,7 +22,7 @@
     "@modelcontextprotocol/sdk": "1.0.1",
     "@types/node": "^22",
     "@types/node-fetch": "^2.6.12",
-    "node-fetch": "^3.3.2",
+    "node-fetch": "2",
     "universal-user-agent": "^7.0.2",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.23.5"


### PR DESCRIPTION
Fixes #1065 

## Issue
When using the GitHub MCP server via NPX installation, all tool executions fail with the error: `MCP error -32603: fetch is not defined`. This occurs because the server is using node-fetch v3, which is ESM-only, while the codebase appears to be using CommonJS-style requires.

## Fix
This PR downgrades node-fetch from v3.3.2 to v2, which supports both CommonJS and ESM module systems. This ensures compatibility across different Node.js versions and environments.

## Testing
- Verified the fix by running the server locally
- Confirmed API calls work without the 'fetch is not defined' error
- Tested with the MCP interface to ensure all tools function correctly

## Technical Details
- Node-fetch v3 is ESM-only (ECMAScript Modules)
- Node-fetch v2 supports both CommonJS and ESM
- The GitHub MCP server appears to be using CommonJS-style requires
- This change maintains backward compatibility while resolving the issue