### PR TITLE
fix: puppeteer readme launch option json missing comma

### DIFF
--- a/src/puppeteer/README.md
+++ b/src/puppeteer/README.md
@@ -108,7 +108,7 @@ You can customize Puppeteer's browser behavior in two ways:
       "mcpServers": {
         "mcp-puppeteer": {
           "command": "npx",
-          "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+          "args": ["-y", "@modelcontextprotocol/server-puppeteer"],
           "env": {
             "PUPPETEER_LAUNCH_OPTIONS": "{ \"headless\": false, \"executablePath\": \"C:/Program Files/Google/Chrome/Application/chrome.exe\", \"args\": [] }",
             "ALLOW_DANGEROUS": "true"


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->
fix: puppeteer readme launch option json missing comma

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: <!-- e.g., filesystem, github -->
- Changes to: <!-- e.g., tools, resources, prompts -->

## Motivation and Context
I tried copying the launch json on puppeteer and notice that it's missing a comma

## How Has This Been Tested?
I tested it with my mcp server. It doesn't work without the comma and worked with the comma

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
