### PR TITLE
[filesystem] Added an excludePatterns input to the directory_tree tool

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -64,6 +64,15 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - List directory contents with [FILE] or [DIR] prefixes
   - Input: `path` (string)
 
+- **directory_tree**
+  - Get a recursive tree view of files and directories as a JSON structure
+  - Each entry includes 'name', 'type' (file/directory), and 'children' for directories
+  - Files have no children array, while directories always have a children array
+  - Inputs:
+    - `path` (string): Starting directory
+    - `excludePatterns` (string[]): Exclude any patterns. Glob formats are supported.
+  - Output is formatted with 2-space indentation for readability
+
 - **move_file**
   - Move or rename files and directories
   - Inputs:


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

[filesystem] Added an excludePatterns input to the directory_tree tool, similar to the search_files tool.  Also, document the directory_tree tool in READE.md.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server:filesystem
- Changes to: tools (directory_tree)

## Motivation and Context

I think it will be generally useful, but I wanted it to exclude irrelevant files in listing source code directories (.git, node_modules, *~, etc.), stuff that would normally be in a .gitignore.

## How Has This Been Tested?

I built it and verified the TS compiles cleanly.  I used it with the Claude Desktop Application without issue.

## Breaking Changes

It only adds an input.  It is not a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

There are no tests that I'm aware of.

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
