### PR TITLE
Add directory depth limit

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -97,6 +97,13 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - Returns:
     - Directories that this server can read/write from
 
+- **directory_tree**
+  - Get a recursive tree view of files and directories as a JSON structure upto default depth 3.
+  - `path` (string): Starting directory
+  - `depth` (int): Depth limit upto which it traverses directries. (optional)
+  - Returns:
+    - JSON Array with each entry including 'name', 'type' (file/directory), and 'children' for directories.
+
 ## Usage with Claude Desktop
 Add this to your `claude_desktop_config.json`:
 


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

This update introduces a depth limit for the directory_tree tool to prevent excessively large responses. Previously, the tool listed all files recursively within a directory, which could result in responses exceeding token limits, causing failures in some MCP clients. This enhancement (#1077) ensures controlled response sizes by allowing configurable depth limits.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: filesystem
- Changes to: directory_tree tool

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Resolves issue #1077. The directory_tree tool previously retrieved all files and sub directories recursively, leading to excessively large JSON responses. Some MCP clients were unable to handle these responses due to token limitations, resulting in failures or crashes. Introducing a depth limit mitigates this issue by restricting how deep the tool traverses the directory structure, ensuring responses remain manageable for LLM clients.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

The changes were validated using **Claude 3.7 Sonnet**, with a test directory containing this project folder configured as an allowed directory in the filesystem server.

#### Test Scenarios
1. **Without a Depth Limit:**
   - The application crashed due to an excessively large JSON response.
   - Logs confirmed the response exceeded token limits, preventing proper handling.

2. **With a Default Depth of 3:**
   - The application successfully processed and returned results up to depth **3**.
   - No crashes occurred, and responses remained within acceptable size limits.

3. **With Custom Depth Settings:**
   - Increasing the depth beyond **3** (e.g., to **4**) led to crashes again due to large response sizes.
   - Reducing the depth resulted in stable and expected behavior.


## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
No breaking changes - depth parameter is optional with default value 3.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
