### PR TITLE
Add a tool to fetch the repo labels

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -277,6 +277,15 @@ MCP Server for the GitHub API, enabling file operations, repository management, 
      - `pull_number` (number): Pull request number
    - Returns: Array of pull request reviews with details like the review state (APPROVED, CHANGES_REQUESTED, etc.), reviewer, and review body
 
+27. `list_repository_labels`
+   - List labels for a repository
+   - Inputs:
+     - `owner` (string): Repository owner (username or organization)
+     - `repo` (string): Repository name
+     - `page` (optional number): Page number for pagination (default: 1)
+     - `perPage` (optional number): Number of results per page (default: 30, max: 100)
+   - Returns: Array of repository labels with details like name, color, and description
+
 ## Search Query Syntax
 
 ### Code Search

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -200,6 +200,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_pull_request_reviews",
         description: "Get the reviews on a pull request",
         inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema)
+      },
+      {
+        name: "list_repository_labels",
+        description: "List all labels in a GitHub repository",
+        inputSchema: zodToJsonSchema(repository.ListRepositoryLabelsSchema),
       }
     ],
   };
@@ -488,6 +493,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
         return {
           content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
+        };
+      }
+      
+      case "list_repository_labels": {
+        const args = repository.ListRepositoryLabelsSchema.parse(request.params.arguments);
+        const { owner, repo, ...options } = args;
+        const labels = await repository.listRepositoryLabels(owner, repo, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(labels, null, 2) }],
         };
       }
 


### PR DESCRIPTION
## Description

This PR adds the ability for the GitHub server to fetch labels.

Before this change, asking for labels would result in the AI going off and searching for issues and possibly collecting the ones it finds. But sometimes it just breaks and gives up. After this change, there it is much better and always seems to just use the tool.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: tools

## Motivation and Context
Right now, the ability to fetch labels is mostly not working, this PR makes it far more reliable. The main use case for me is my Tirage bot that is going to try and apply and verify labels on issues and PRs.

## How Has This Been Tested?
I am testing this with my bot, which is just a prompt for now: https://github.com/mattleibow/AI-Triage/blob/58b74200d2242e61449d17c4c20719b1b8358097/.github/prompts/system.prompt.md#2-fetching-the-labels

## Breaking Changes
No breaks, just a new tool.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
