### PR TITLE
feat: add append_file tool to prevent errors caused by too long content

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -36,6 +36,13 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
     - `path` (string): File location
     - `content` (string): File content
 
+- **append_file**
+  - Append content to an existing file without overwriting previous content
+  - Inputs:
+    - `path` (string): File location
+    - `content` (string): Content to append
+  - Useful for adding content to log files or continuing content from previous operations
+
 - **edit_file**
   - Make selective edits using advanced pattern matching and formatting
   - Features:


### PR DESCRIPTION
Sometimes LLM generates long file contents that need to be generated in multiple consecutive responses. 
However, the write_file tool supports write-at-once only. So the write_file call with long response not applied to file content, because it is not properly closed, and it makes repeating file write failure.

So I made the following changes:
- added append_file tool, and its prompt
- updated the edit_file prompt to help LLM understand when to use it better

## Description

## Server Details
- Server: filesystem
- Changes to: tools, prompts

## Motivation and Context
I asked Calude Desktop to write a markdown file that contains a wide business research (total output was almost 24kB). While Claude Desktop trying to write the file, it failed repeatedly because Clauded encountered the output limit, so the write_file request is not closed successfuly.


## How Has This Been Tested?
After I add this append_file, I ran filesystem mcp server locally again, restarted Claude Desktop, and asked to do the same operation, and Claude did it well by using new tools.

## Breaking Changes
Not at all.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally - no test code exists, so created temporal test codes but not committed the test codes.
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
