### PR TITLE
Allows reading github token from the github cli

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -311,6 +311,13 @@ For detailed search syntax, see [GitHub's searching documentation](https://docs.
      - Alternatively, if working only with public repositories, select only the `public_repo` scope
    - Copy the generated token
 
+### Authenticate using GitHub CLI
+Instead of storing a GitHub Personal Access token in the configuration or environment, you can instruct the MCP server to rely on the GitHub CLI for authentication. This is useful when you have the GitHub CLI installed and already authenticated.
+
+To use the GitHub CLI for authentication, follow the steps below:
+   - add `"GITHUB_PERSONAL_ACCESS_TOKEN_USE_GHCLI": "true"` to your environment variables.
+   - Ensure you have the GitHub CLI installed and authenticated by running `gh auth login`.
+
 ### Usage with Claude Desktop
 To use this with Claude Desktop, add the following to your `claude_desktop_config.json`:
 
@@ -348,7 +355,8 @@ To use this with Claude Desktop, add the following to your `claude_desktop_confi
         "@modelcontextprotocol/server-github"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        "GITHUB_PERSONAL_ACCESS_TOKEN_USE_GHCLI": "true"
       }
     }
   }


### PR DESCRIPTION
## Description
If instructed using the
GITHUB_PERSONAL_ACCESS_TOKEN_USE_GHCLI
environment variable, the github token will be
read by calling `gh auth token`.

This simplifies usage of the MCP server inside
vscode and other local scenarios and doesn't
require storing the GitHub token in your
vscode settings or environment.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: authentication

## Motivation and Context
The current setup requires setting an environment variable or storing a sensitive PAT token
in the Visual Studio settings file. Plus, it requires the user to create an acces token 
with longer lifecycle than needed.

## How Has This Been Tested?
I tested this with Visual Studio Code

## Breaking Changes
If they want to opt in to this feature, yes. They need to add:

```json
"github": {
    "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN_USE_GHCLI": "true"
    }
}
```

Instead of supplying an access token.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
