### PR TITLE
fix: standardize search parameter naming to 'q'

### DIFF
--- a/src/github/operations/repository.ts
+++ b/src/github/operations/repository.ts
@@ -11,7 +11,7 @@ export const CreateRepositoryOptionsSchema = z.object({
 });
 
 export const SearchRepositoriesSchema = z.object({
-  query: z.string().describe("Search query (see GitHub search syntax)"),
+  q: z.string().describe("Search query (see GitHub search syntax)"),
   page: z.number().optional().describe("Page number for pagination (default: 1)"),
   perPage: z.number().optional().describe("Number of results per page (default: 30, max: 100)"),
 });
@@ -35,15 +35,14 @@ export async function createRepository(options: CreateRepositoryOptions) {
 }
 
 export async function searchRepositories(
-  query: string,
+  q: string,
   page: number = 1,
   perPage: number = 30
 ) {
   const url = new URL("https://api.github.com/search/repositories");
-  url.searchParams.append("q", query);
+  url.searchParams.append("q", q);
   url.searchParams.append("page", page.toString());
   url.searchParams.append("per_page", perPage.toString());
-
   const response = await githubRequest(url.toString());
   return GitHubSearchResponseSchema.parse(response);
 }
@@ -56,7 +55,6 @@ export async function forkRepository(
   const url = organization
     ? `https://api.github.com/repos/${owner}/${repo}/forks?organization=${organization}`
     : `https://api.github.com/repos/${owner}/${repo}/forks`;
-
   const response = await githubRequest(url, { method: "POST" });
   return GitHubRepositorySchema.extend({
     parent: GitHubRepositorySchema,


### PR DESCRIPTION
## Description
This PR fixes an inconsistency in parameter naming between different search operations. Some operations were using `query` (specifically in `SearchRepositoriesSchema`) while others were using `q`. This caused confusion for LLMs when using these tools.

## Changes
- Changed parameter name in `SearchRepositoriesSchema` from `query` to `q`  
- Updated the `searchRepositories()` function signature to match
- Ensures consistent naming with other search operations and GitHub's API

## Testing
- Verified schema validation works correctly with the new parameter
- Confirmed validation fails appropriately with the old parameter name

## Related Issues
Fixes #1080  (GitHub MCP Server: "q" vs "query" in parameters)

This change is a straightforward parameter naming standardization to improve consistency across the codebase.