### PR TITLE
Add GitHub Enterprise Support by adding flexible endpoint and optional user access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,11 @@
         "@modelcontextprotocol/server-postgres": "*",
         "@modelcontextprotocol/server-puppeteer": "*",
         "@modelcontextprotocol/server-sequential-thinking": "*",
-        "@modelcontextprotocol/server-slack": "*"
+        "@modelcontextprotocol/server-slack": "*",
+        "universal-user-agent": "^7.0.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.14.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1636,12 +1640,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -5039,9 +5043,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -19,15 +19,19 @@
     "link-all": "npm link --workspaces"
   },
   "dependencies": {
+    "@modelcontextprotocol/server-brave-search": "*",
+    "@modelcontextprotocol/server-everart": "*",
     "@modelcontextprotocol/server-everything": "*",
+    "@modelcontextprotocol/server-filesystem": "*",
     "@modelcontextprotocol/server-gdrive": "*",
+    "@modelcontextprotocol/server-memory": "*",
     "@modelcontextprotocol/server-postgres": "*",
     "@modelcontextprotocol/server-puppeteer": "*",
+    "@modelcontextprotocol/server-sequential-thinking": "*",
     "@modelcontextprotocol/server-slack": "*",
-    "@modelcontextprotocol/server-brave-search": "*",
-    "@modelcontextprotocol/server-memory": "*",
-    "@modelcontextprotocol/server-filesystem": "*",
-    "@modelcontextprotocol/server-everart": "*",
-    "@modelcontextprotocol/server-sequential-thinking": "*"
+    "universal-user-agent": "^7.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0"
   }
 }

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -2,6 +2,11 @@
 
 MCP Server for the GitHub API, enabling file operations, repository management, search functionality, and more.
 
+## Environment Variables
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN` (Optional): A GitHub Personal Access Token (PAT) with necessary scopes for accessing private repositories or performing write operations (e.g., `repo`, `write:discussion`). If not provided, the server operates with unauthenticated access, limited to public resources and lower rate limits.
+- `GITHUB_API_URL` (Optional): The base URL for the GitHub API. Defaults to `https://api.github.com`. Set this to use the server with GitHub Enterprise installations (e.g., `https://github.yourcompany.com/api/v3`).
+
 ### Features
 
 - **Automatic Branch Creation**: When creating/updating files or pushing changes, branches are automatically created if they don't exist

--- a/src/github/common/utils.ts
+++ b/src/github/common/utils.ts
@@ -2,6 +2,8 @@ import { getUserAgent } from "universal-user-agent";
 import { createGitHubError } from "./errors.js";
 import { VERSION } from "./version.js";
 
+export const GITHUB_API_URL = process.env.GITHUB_API_URL || "https://api.github.com";
+
 type RequestOptions = {
   method?: string;
   body?: unknown;
@@ -114,7 +116,7 @@ export async function checkBranchExists(
 ): Promise<boolean> {
   try {
     await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/branches/${branch}`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/branches/${branch}`
     );
     return true;
   } catch (error) {
@@ -127,7 +129,7 @@ export async function checkBranchExists(
 
 export async function checkUserExists(username: string): Promise<boolean> {
   try {
-    await githubRequest(`https://api.github.com/users/${username}`);
+    await githubRequest(`${GITHUB_API_URL}/users/${username}`);
     return true;
   } catch (error) {
     if (error && typeof error === "object" && "status" in error && error.status === 404) {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -27,16 +27,40 @@ import {
   isGitHubError,
 } from './common/errors.js';
 import { VERSION } from "./common/version.js";
+import { GITHUB_API_URL } from "./common/utils.js";
 
 // If fetch doesn't exist in global scope, add it
 if (!globalThis.fetch) {
   globalThis.fetch = fetch as unknown as typeof global.fetch;
 }
 
+// Determine server name and description based on API URL
+const DEFAULT_API_URL = "https://api.github.com";
+const isDefaultApiUrl = GITHUB_API_URL === DEFAULT_API_URL;
+let serverName = "github-mcp-server"; // Default name
+let serverDescription = ""; // Default description
+
+if (!isDefaultApiUrl) {
+  try {
+    // Attempt to parse the custom URL to extract the hostname
+    const apiUrlObject = new URL(GITHUB_API_URL);
+    // Use hostname for a more user-friendly name, fallback to full URL if needed
+    const identifier = apiUrlObject.hostname || GITHUB_API_URL;
+    serverName = `GitHub (${identifier})`;
+    serverDescription += ` This server targets the GitHub instance at ${GITHUB_API_URL}.`;
+  } catch (e) {
+    // Log error if URL is invalid, but continue with a modified default name
+    console.error(`Invalid GITHUB_API_URL format ('${GITHUB_API_URL}'). Using a generic name.`, e);
+    serverName = `GitHub (Custom: ${GITHUB_API_URL})`; // Indicate custom URL even if unparsable
+     serverDescription += ` This server targets a custom GitHub instance at ${GITHUB_API_URL}.`;
+  }
+}
+
 const server = new Server(
   {
-    name: "github-mcp-server",
+    name: serverName,
     version: VERSION,
+    description: serverDescription,
   },
   {
     capabilities: {

--- a/src/github/operations/branches.ts
+++ b/src/github/operations/branches.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest } from "../common/utils.js";
+import { githubRequest, GITHUB_API_URL } from "../common/utils.js";
 import { GitHubReferenceSchema } from "../common/types.js";
 
 // Schema definitions
@@ -22,13 +22,13 @@ export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 export async function getDefaultBranchSHA(owner: string, repo: string): Promise<string> {
   try {
     const response = await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/main`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/main`
     );
     const data = GitHubReferenceSchema.parse(response);
     return data.object.sha;
   } catch (error) {
     const masterResponse = await githubRequest(
-      `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/master`
+      `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/master`
     );
     if (!masterResponse) {
       throw new Error("Could not find default branch (tried 'main' and 'master')");
@@ -46,7 +46,7 @@ export async function createBranch(
   const fullRef = `refs/heads/${options.ref}`;
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs`,
     {
       method: "POST",
       body: {
@@ -65,7 +65,7 @@ export async function getBranchSHA(
   branch: string
 ): Promise<string> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`
   );
 
   const data = GitHubReferenceSchema.parse(response);
@@ -98,7 +98,7 @@ export async function updateBranch(
   sha: string
 ): Promise<z.infer<typeof GitHubReferenceSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`,
     {
       method: "PATCH",
       body: {

--- a/src/github/operations/commits.ts
+++ b/src/github/operations/commits.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest, buildUrl } from "../common/utils.js";
+import { githubRequest, buildUrl, GITHUB_API_URL } from "../common/utils.js";
 
 export const ListCommitsSchema = z.object({
   owner: z.string(),
@@ -17,7 +17,7 @@ export async function listCommits(
   sha?: string
 ) {
   return githubRequest(
-    buildUrl(`https://api.github.com/repos/${owner}/${repo}/commits`, {
+    buildUrl(`${GITHUB_API_URL}/repos/${owner}/${repo}/commits`, {
       page: page?.toString(),
       per_page: perPage?.toString(),
       sha

--- a/src/github/operations/files.ts
+++ b/src/github/operations/files.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest } from "../common/utils.js";
+import { githubRequest, GITHUB_API_URL } from "../common/utils.js";
 import {
   GitHubContentSchema,
   GitHubAuthorSchema,
@@ -75,7 +75,7 @@ export async function getFileContents(
   path: string,
   branch?: string
 ) {
-  let url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  let url = `${GITHUB_API_URL}/repos/${owner}/${repo}/contents/${path}`;
   if (branch) {
     url += `?ref=${branch}`;
   }
@@ -114,7 +114,7 @@ export async function createOrUpdateFile(
     }
   }
 
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  const url = `${GITHUB_API_URL}/repos/${owner}/${repo}/contents/${path}`;
   const body = {
     message,
     content: encodedContent,
@@ -144,7 +144,7 @@ async function createTree(
   }));
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/trees`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/trees`,
     {
       method: "POST",
       body: {
@@ -165,7 +165,7 @@ async function createCommit(
   parents: string[]
 ) {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/commits`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/commits`,
     {
       method: "POST",
       body: {
@@ -186,7 +186,7 @@ async function updateReference(
   sha: string
 ) {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/${ref}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/${ref}`,
     {
       method: "PATCH",
       body: {
@@ -207,7 +207,7 @@ export async function pushFiles(
   message: string
 ) {
   const refResponse = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`
   );
 
   const ref = GitHubReferenceSchema.parse(refResponse);

--- a/src/github/operations/issues.ts
+++ b/src/github/operations/issues.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest, buildUrl } from "../common/utils.js";
+import { githubRequest, buildUrl, GITHUB_API_URL } from "../common/utils.js";
 
 export const GetIssueSchema = z.object({
   owner: z.string(),
@@ -53,7 +53,7 @@ export const UpdateIssueOptionsSchema = z.object({
 });
 
 export async function getIssue(owner: string, repo: string, issue_number: number) {
-  return githubRequest(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}`);
+  return githubRequest(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}`);
 }
 
 export async function addIssueComment(
@@ -62,7 +62,7 @@ export async function addIssueComment(
   issue_number: number,
   body: string
 ) {
-  return githubRequest(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}/comments`, {
+  return githubRequest(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}/comments`, {
     method: "POST",
     body: { body },
   });
@@ -74,7 +74,7 @@ export async function createIssue(
   options: z.infer<typeof CreateIssueOptionsSchema>
 ) {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/issues`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/issues`,
     {
       method: "POST",
       body: options,
@@ -98,7 +98,7 @@ export async function listIssues(
   };
 
   return githubRequest(
-    buildUrl(`https://api.github.com/repos/${owner}/${repo}/issues`, urlParams)
+    buildUrl(`${GITHUB_API_URL}/repos/${owner}/${repo}/issues`, urlParams)
   );
 }
 
@@ -109,7 +109,7 @@ export async function updateIssue(
   options: Omit<z.infer<typeof UpdateIssueOptionsSchema>, "owner" | "repo" | "issue_number">
 ) {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${issue_number}`,
     {
       method: "PATCH",
       body: options,

--- a/src/github/operations/pulls.ts
+++ b/src/github/operations/pulls.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest } from "../common/utils.js";
+import { githubRequest, GITHUB_API_URL } from "../common/utils.js";
 import {
   GitHubPullRequestSchema,
   GitHubIssueAssigneeSchema,
@@ -166,7 +166,7 @@ export async function createPullRequest(
   const { owner, repo, ...options } = CreatePullRequestSchema.parse(params);
 
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls`,
     {
       method: "POST",
       body: options,
@@ -182,7 +182,7 @@ export async function getPullRequest(
   pullNumber: number
 ): Promise<z.infer<typeof GitHubPullRequestSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}`
   );
   return GitHubPullRequestSchema.parse(response);
 }
@@ -192,7 +192,7 @@ export async function listPullRequests(
   repo: string,
   options: Omit<z.infer<typeof ListPullRequestsSchema>, 'owner' | 'repo'>
 ): Promise<z.infer<typeof GitHubPullRequestSchema>[]> {
-  const url = new URL(`https://api.github.com/repos/${owner}/${repo}/pulls`);
+  const url = new URL(`${GITHUB_API_URL}/repos/${owner}/${repo}/pulls`);
   
   if (options.state) url.searchParams.append('state', options.state);
   if (options.head) url.searchParams.append('head', options.head);
@@ -213,7 +213,7 @@ export async function createPullRequestReview(
   options: Omit<z.infer<typeof CreatePullRequestReviewSchema>, 'owner' | 'repo' | 'pull_number'>
 ): Promise<z.infer<typeof PullRequestReviewSchema>> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`,
     {
       method: 'POST',
       body: options,
@@ -229,7 +229,7 @@ export async function mergePullRequest(
   options: Omit<z.infer<typeof MergePullRequestSchema>, 'owner' | 'repo' | 'pull_number'>
 ): Promise<any> {
   return githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/merge`,
     {
       method: 'PUT',
       body: options,
@@ -243,7 +243,7 @@ export async function getPullRequestFiles(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestFileSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/files`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/files`
   );
   return z.array(PullRequestFileSchema).parse(response);
 }
@@ -255,7 +255,7 @@ export async function updatePullRequestBranch(
   expectedHeadSha?: string
 ): Promise<void> {
   await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/update-branch`,
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/update-branch`,
     {
       method: "PUT",
       body: expectedHeadSha ? { expected_head_sha: expectedHeadSha } : undefined,
@@ -269,7 +269,7 @@ export async function getPullRequestComments(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestCommentSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/comments`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/comments`
   );
   return z.array(PullRequestCommentSchema).parse(response);
 }
@@ -280,7 +280,7 @@ export async function getPullRequestReviews(
   pullNumber: number
 ): Promise<z.infer<typeof PullRequestReviewSchema>[]> {
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`
   );
   return z.array(PullRequestReviewSchema).parse(response);
 }
@@ -290,13 +290,10 @@ export async function getPullRequestStatus(
   repo: string,
   pullNumber: number
 ): Promise<z.infer<typeof CombinedStatusSchema>> {
-  // First get the PR to get the head SHA
-  const pr = await getPullRequest(owner, repo, pullNumber);
-  const sha = pr.head.sha;
-
-  // Then get the combined status for that SHA
+  const pullRequest = await getPullRequest(owner, repo, pullNumber);
+  const sha = pullRequest.head.sha;
   const response = await githubRequest(
-    `https://api.github.com/repos/${owner}/${repo}/commits/${sha}/status`
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/commits/${sha}/status`
   );
   return CombinedStatusSchema.parse(response);
 }

--- a/src/github/operations/repository.ts
+++ b/src/github/operations/repository.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest } from "../common/utils.js";
+import { githubRequest, GITHUB_API_URL } from "../common/utils.js";
 import { GitHubRepositorySchema, GitHubSearchResponseSchema } from "../common/types.js";
 
 // Schema definitions
@@ -27,7 +27,7 @@ export type CreateRepositoryOptions = z.infer<typeof CreateRepositoryOptionsSche
 
 // Function implementations
 export async function createRepository(options: CreateRepositoryOptions) {
-  const response = await githubRequest("https://api.github.com/user/repos", {
+  const response = await githubRequest(`${GITHUB_API_URL}/user/repos`, {
     method: "POST",
     body: options,
   });
@@ -39,7 +39,7 @@ export async function searchRepositories(
   page: number = 1,
   perPage: number = 30
 ) {
-  const url = new URL("https://api.github.com/search/repositories");
+  const url = new URL(`${GITHUB_API_URL}/search/repositories`);
   url.searchParams.append("q", query);
   url.searchParams.append("page", page.toString());
   url.searchParams.append("per_page", perPage.toString());
@@ -54,8 +54,8 @@ export async function forkRepository(
   organization?: string
 ) {
   const url = organization
-    ? `https://api.github.com/repos/${owner}/${repo}/forks?organization=${organization}`
-    : `https://api.github.com/repos/${owner}/${repo}/forks`;
+    ? `${GITHUB_API_URL}/repos/${owner}/${repo}/forks?organization=${organization}`
+    : `${GITHUB_API_URL}/repos/${owner}/${repo}/forks`;
 
   const response = await githubRequest(url, { method: "POST" });
   return GitHubRepositorySchema.extend({

--- a/src/github/operations/search.ts
+++ b/src/github/operations/search.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { githubRequest, buildUrl } from "../common/utils.js";
+import { githubRequest, buildUrl, GITHUB_API_URL } from "../common/utils.js";
 
 export const SearchOptions = z.object({
   q: z.string(),
@@ -33,13 +33,13 @@ export const SearchUsersSchema = SearchUsersOptions;
 export const SearchIssuesSchema = SearchIssuesOptions;
 
 export async function searchCode(params: z.infer<typeof SearchCodeSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/code", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/code`, params));
 }
 
 export async function searchIssues(params: z.infer<typeof SearchIssuesSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/issues", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/issues`, params));
 }
 
 export async function searchUsers(params: z.infer<typeof SearchUsersSchema>) {
-  return githubRequest(buildUrl("https://api.github.com/search/users", params));
+  return githubRequest(buildUrl(`${GITHUB_API_URL}/search/users`, params));
 }


### PR DESCRIPTION
## Description
Add GitHub Enterprise Support
This PR introduces support for configuring the GitHub MCP server to connect to GitHub Enterprise instances by introducing two new optional environment variables:
* GITHUB_API_URL - to target custom GitHub API endpoints (e.g., https://github.yourcompany.com/api/v3)
* GITHUB_PERSONAL_ACCESS_TOKEN

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github)
- Changes to: Configuration, base URL 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Allows optionally connecting to an on prem enterprise installation of GitHub. Without the extra configuration it behaves like normal. (Also allows for having both private and public GitHub MCP servers simultaneously. )

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Used With Cline in VS Code

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Updated all internal API calls to use the configured GITHUB_API_URL instead of the default https://api.github.com.

Documentation:
Updated README.md to document the new GITHUB_API_URL environment variable and clarify the usage of GITHUB_PERSONAL_ACCESS_TOKEN.

Dependency Management:
Added universal-user-agent as a dependency.
