### PR TITLE
Update github CreatePullRequestReview schema to allow line or position

### DIFF
--- a/src/github/operations/pulls.ts
+++ b/src/github/operations/pulls.ts
@@ -112,11 +112,20 @@ export const CreatePullRequestReviewSchema = z.object({
   commit_id: z.string().optional().describe("The SHA of the commit that needs a review"),
   body: z.string().describe("The body text of the review"),
   event: z.enum(['APPROVE', 'REQUEST_CHANGES', 'COMMENT']).describe("The review action to perform"),
-  comments: z.array(z.object({
-    path: z.string().describe("The relative path to the file being commented on"),
-    position: z.number().describe("The position in the diff where you want to add a review comment"),
-    body: z.string().describe("Text of the review comment")
-  })).optional().describe("Comments to post as part of the review")
+  comments: z.array(
+    z.union([
+      z.object({
+        path: z.string().describe("The relative path to the file being commented on"),
+        position: z.number().describe("The position in the diff where you want to add a review comment"),
+        body: z.string().describe("Text of the review comment")
+      }),
+      z.object({
+        path: z.string().describe("The relative path to the file being commented on"),
+        line: z.number().describe("The line number in the file where you want to add a review comment"),
+        body: z.string().describe("Text of the review comment")
+      })
+    ])
+  ).optional().describe("Comments to post as part of the review (specify either position or line, not both)")
 });
 
 export const MergePullRequestSchema = z.object({


### PR DESCRIPTION
## Description

Allow either line or position in PR review comments, but not both, to align with GitHub API functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: github
- Changes to: tools

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Adding the ability to submit pull requests with line numbers instead of line positions. GitHub's API supports both: https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

Verified in MCP inspector and in Claude Code

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
