### PR TITLE
Add Aptos wallet MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Anki](https://github.com/scorzeth/anki-mcp-server)** - An MCP server for interacting with your [Anki](https://apps.ankiweb.net) decks and cards.
 - **[Any Chat Completions](https://github.com/pyroprompts/any-chat-completions-mcp)** - Interact with any OpenAI SDK Compatible Chat Completions API like OpenAI, Perplexity, Groq, xAI and many more.
 - **[Apple Calendar](https://github.com/Omar-v2/mcp-ical)** - An MCP server that allows you to interact with your MacOS Calendar through natural language, including features such as event creation, modification, schedule listing, finding free time slots etc.
+- **[Aptos Wallet](https://github.com/longcipher/aptos-wallet-mcp)** - A MCP server that allows you to interact with the aptos wallet via aptos-core SDK, written in Rust.
 - **[ArangoDB](https://github.com/ravenwits/mcp-server-arangodb)** - MCP Server that provides database interaction capabilities through [ArangoDB](https://arangodb.com/).
 - **[Arduino](https://github.com/vishalmysore/choturobo)** - MCP Server that enables AI-powered robotics using Claude AI and Arduino (ESP32) for real-world automation and interaction with robots.
 - **[Atlassian](https://github.com/sooperset/mcp-atlassian)** - Interact with Atlassian Cloud products (Confluence and Jira) including searching/reading Confluence spaces/pages, accessing Jira issues, and project metadata.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

A MCP server that allows you to interact with the aptos wallet via aptos-core SDK, written in Rust.

## Server Details

Support basic aptos wallet operations like get_blance, transfer, query tx status...