### PR TITLE
Add scheduled email support to Resend MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -867,6 +867,10 @@
       "resolved": "src/redis",
       "link": true
     },
+    "node_modules/@modelcontextprotocol/server-resend": {
+      "resolved": "src/resend",
+      "link": true
+    },
     "node_modules/@modelcontextprotocol/server-sequential-thinking": {
       "resolved": "src/sequentialthinking",
       "link": true
@@ -874,6 +878,12 @@
     "node_modules/@modelcontextprotocol/server-slack": {
       "resolved": "src/slack",
       "link": true
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -926,6 +936,21 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/@react-email/render": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-0.0.9.tgz",
+      "integrity": "sha512-nrim7wiACnaXsGtL7GF6jp3Qmml8J6vAjAH88jkC8lIbfNZaCyuPQHANjyYIXlvQeAbsWADQJFZgOHUqFqjh/A==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "9.0.5",
+        "pretty": "2.0.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@redis/bloom": {
       "version": "1.2.0",
@@ -984,6 +1009,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -1731,6 +1769,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2168,11 +2215,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2274,6 +2354,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-browser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
@@ -2369,6 +2458,61 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.6",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.6.tgz",
@@ -2408,6 +2552,48 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2432,6 +2618,18 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -2696,6 +2894,18 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -3162,6 +3372,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -3312,6 +3557,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -3346,6 +3597,12 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
@@ -3373,6 +3630,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3431,6 +3697,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -3461,6 +3736,80 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -3527,6 +3876,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3536,6 +3906,18 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
@@ -3716,6 +4098,21 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -3902,6 +4299,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3961,6 +4371,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -4169,6 +4588,20 @@
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "dev": true
     },
+    "node_modules/pretty": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==",
+      "license": "MIT",
+      "dependencies": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -4176,6 +4609,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4351,6 +4790,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -4373,6 +4837,18 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-2.1.0.tgz",
+      "integrity": "sha512-s6LlaEReTUvlbo6w3Eg1M1TMuwK9OKJ1GVgyptIV8smLPHhFZVqnwBTFPZHID9rcsih72t3iuyrtkQ3IIGwnow==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "0.0.9"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/resolve": {
@@ -4547,6 +5023,27 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -6222,6 +6719,36 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "src/resend": {
+      "name": "@modelcontextprotocol/server-resend",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.0.1",
+        "@types/node": "^22",
+        "resend": "^2.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "mcp-server-resend": "dist/index.js"
+      },
+      "devDependencies": {
+        "shx": "^0.3.4",
+        "typescript": "^5.6.2"
+      }
+    },
+    "src/resend/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-slLdFaxQJ9AlRg+hw28iiTtGvShAOgOKXcD0F91nUcRYiOMuS9ZBYjcdNZRXW9G5JQ511GRTdUy1zQVZDpJ+4w==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
       }
     },
     "src/sequentialthinking": {

--- a/src/resend/Dockerfile
+++ b/src/resend/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS runner
+
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package*.json ./
+
+RUN npm install --production
+
+ENV NODE_ENV=production
+
+ENTRYPOINT ["node", "dist/index.js"] 

--- a/src/resend/README.md
+++ b/src/resend/README.md
@@ -8,6 +8,7 @@ A Model Context Protocol (MCP) server for interacting with the [Resend](https://
 - Send emails using Resend templates
 - Support for attachments, CC, BCC, and reply-to addresses
 - Email tagging for tracking
+- Schedule emails for future delivery
 
 ## Setup
 
@@ -43,6 +44,18 @@ const result = await sendEmail({
 });
 ```
 
+### Sending a scheduled email
+
+```typescript
+const result = await sendEmail({
+  from: "Your Name <you@example.com>",
+  to: "recipient@example.com",
+  subject: "Scheduled Email from Resend",
+  html: "<p>This email was scheduled to be sent at a future time.</p>",
+  scheduled_at: "2023-12-31T23:59:59Z" // ISO 8601 timestamp
+});
+```
+
 ### Sending an email with a template
 
 ```typescript
@@ -75,6 +88,7 @@ Parameters:
 - `reply_to`: Reply-to email address
 - `attachments`: Array of file attachments
 - `tags`: Array of tags for tracking emails
+- `scheduled_at`: ISO 8601 timestamp for scheduling the email delivery
 
 ### `send_email_with_template`
 
@@ -91,6 +105,7 @@ Parameters:
 - `reply_to`: Reply-to email address
 - `attachments`: Array of file attachments
 - `tags`: Array of tags for tracking emails
+- `scheduled_at`: ISO 8601 timestamp for scheduling the email delivery
 
 ## License
 

--- a/src/resend/README.md
+++ b/src/resend/README.md
@@ -1,0 +1,97 @@
+# Resend MCP Server
+
+A Model Context Protocol (MCP) server for interacting with the [Resend](https://resend.com) email API. This server allows AI assistants to send emails programmatically.
+
+## Features
+
+- Send emails with HTML or plain text content
+- Send emails using Resend templates
+- Support for attachments, CC, BCC, and reply-to addresses
+- Email tagging for tracking
+
+## Setup
+
+### Prerequisites
+
+- Node.js 18 or higher
+- A Resend API key (get one at [resend.com](https://resend.com))
+
+### Installation
+
+```bash
+npm install -g @modelcontextprotocol/server-resend
+```
+
+### Usage
+
+To use this server, you need to provide your Resend API key:
+
+```bash
+RESEND_API_KEY=your_api_key npx @modelcontextprotocol/server-resend
+```
+
+## Examples
+
+### Sending a basic email
+
+```typescript
+const result = await sendEmail({
+  from: "Your Name <you@example.com>",
+  to: "recipient@example.com",
+  subject: "Hello from Resend",
+  html: "<h1>Hello World</h1><p>This is a test email sent via Resend.</p>"
+});
+```
+
+### Sending an email with a template
+
+```typescript
+const result = await sendEmailWithTemplate({
+  from: "Your Name <you@example.com>",
+  to: "recipient@example.com",
+  subject: "Hello from Resend",
+  template_id: "your_template_id",
+  data: {
+    name: "John Doe",
+    company: "Acme Inc."
+  }
+});
+```
+
+## Tools
+
+### `send_email`
+
+Sends an email using the Resend API.
+
+Parameters:
+- `from`: Sender email address (required)
+- `to`: Recipient email address or array of addresses (required)
+- `subject`: Email subject line (required)
+- `html`: HTML content of the email (either html or text is required)
+- `text`: Plain text content of the email (either html or text is required)
+- `cc`: Carbon copy recipients
+- `bcc`: Blind carbon copy recipients
+- `reply_to`: Reply-to email address
+- `attachments`: Array of file attachments
+- `tags`: Array of tags for tracking emails
+
+### `send_email_with_template`
+
+Sends an email using a Resend template.
+
+Parameters:
+- `from`: Sender email address (required)
+- `to`: Recipient email address or array of addresses (required)
+- `subject`: Email subject line (required)
+- `template_id`: ID of the template to use (required)
+- `data`: Data to populate the template (required)
+- `cc`: Carbon copy recipients
+- `bcc`: Blind carbon copy recipients
+- `reply_to`: Reply-to email address
+- `attachments`: Array of file attachments
+- `tags`: Array of tags for tracking emails
+
+## License
+
+MIT 

--- a/src/resend/common/errors.ts
+++ b/src/resend/common/errors.ts
@@ -1,0 +1,62 @@
+export class ResendError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly response: unknown
+  ) {
+    super(message);
+    this.name = "ResendError";
+  }
+}
+
+export class ResendValidationError extends ResendError {
+  constructor(message: string, status: number, response: unknown) {
+    super(message, status, response);
+    this.name = "ResendValidationError";
+  }
+}
+
+export class ResendAuthenticationError extends ResendError {
+  constructor(message = "Authentication failed") {
+    super(message, 401, { message });
+    this.name = "ResendAuthenticationError";
+  }
+}
+
+export class ResendRateLimitError extends ResendError {
+  constructor(
+    message = "Rate limit exceeded",
+    public readonly resetAt: Date
+  ) {
+    super(message, 429, { message, reset_at: resetAt.toISOString() });
+    this.name = "ResendRateLimitError";
+  }
+}
+
+export function isResendError(error: unknown): error is ResendError {
+  return error instanceof ResendError;
+}
+
+export function createResendError(status: number, response: any): ResendError {
+  switch (status) {
+    case 401:
+      return new ResendAuthenticationError(response?.message);
+    case 422:
+      return new ResendValidationError(
+        response?.message || "Validation failed",
+        status,
+        response
+      );
+    case 429:
+      return new ResendRateLimitError(
+        response?.message,
+        new Date(response?.reset_at || Date.now() + 60000)
+      );
+    default:
+      return new ResendError(
+        response?.message || "Resend API error",
+        status,
+        response
+      );
+  }
+} 

--- a/src/resend/common/types.ts
+++ b/src/resend/common/types.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Basic types
+export const EmailAddressSchema = z.string().email().describe("Valid email address");
+export const AttachmentSchema = z.object({
+  filename: z.string().describe("Filename of the attachment"),
+  content: z.string().describe("Content of the attachment (base64 encoded)"),
+  path: z.string().optional().describe("Optional path to the attachment file"),
+  contentType: z.string().optional().describe("MIME type of the attachment"),
+});
+
+// Email recipient types
+export const RecipientSchema = z.union([
+  EmailAddressSchema,
+  z.object({
+    email: EmailAddressSchema,
+    name: z.string().optional(),
+  }),
+]);
+
+// CC and BCC recipients are always arrays
+export const RecipientsArraySchema = z.array(RecipientSchema).describe("Array of email recipients");
+
+// But 'to' can be a single recipient or an array
+export const ToRecipientsSchema = z.union([
+  RecipientSchema,
+  RecipientsArraySchema,
+]).describe("Email recipient(s)");
+
+// Email content types
+export const EmailContentSchema = z.object({
+  html: z.string().optional().describe("HTML content of the email"),
+  text: z.string().optional().describe("Plain text content of the email"),
+  react: z.any().optional().describe("React component to render as email content"),
+});
+
+// Response type for sending an email
+export const SendEmailResponseSchema = z.object({
+  id: z.string().describe("ID of the sent email"),
+});
+
+// Type exports
+export type Attachment = z.infer<typeof AttachmentSchema>;
+export type Recipient = z.infer<typeof RecipientSchema>;
+export type RecipientsArray = z.infer<typeof RecipientsArraySchema>;
+export type ToRecipients = z.infer<typeof ToRecipientsSchema>;
+export type EmailContent = z.infer<typeof EmailContentSchema>;
+export type SendEmailResponse = z.infer<typeof SendEmailResponseSchema>; 

--- a/src/resend/common/utils.ts
+++ b/src/resend/common/utils.ts
@@ -1,0 +1,36 @@
+import { Resend } from 'resend';
+import { createResendError } from './errors.js';
+import { VERSION } from './version.js';
+
+let resendClient: Resend | null = null;
+
+export function getResendClient(): Resend {
+  if (!resendClient) {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error("RESEND_API_KEY environment variable is not set");
+    }
+    resendClient = new Resend(apiKey);
+  }
+  return resendClient;
+}
+
+export function validateEmail(email: string): boolean {
+  // Simple regex for email validation
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+export function validateAndFormatEmail(email: string, name?: string): string {
+  if (!validateEmail(email)) {
+    throw new Error(`Invalid email address: ${email}`);
+  }
+  
+  if (name) {
+    // Remove any special characters from the name to prevent injection
+    const sanitizedName = name.replace(/["<>]/g, '');
+    return `${sanitizedName} <${email}>`;
+  }
+  
+  return email;
+} 

--- a/src/resend/common/utils.ts
+++ b/src/resend/common/utils.ts
@@ -33,4 +33,27 @@ export function validateAndFormatEmail(email: string, name?: string): string {
   }
   
   return email;
+}
+
+export function validateScheduledTime(timestamp: string | undefined): string | undefined {
+  if (!timestamp) {
+    return undefined;
+  }
+
+  const scheduledDate = new Date(timestamp);
+  
+  // Check if date is valid
+  if (isNaN(scheduledDate.getTime())) {
+    throw new Error(`Invalid scheduled_at timestamp: ${timestamp}. Use ISO 8601 format (e.g., "2023-12-31T23:59:59Z").`);
+  }
+  
+  // Check if date is in the future (with a small buffer for processing)
+  const now = new Date();
+  const minSchedulingTime = new Date(now.getTime() + 60000); // 1 minute in the future
+  
+  if (scheduledDate < minSchedulingTime) {
+    throw new Error(`Scheduled time must be at least 1 minute in the future.`);
+  }
+  
+  return timestamp;
 } 

--- a/src/resend/common/version.ts
+++ b/src/resend/common/version.ts
@@ -1,0 +1,2 @@
+// Auto-generated and updated by publishing process
+export const VERSION = "0.1.0"; 

--- a/src/resend/index.ts
+++ b/src/resend/index.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import * as email from './operations/email.js';
+import * as templates from './operations/templates.js';
+import { isResendError } from './common/errors.js';
+import { VERSION } from "./common/version.js";
+
+const server = new Server(
+  {
+    name: "resend-mcp-server",
+    version: VERSION,
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+function formatResendError(error: Error): string {
+  let message = `Resend API Error: ${error.message}`;
+  
+  if (isResendError(error)) {
+    message = `Resend Error: ${error.message}`;
+    if (error.response) {
+      message += `\nDetails: ${JSON.stringify(error.response)}`;
+    }
+  }
+
+  return message;
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "send_email",
+        description: "Send an email using Resend API",
+        inputSchema: zodToJsonSchema(email.SendEmailSchema),
+      },
+      {
+        name: "send_email_with_template",
+        description: "Send an email using a Resend template",
+        inputSchema: zodToJsonSchema(templates.SendEmailWithTemplateSchema),
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    if (!request.params.arguments) {
+      throw new Error("Arguments are required");
+    }
+
+    switch (request.params.name) {
+      case "send_email": {
+        const args = email.SendEmailSchema.parse(request.params.arguments);
+        const result = await email.sendEmail(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "send_email_with_template": {
+        const args = templates.SendEmailWithTemplateSchema.parse(request.params.arguments);
+        const result = await templates.sendEmailWithTemplate(args);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    let errorMessage = error instanceof Error ? error.message : String(error);
+    
+    if (isResendError(error)) {
+      errorMessage = formatResendError(error);
+    }
+    
+    return {
+      content: [{ type: "text", text: JSON.stringify({ error: errorMessage }, null, 2) }],
+    };
+  }
+});
+
+async function runServer() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Resend MCP Server running on stdio");
+}
+
+runServer().catch((error) => {
+  console.error("Fatal server error:", error);
+  process.exit(1);
+}); 

--- a/src/resend/operations/email.ts
+++ b/src/resend/operations/email.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { getResendClient } from "../common/utils.js";
+import { getResendClient, validateScheduledTime } from "../common/utils.js";
 import {
   AttachmentSchema,
   ToRecipientsSchema,
@@ -25,6 +25,7 @@ export const SendEmailSchema = z.object({
       value: z.string(),
     })
   ).optional().describe("Tags for tracking emails"),
+  scheduled_at: z.string().optional().describe("ISO timestamp for scheduling the email delivery"),
 });
 
 // Function implementations
@@ -43,6 +44,9 @@ export async function sendEmail(params: z.infer<typeof SendEmailSchema>) {
   };
 
   try {
+    // Validate scheduled_at timestamp if provided
+    const validatedScheduledAt = validateScheduledTime(params.scheduled_at);
+    
     // Prepare email options based on content type
     const emailOptions: any = {
       from: params.from,
@@ -55,6 +59,7 @@ export async function sendEmail(params: z.infer<typeof SendEmailSchema>) {
       bcc: params.bcc?.map(formatRecipient),
       attachments: params.attachments,
       tags: params.tags,
+      scheduled_at: validatedScheduledAt,
     };
     
     // Add content (html or text)

--- a/src/resend/operations/email.ts
+++ b/src/resend/operations/email.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { getResendClient } from "../common/utils.js";
+import {
+  AttachmentSchema,
+  ToRecipientsSchema,
+  RecipientsArraySchema,
+  EmailContentSchema,
+  SendEmailResponseSchema,
+} from "../common/types.js";
+
+// Schema definitions
+export const SendEmailSchema = z.object({
+  from: z.string().describe("Sender email address or formatted 'Name <email@example.com>'"),
+  to: ToRecipientsSchema.describe("Recipient(s) of the email"),
+  subject: z.string().describe("Email subject line"),
+  cc: RecipientsArraySchema.optional().describe("Carbon copy recipients"),
+  bcc: RecipientsArraySchema.optional().describe("Blind carbon copy recipients"),
+  reply_to: z.string().optional().describe("Reply-to email address"),
+  html: z.string().optional().describe("HTML content of the email"),
+  text: z.string().optional().describe("Plain text content of the email"),
+  attachments: z.array(AttachmentSchema).optional().describe("Array of attachments"),
+  tags: z.array(
+    z.object({
+      name: z.string(),
+      value: z.string(),
+    })
+  ).optional().describe("Tags for tracking emails"),
+});
+
+// Function implementations
+export async function sendEmail(params: z.infer<typeof SendEmailSchema>) {
+  const resend = getResendClient();
+  
+  // Ensuring at least one content type is provided
+  if (!params.html && !params.text) {
+    throw new Error("Either html or text content must be provided");
+  }
+
+  // Convert complex recipient types to strings for the Resend API
+  const formatRecipient = (recipient: string | { email: string; name?: string }): string => {
+    if (typeof recipient === 'string') return recipient;
+    return recipient.name ? `${recipient.name} <${recipient.email}>` : recipient.email;
+  };
+
+  try {
+    // Prepare email options based on content type
+    const emailOptions: any = {
+      from: params.from,
+      to: Array.isArray(params.to) 
+        ? params.to.map(formatRecipient) 
+        : [formatRecipient(params.to)],
+      subject: params.subject,
+      reply_to: params.reply_to,
+      cc: params.cc?.map(formatRecipient),
+      bcc: params.bcc?.map(formatRecipient),
+      attachments: params.attachments,
+      tags: params.tags,
+    };
+    
+    // Add content (html or text)
+    if (params.html) {
+      emailOptions.html = params.html;
+    }
+    if (params.text) {
+      emailOptions.text = params.text;
+    }
+
+    const { data, error } = await resend.emails.send(emailOptions);
+
+    if (error) {
+      throw new Error(`Failed to send email: ${error.message}`);
+    }
+
+    return SendEmailResponseSchema.parse(data);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Unexpected error: ${String(error)}`);
+  }
+} 

--- a/src/resend/operations/templates.ts
+++ b/src/resend/operations/templates.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { getResendClient } from "../common/utils.js";
+import { getResendClient, validateScheduledTime } from "../common/utils.js";
 import { SendEmailResponseSchema } from "../common/types.js";
 
 // Schema definitions
@@ -24,6 +24,7 @@ export const SendEmailWithTemplateSchema = z.object({
       value: z.string(),
     })
   ).optional().describe("Tags for tracking emails"),
+  scheduled_at: z.string().optional().describe("ISO timestamp for scheduling the email delivery"),
 });
 
 // Function implementations
@@ -31,6 +32,9 @@ export async function sendEmailWithTemplate(params: z.infer<typeof SendEmailWith
   const resend = getResendClient();
 
   try {
+    // Validate scheduled_at timestamp if provided
+    const validatedScheduledAt = validateScheduledTime(params.scheduled_at);
+    
     // Prepare the API payload
     const emailOptions: any = {
       from: params.from,
@@ -41,6 +45,7 @@ export async function sendEmailWithTemplate(params: z.infer<typeof SendEmailWith
       bcc: params.bcc,
       attachments: params.attachments,
       tags: params.tags,
+      scheduled_at: validatedScheduledAt,
     };
 
     // Add template information - checking docs, Resend might use different fields

--- a/src/resend/operations/templates.ts
+++ b/src/resend/operations/templates.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import { getResendClient } from "../common/utils.js";
+import { SendEmailResponseSchema } from "../common/types.js";
+
+// Schema definitions
+export const SendEmailWithTemplateSchema = z.object({
+  from: z.string().describe("Sender email address or formatted 'Name <email@example.com>'"),
+  to: z.union([z.string(), z.array(z.string())]).describe("Recipient(s) of the email"),
+  subject: z.string().describe("Email subject line"),
+  reply_to: z.string().optional().describe("Reply-to email address"),
+  template_id: z.string().describe("ID of the template to use"),
+  data: z.record(z.any()).describe("Data to populate the template"),
+  cc: z.union([z.string(), z.array(z.string())]).optional().describe("Carbon copy recipients"),
+  bcc: z.union([z.string(), z.array(z.string())]).optional().describe("Blind carbon copy recipients"),
+  attachments: z.array(
+    z.object({
+      filename: z.string(),
+      content: z.string(),
+    })
+  ).optional().describe("Array of attachments"),
+  tags: z.array(
+    z.object({
+      name: z.string(),
+      value: z.string(),
+    })
+  ).optional().describe("Tags for tracking emails"),
+});
+
+// Function implementations
+export async function sendEmailWithTemplate(params: z.infer<typeof SendEmailWithTemplateSchema>) {
+  const resend = getResendClient();
+
+  try {
+    // Prepare the API payload
+    const emailOptions: any = {
+      from: params.from,
+      to: params.to,
+      subject: params.subject,
+      reply_to: params.reply_to,
+      cc: params.cc,
+      bcc: params.bcc,
+      attachments: params.attachments,
+      tags: params.tags,
+    };
+
+    // Add template information - checking docs, Resend might use different fields
+    // depending on your template type (using any to bypass TypeScript checks)
+    emailOptions.template = params.template_id;
+    emailOptions.data = params.data;
+
+    const { data, error } = await resend.emails.send(emailOptions);
+
+    if (error) {
+      throw new Error(`Failed to send email with template: ${error.message}`);
+    }
+
+    return SendEmailResponseSchema.parse(data);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Unexpected error: ${String(error)}`);
+  }
+} 

--- a/src/resend/package.json
+++ b/src/resend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@modelcontextprotocol/server-resend",
+  "version": "0.1.0",
+  "description": "MCP server for using the Resend API",
+  "license": "MIT",
+  "author": "Anthropic, PBC (https://anthropic.com)",
+  "homepage": "https://modelcontextprotocol.io",
+  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "type": "module",
+  "bin": {
+    "mcp-server-resend": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && shx chmod +x dist/*.js",
+    "prepare": "npm run build",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.0.1",
+    "@types/node": "^22",
+    "resend": "^2.0.0",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "shx": "^0.3.4",
+    "typescript": "^5.6.2"
+  }
+} 

--- a/src/resend/tsconfig.json
+++ b/src/resend/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+} 


### PR DESCRIPTION
## Description
Add support for scheduled emails using Resend's scheduled_at parameter

## Server Details
- Server: resend
- Changes to: tools, feature enhancements

## Motivation and Context
This PR adds the ability to schedule emails for future delivery using the Resend API's scheduled_at parameter. This is a valuable feature for many use cases like marketing campaigns, reminder emails, and timed notifications. The enhancement follows Resend's official API specification and includes proper validation of the timestamp input.

## How Has This Been Tested?
- Tested with both direct emails and template emails
- Verified that timestamp validation prevents invalid scheduled dates
- Confirmed compatibility with Resend's API documentation

## Breaking Changes
No breaking changes. This addition is entirely backward compatible.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The implementation includes validation to ensure:
1. The timestamp is a valid ISO 8601 format
2. The scheduled date is at least 1 minute in the future
3. Proper error handling if invalid timestamps are provided