### PR TITLE
GitHub MCP server deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Webflow](https://github.com/kapilduraphe/webflow-mcp-server)** - Interfact with the Webflow APIs
 - **[whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp)**  -  A mcp server for tracking cryptocurrency whale transactions. 
 - **[Whois MCP](https://github.com/bharathvaj-ganesan/whois-mcp)** - MCP server that performs whois lookup against domain, IP, ASN and TLD. 
+- **[Wikidata MCP](https://github.com/zzaebok/mcp-wikidata)** - Wikidata MCP server that interact with Wikidata, by searching identifiers, extracting metadata, and executing sparql query.
 - **[WildFly MCP](https://github.com/wildfly-extras/wildfly-mcp)** - WildFly MCP server that enables LLM to interact with running WildFly servers (retrieve metrics, logs, invoke operations, ...).
 - **[Windows CLI](https://github.com/SimonB97/win-cli-mcp-server)** - MCP server for secure command-line interactions on Windows systems, enabling controlled access to PowerShell, CMD, and Git Bash shells.
 - **[World Bank data API](https://github.com/anshumax/world_bank_mcp_server)** - A server that fetches data indicators available with the World Bank as part of their data API

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -1,5 +1,9 @@
 # GitHub MCP Server
 
+**Deprecation Notice:** Development for this project has been moved to GitHub in the http://github.com/github/github-mcp-server repo.
+
+---
+
 MCP Server for the GitHub API, enabling file operations, repository management, search functionality, and more.
 
 ### Features


### PR DESCRIPTION
## Description

GitHub has taken ownership of the [GitHub MCP Server](https://github.com/github/github-mcp-server). This Pull request adds a deprecation notice to the old server.

## Server Details

- Server: GitHub
- Changes to: README

