### PR TITLE
update readme - add revit mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Redis](https://github.com/prajwalnayak7/mcp-server-redis)** MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate
 - **[Rememberizer AI](https://github.com/skydeckai/mcp-server-rememberizer)** - An MCP server designed for interacting with the Rememberizer data source, facilitating enhanced knowledge retrieval.
 - **[Replicate](https://github.com/deepfates/mcp-replicate)** - Search, run and manage machine learning models on Replicate through a simple tool-based interface. Browse models, create predictions, track their status, and handle generated images.
+- [**Revit MCP**](https://github.com/revit-mcp) - A service implementing the MCP protocol for Autodesk Revit.
 - **[Rquest](https://github.com/xxxbrian/mcp-rquest)** - An MCP server providing realistic browser-like HTTP request capabilities with accurate TLS/JA3/JA4 fingerprints for bypassing anti-bot measures.
 - **[Rijksmuseum](https://github.com/r-huijts/rijksmuseum-mcp)** - Interface with the Rijksmuseum API to search artworks, retrieve artwork details, access image tiles, and explore user collections.
 - **[Salesforce MCP](https://github.com/smn2gnt/MCP-Salesforce)** - Interact with Salesforce Data and Metadata

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Redis](https://github.com/prajwalnayak7/mcp-server-redis)** MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate
 - **[Rememberizer AI](https://github.com/skydeckai/mcp-server-rememberizer)** - An MCP server designed for interacting with the Rememberizer data source, facilitating enhanced knowledge retrieval.
 - **[Replicate](https://github.com/deepfates/mcp-replicate)** - Search, run and manage machine learning models on Replicate through a simple tool-based interface. Browse models, create predictions, track their status, and handle generated images.
-- [**Revit MCP**](https://github.com/revit-mcp) - A service implementing the MCP protocol for Autodesk Revit.
+- **[Revit MCP](https://github.com/revit-mcp)** - A service implementing the MCP protocol for Autodesk Revit.
 - **[Rquest](https://github.com/xxxbrian/mcp-rquest)** - An MCP server providing realistic browser-like HTTP request capabilities with accurate TLS/JA3/JA4 fingerprints for bypassing anti-bot measures.
 - **[Rijksmuseum](https://github.com/r-huijts/rijksmuseum-mcp)** - Interface with the Rijksmuseum API to search artworks, retrieve artwork details, access image tiles, and explore user collections.
 - **[Salesforce MCP](https://github.com/smn2gnt/MCP-Salesforce)** - Interact with Salesforce Data and Metadata


### PR DESCRIPTION
## Description

Added an official MCP community project link (https://github.com/revit-mcp) for Autodesk Revit (Revit MCP) to the README documentation. This project provides MCP protocol implementation solutions for developers using the Revit platform.

## Server Details

- Modified file: README.md
- Change type: Documentation update only

## Motivation and Context

1. **Industry Background**: Revit is Autodesk's leading BIM design platform with millions of users in AEC (Architecture/Engineering/Construction) industries
2. **Community Need**: Revit MCP offers an open-source middleware solution for construction industry developers
3. **Ecosystem Growth**: Recommending quality community projects to foster cross-platform MCP ecosystem development

## Breaking Changes

None (documentation addition doesn't affect existing functionality)

## Types of Changes

- Documentation Update

## Additional Context

1. **Project Scope**: Revit MCP serves as a bridge component between Autodesk Revit and MCP protocol, enabling AI-powered BIM data interaction and command-driven capabilities
2. **Recommendation Basis**: The project has implemented core functionalities like real-time MCP event streaming for Revit model changes with high code quality