### PR TITLE
feat: add Job Searcher MCP server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[JavaFX](https://github.com/mcpso/mcp-server-javafx)** - Make drawings using a JavaFX canvas
 - **[JDBC](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc)** - Connect to any JDBC-compatible database and query, insert, update, delete, and more. Supports MySQL, PostgreSQL, Oracle, SQL Server, sqllite and [more](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc#supported-jdbc-variants).
 - **[JSON](https://github.com/GongRzhe/JSON-MCP-Server)** - JSON handling and processing server with advanced query capabilities using JSONPath syntax and support for array, string, numeric, and date operations.
+- **[Job Searcher](https://github.com/0xDAEF0F/job-searchoor)** - A FastMCP server that provides tools for retrieving and filtering job listings based on time period, keywords, and remote work preferences.
 - **[KiCad MCP](https://github.com/lamaalrajih/kicad-mcp)** - MCP server for KiCad on Mac, Windows, and Linux.
 - **[Keycloak MCP](https://github.com/ChristophEnglisch/keycloak-model-context-protocol)** - This MCP server enables natural language interaction with Keycloak for user and realm management including creating, deleting, and listing users and realms.
 - **[Kibela](https://github.com/kiwamizamurai/mcp-kibela-server)** (by kiwamizamurai) - Interact with Kibela API.


### PR DESCRIPTION
## Description
Adding the job-searchoor MCP server to the list of available MCP servers in the README.md.

## Server Details
- Server: job-searchoor
- Changes to: Added new server to the README.md list

## Motivation and Context
The job-searchoor MCP server provides a useful tool for retrieving and filtering job listings based on time period, keywords, and remote work preferences. Adding it to the list of available MCP servers will increase visibility and adoption.

## How Has This Been Tested?
The server has been tested with Claude AI and the debugger tool from mcp, retrieving job listings with various filtering options such as time periods (e.g., '1d', '1w'), keyword filters, and remote work preferences. All functionality works as expected.

## Breaking Changes
No breaking changes. This is a new server addition that doesn't affect existing functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The job-searchoor server is implemented in TypeScript and works with standard MCP clients like Claude. It provides a straightforward API for retrieving job listings with flexible filtering options.