### PR TITLE
docs: add Todos MCP server to community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[TFT-Match-Analyzer](https://github.com/GeLi2001/tft-mcp-server)** - MCP server for teamfight tactics match history & match details fetching, providing user the detailed context for every match.
 - **[Ticketmaster](https://github.com/delorenj/mcp-server-ticketmaster)** - Search for events, venues, and attractions through the Ticketmaster Discovery API
 - **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Interact with Todoist to manage your tasks.
+- **[Todos](https://github.com/tomelliot/mcp-todos)** - A practical todo list manager to use with your favourite chatbot.
 - **[Typesense](https://github.com/suhail-ak-s/mcp-typesense-server)** - A Model Context Protocol (MCP) server implementation that provides AI models with access to Typesense search capabilities. This server enables LLMs to discover, search, and analyze data stored in Typesense collections.
 - **[Travel Planner](https://github.com/GongRzhe/TRAVEL-PLANNER-MCP-Server)** - Travel planning and itinerary management server integrating with Google Maps API for location search, place details, and route calculations.
 - **[Unity Catalog](https://github.com/ognis1205/mcp-server-unitycatalog)** - An MCP server that enables LLMs to interact with Unity Catalog AI, supporting CRUD operations on Unity Catalog Functions and executing them as MCP tools.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
- Server: todos

## Motivation and Context

Being able to use a todo list with a chatbot is very convenient - ("run through this transcript and add any of my todos to my todo list"). Other todo list applications require a 3rd party service to work, this is a local only solution.

## How Has This Been Tested?
Tested with Claude Desktop 0.9.1


https://github.com/user-attachments/assets/ae12d21d-0067-426c-80d8-d13690f19c98



## Breaking Changes
None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

A community developed and maintained [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that provides a locally stored todo list - no signup for a service required. Built for use with MCP-compatible [clients](https://modelcontextprotocol.io/clients).