### PR TITLE
fix: use default HEAD as ref

### DIFF
--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -262,7 +262,6 @@ export const CreateRepositorySchema = z.object({
 });
 
 export const GetFileContentsSchema = ProjectParamsSchema.extend({
-  project_id: z.string().describe("Project ID or URL-encoded path"),
   file_path: z.string().describe("Path to the file or directory"),
   ref: z.string().optional().describe("Branch/tag/commit to get contents from")
 });

--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -262,6 +262,7 @@ export const CreateRepositorySchema = z.object({
 });
 
 export const GetFileContentsSchema = ProjectParamsSchema.extend({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
   file_path: z.string().describe("Path to the file or directory"),
   ref: z.string().optional().describe("Branch/tag/commit to get contents from")
 });


### PR DESCRIPTION
## Description
This PR fixes the `get_file_contents` tool, as the ref is optional for the AI, but not set when a request is made to the gitlab API. It also sets the default ref to `HEAD` for the `create_branch` tool, this avoids making an unnecessary API request to retrieve it. 

## Server Details
- Server: gitlab
- Changes to: tools

## Motivation and Context
The `get_file_contents` has an optional `ref` parameter for the AI tooling, but is not set properly in the API request when omitted by the AI.

## How Has This Been Tested?
Yeah have tested the MCP locally

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
See [Repository Files API Gitlab Documentation](https://docs.gitlab.com/api/repository_files/)

Attribute | Type | Required | Description
-- | -- | -- | --
id | integer or string | yes | The ID or URL-encoded path of the project.
file_path | string | yes | URL encoded full path to new file, such as lib%2Fclass%2Erb.
ref | string | yes | The name of branch, tag or commit. Use HEAD to automatically use the default branch.

If you don’t know the branch name or want to use the default branch, you can use HEAD as the ref value. For example:

```Shell
curl --header "PRIVATE-TOKEN: " \
  --url "https://gitlab.example.com/api/v4/projects/13083/repository/files/app%2Fmodels%2Fkey%2Erb?ref=HEAD"
  ```