### PR TITLE
feat: Gitlab list repository tree tool

### DIFF
--- a/src/gitlab/README.md
+++ b/src/gitlab/README.md
@@ -38,7 +38,7 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `search` (string): Search query
      - `page` (optional number): Page number for pagination
      - `per_page` (optional number): Results per page (default 20)
-   - Returns: Project search results
+   - Returns: Project search results with total count
 
 4. `create_repository`
    - Create a new GitLab project
@@ -49,15 +49,27 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `initialize_with_readme` (optional boolean): Initialize with README
    - Returns: Created project details
 
-5. `get_file_contents`
+5. `list_repository_tree`
+   - List files and directories in a repository
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `path` (optional string): Path to list contents from
+     - `ref` (optional string): Branch/tag/commit to list from
+     - `recursive` (optional boolean): List recursively
+     - `per_page` (optional number): Results per page
+     - `page_token` (optional string): Token for pagination
+     - `pagination` (optional string): Pagination type
+   - Returns: List of files and directories with their metadata
+
+6. `get_file_contents`
    - Get contents of a file or directory
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
      - `file_path` (string): Path to file/directory
      - `ref` (optional string): Branch/tag/commit to get contents from
-   - Returns: File/directory contents
+   - Returns: File/directory contents with metadata
 
-6. `create_issue`
+7. `create_issue`
    - Create a new issue
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
@@ -68,7 +80,7 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `milestone_id` (optional number): Milestone ID
    - Returns: Created issue details
 
-7. `create_merge_request`
+8. `create_merge_request`
    - Create a new merge request
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
@@ -80,14 +92,14 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `allow_collaboration` (optional boolean): Allow commits from upstream members
    - Returns: Created merge request details
 
-8. `fork_repository`
+9. `fork_repository`
    - Fork a project
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
      - `namespace` (optional string): Namespace to fork to
    - Returns: Forked project details
 
-9. `create_branch`
+10. `create_branch`
    - Create a new branch
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path

--- a/src/gitlab/index.ts
+++ b/src/gitlab/index.ts
@@ -20,6 +20,8 @@ import {
   GitLabSearchResponseSchema,
   GitLabTreeSchema,
   GitLabCommitSchema,
+  GitLabTreeItemSchema,
+  GetRepositoryTreeSchema,
   CreateRepositoryOptionsSchema,
   CreateIssueOptionsSchema,
   CreateMergeRequestOptionsSchema,
@@ -44,6 +46,7 @@ import {
   type GitLabTree,
   type GitLabCommit,
   type FileOperation,
+  type GitLabTreeItem,
 } from './schemas.js';
 
 const server = new Server({
@@ -127,6 +130,40 @@ async function getDefaultBranchRef(projectId: string): Promise<string> {
 
   const project = GitLabRepositorySchema.parse(await response.json());
   return project.default_branch;
+}
+
+async function getRepositoryTree(
+  projectId: string,
+  options: z.infer<typeof GetRepositoryTreeSchema>
+): Promise<GitLabTreeItem[]> {
+  const queryParams = new URLSearchParams();
+  if (options.path) queryParams.append('path', options.path);
+  if (options.ref) queryParams.append('ref', options.ref);
+  if (options.recursive) queryParams.append('recursive', 'true');
+  if (options.per_page) queryParams.append('per_page', options.per_page.toString());
+  if (options.page_token) queryParams.append('page_token', options.page_token);
+  if (options.pagination) queryParams.append('pagination', options.pagination);
+
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/tree?${queryParams.toString()}`,
+    {
+      headers: {
+        'Authorization': `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (response.status === 404) {
+    throw new Error('Repository or path not found');
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to get repository tree: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return z.array(GitLabTreeItemSchema).parse(data);
 }
 
 async function getFileContents(
@@ -394,6 +431,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: zodToJsonSchema(CreateRepositorySchema)
       },
       {
+        name: "list_repository_tree",
+        description: "Get the tree of a GitLab project at a specific path",
+        inputSchema: zodToJsonSchema(GetRepositoryTreeSchema)
+      },
+      {
         name: "get_file_contents",
         description: "Get the contents of a file or directory from a GitLab project",
         inputSchema: zodToJsonSchema(GetFileContentsSchema)
@@ -465,6 +507,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const args = CreateRepositorySchema.parse(request.params.arguments);
         const repository = await createRepository(args);
         return { content: [{ type: "text", text: JSON.stringify(repository, null, 2) }] };
+      }
+
+      case "list_repository_tree": {
+        const args = GetRepositoryTreeSchema.parse(request.params.arguments);
+        const tree = await getRepositoryTree(args.project_id, args);
+        return { content: [{ type: "text", text: JSON.stringify(tree, null, 2) }] };
       }
 
       case "get_file_contents": {

--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -80,6 +80,25 @@ export const GitLabTreeSchema = z.object({
   tree: z.array(GitLabTreeEntrySchema)
 });
 
+// Repository tree schemas
+export const GitLabTreeItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(['tree', 'blob']),
+  path: z.string(),
+  mode: z.string()
+});
+
+export const GetRepositoryTreeSchema = z.object({
+  project_id: z.string().describe("The ID or URL-encoded path of the project"),
+  path: z.string().optional().describe("The path inside the repository"),
+  ref: z.string().optional().describe("The name of a repository branch or tag. Defaults to the default branch."),
+  recursive: z.boolean().optional().describe("Boolean value to get a recursive tree"),
+  per_page: z.number().optional().describe("Number of results to show per page"),
+  page_token: z.string().optional().describe("The tree record ID for pagination"),
+  pagination: z.string().optional().describe("Pagination method (keyset)")
+});
+
 export const GitLabCommitSchema = z.object({
   id: z.string(), // Changed from sha to match GitLab API
   short_id: z.string(), // Added to match GitLab API
@@ -263,7 +282,7 @@ export const CreateRepositorySchema = z.object({
 
 export const GetFileContentsSchema = ProjectParamsSchema.extend({
   file_path: z.string().describe("Path to the file or directory"),
-  ref: z.string().optional().describe("Branch/tag/commit to get contents from")
+  ref: z.string().optional().describe("Branch/tag/commit to get contents from. Defaults to the default branch.")
 });
 
 export const PushFilesSchema = ProjectParamsSchema.extend({
@@ -301,7 +320,7 @@ export const ForkRepositorySchema = ProjectParamsSchema.extend({
 export const CreateBranchSchema = ProjectParamsSchema.extend({
   branch: z.string().describe("Name for the new branch"),
   ref: z.string().optional()
-    .describe("Source branch/commit for new branch")
+    .describe("Source branch/commit for new branch. Defaults to the default branch.")
 });
 
 // Export types
@@ -323,3 +342,4 @@ export type CreateMergeRequestOptions = z.infer<typeof CreateMergeRequestOptions
 export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 export type GitLabCreateUpdateFileResponse = z.infer<typeof GitLabCreateUpdateFileResponseSchema>;
 export type GitLabSearchResponse = z.infer<typeof GitLabSearchResponseSchema>;
+export type GitLabTreeItem = z.infer<typeof GitLabTreeItemSchema>;


### PR DESCRIPTION
This PR adds a `list_repository_tree` tool for the Gitlab MCP, so AI agents can explore repositories interactively.

## Description
This PR adds a `list_repository_tree` tool for the Gitlab MCP, so It can explore a repository interactively. It wraps around the corresponding [List repository tree](https://docs.gitlab.com/api/repositories/#list-repository-tree).

## Server Details
- Server: gitlab
- Changes to: tools

## Motivation and Context
The AI agents are in the dark regarding the structure of a repository and can only read specific files in their entirety. This PR adds the `list_repository_tree` to allow the AI to explore the repository before reading/updating specific files.

## How Has This Been Tested?
Yes, have tested locally using `Claude Sonnet 3.7`

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
See [List repository tree - Gitlab Documentation](https://docs.gitlab.com/api/repositories/#list-repository-tree).

Get a list of repository files and directories in a project. This endpoint can be accessed without authentication if the repository is publicly accessible.

This command provides essentially the same features as the git ls-tree command. For more information, refer to the section [Tree Objects](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects.html#_tree_objects) in the Git internals documentation.

Attribute | Type | Required | Description
-- | -- | -- | --
id | integer or string | yes | The ID or URL-encoded path of the project.
page_token | string | no | The tree record ID at which to fetch the next page. Used only with keyset pagination.
pagination | string | no | If keyset, use the keyset-based pagination method.
path | string | no | The path inside the repository. Used to get content of subdirectories.
per_page | integer | no | Number of results to show per page. If not specified, defaults to 20. For more information, see Pagination.
recursive | boolean | no | Boolean value used to get a recursive tree. Default is false.
ref | string | no | The name of a repository branch or tag or, if not given, the default branch.