### PR TITLE
Add ChuckNorris MCP server to Community Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[CFBD API](https://github.com/lenwood/cfbd-mcp-server)** - An MCP server for the [College Football Data API](https://collegefootballdata.com/).
 - **[ChatMCP](https://github.com/AI-QL/chat-mcp)** – An Open Source Cross-platform GUI Desktop application compatible with Linux, macOS, and Windows, enabling seamless interaction with MCP servers across dynamically selectable LLMs, by **[AIQL](https://github.com/AI-QL)**
 - **[ChatSum](https://github.com/mcpso/mcp-server-chatsum)** - Query and Summarize chat messages with LLM. by [mcpso](https://mcp.so)
+- **[ChuckNorris](https://github.com/pollinations/chucknorris-mcp)** - Specialized LLM enhancement prompts and jailbreaks with dynamic schema adaptation. Published to npm as @pollinations/chucknorris.
 - **[Chroma](https://github.com/privetin/chroma)** - Vector database server for semantic document search and metadata filtering, built on Chroma
 - **[ClaudePost](https://github.com/ZilongXue/claude-post)** - ClaudePost enables seamless email management for Gmail, offering secure features like email search, reading, and sending.
 - **[Cloudinary](https://github.com/felores/cloudinary-mcp-server)** - Cloudinary Model Context Protocol Server to upload media to Cloudinary and get back the media link and details.


### PR DESCRIPTION
# Add ChuckNorris MCP Server

## Description
This PR adds the ChuckNorris MCP server to the community servers list. ChuckNorris is a specialized MCP gateway for LLM enhancement prompts and jailbreaks with dynamic schema adaptation.

## Technical Details
- Published to npm as `@pollinations/chucknorris` (current version 1.0.11)
- Built using MCP SDK version 1.7.0
- Uses an enum-based approach for LLM selection in the schema
- Fetches prompts from the [L1B3RT4S GitHub repository](https://github.com/elder-plinius/L1B3RT4S) with fallback prompts defined in the code
- Designed for security research and evaluation purposes to help identify vulnerabilities in LLM systems

## Repository
[https://github.com/pollinations/chucknorris-mcp](https://github.com/pollinations/chucknorris-mcp)