### PR TITLE
Feat/conversation-history-cursor

### DIFF
--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -39,6 +39,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
    - Required inputs:
      - `channel_id` (string): The channel ID
    - Optional inputs:
+     - `cursor` (string): Pagination cursor for next page
      - `limit` (number, default: 10): Number of messages to retrieve
    - Returns: List of messages with their content and metadata
 

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -147,6 +147,10 @@ const getChannelHistoryTool: Tool = {
         type: "string",
         description: "The ID of the channel",
       },
+      cursor: {
+        type: "string",
+        description: "Pagination cursor for next page of results",
+      },
       limit: {
         type: "number",
         description: "Number of messages to retrieve (default 10)",

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -33,6 +33,7 @@ interface AddReactionArgs {
 
 interface GetChannelHistoryArgs {
   channel_id: string;
+  cursor?: string;
   limit?: number;
 }
 
@@ -291,12 +292,17 @@ class SlackClient {
 
   async getChannelHistory(
     channel_id: string,
-    limit: number = 10,
+    cursor?: string,
+    limit: number = 10
   ): Promise<any> {
     const params = new URLSearchParams({
       channel: channel_id,
       limit: limit.toString(),
     });
+
+    if (cursor) {
+      params.append("cursor", cursor);
+    }
 
     const response = await fetch(
       `https://slack.com/api/conversations.history?${params}`,
@@ -459,6 +465,7 @@ async function main() {
             }
             const response = await slackClient.getChannelHistory(
               args.channel_id,
+              args.cursor,
               args.limit,
             );
             return {


### PR DESCRIPTION
## Description
Added the ability for slack MCP to use  a cursor when retrieving slack conversation history

## Server Details
- Server: Slack
- Changes to: slack_get_channel_history (tool)

## Motivation and Context
Currently i am only able to get a max of 200 records when pressing claude. This would allow it to continue move backwards in the conversation history.

## How Has This Been Tested?
Yes this has been tested with my teams slack. I created a test MCP app and confirmed the cursor does move forward.

## Breaking Changes
No they should not have to update any configurations

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
https://api.slack.com/methods/conversations.history