### PR TITLE
adding 2 new gitlab endpoints

### DIFF
--- a/src/gitlab/README.md
+++ b/src/gitlab/README.md
@@ -80,20 +80,34 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `allow_collaboration` (optional boolean): Allow commits from upstream members
    - Returns: Created merge request details
 
-8. `fork_repository`
+8. `get_merge_request_raw_diff`
+   - Get a merge request information of the difference in a raw format
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `merge_request_id` (string): ID of the merge request
+   - Returns: The difference of the merge request in a raw format
+
+9. `fork_repository`
    - Fork a project
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
      - `namespace` (optional string): Namespace to fork to
    - Returns: Forked project details
 
-9. `create_branch`
+10. `create_branch`
    - Create a new branch
    - Inputs:
      - `project_id` (string): Project ID or URL-encoded path
      - `branch` (string): Name for new branch
      - `ref` (optional string): Source branch/commit for new branch
    - Returns: Created branch reference
+
+11. `get_job_logs`
+   - Retrieve the logs from a job
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `job_id` (string): ID of the job
+   - Returns: The logs of the job
 
 ## Setup
 

--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -293,6 +293,11 @@ export const CreateMergeRequestSchema = ProjectParamsSchema.extend({
     .describe("Allow commits from upstream members")
 });
 
+export const GetMergeRequestRawDiffSchema = ProjectParamsSchema.extend({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  merge_request_id: z.string().describe("The ID of a merge request")
+});
+
 export const ForkRepositorySchema = ProjectParamsSchema.extend({
   namespace: z.string().optional()
     .describe("Namespace to fork to (full path)")
@@ -303,6 +308,11 @@ export const CreateBranchSchema = ProjectParamsSchema.extend({
   ref: z.string().optional()
     .describe("Source branch/commit for new branch")
 });
+
+export const CreateGetJobLogsSchema = ProjectParamsSchema.extend({
+  project_id: z.string().describe("Project ID or URL-encoded path"),
+  job_id: z.string().describe("ID of a job")
+})
 
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;


### PR DESCRIPTION
## Description
I added 2 new gitlab endpoints to the gitlab MCP.
1. to retrieve job logs.
2. to get the difference of a merge request

## Server Details
- Server: Gitlab
- Changes to: Functionality

## Motivation and Context
The 2 functionalities can be used the following. This is also the motiviation of making these 2 new endpoints
1. Job logs can be analysed locally. For instance ask the AI to check why a job has failed.
2. Getting the raw difference of a merge request can help with code reviewing. You can ask the AI locally all sorts of questions about the merge request of your teammate for instance.

## How Has This Been Tested?
I have run the Gitlab server locally on my Docker Desktop and installed it with Cline.
Then I asked Cline to get me the following 2 things:
1. Analyse why my job failed and gave Cline a link to the job. He then got the job log and made a very detailed analysis.
2. I gave cline the job to do a very general code review on a given merge request.

## Breaking Changes
If they want to use these 2 new features then yes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

