### PR TITLE
Add OpenAPI Schema Explorer server to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[OpenAPI](https://github.com/snaggle-ai/openapi-mcp-server)** - Interact with [OpenAPI](https://www.openapis.org/) APIs.
 - **[OpenAPI AnyApi](https://github.com/baryhuang/mcp-server-any-openapi)** - Interact with large [OpenAPI](https://www.openapis.org/) docs using built-in semantic search for endpoints. Allows for customizing the MCP server prefix.
 - **[OpenAPI Schema](https://github.com/hannesj/mcp-openapi-schema)** - Allow LLMs to explore large [OpenAPI](https://www.openapis.org/) schemas without bloating the context.
+- **[OpenAPI Schema Explorer](https://github.com/kadykov/mcp-openapi-schema-explorer)** - Token-efficient access to local or remote OpenAPI/Swagger specs via MCP Resources.
 - **[OpenCTI](https://github.com/Spathodea-Network/opencti-mcp)** - Interact with OpenCTI platform to retrieve threat intelligence data including reports, indicators, malware and threat actors.
 - **[OpenDota](https://github.com/asusevski/opendota-mcp-server)** - Interact with OpenDota API to retrieve Dota 2 match data, player statistics, and more.
 - **[OpenRPC](https://github.com/shanejonas/openrpc-mpc-server)** - Interact with and discover JSON-RPC APIs via [OpenRPC](https://open-rpc.org).


### PR DESCRIPTION
## Motivation and Context

Working with large OpenAPI or Swagger specifications can quickly consume context window limits. This server solves that problem by providing **token-efficient access** to API specs via MCP Resources.

Instead of loading the entire file, users can interactively explore API paths, operations, and components using intuitive URIs (`openapi://...`). It supports local files and remote URLs, automatically handles Swagger v2 conversion, and transforms internal references into clickable links, making API understanding and exploration significantly faster and more context-friendly.

Compared to other MCP servers, this server exposes the OpenAPI specification through MCP Resources and supports completion and multi-valued requests, making it well-suited for read-only data exploration.

## How Has This Been Tested?

The MCP server has comprehensive set of unit and E2E tests.

## Types of changes

- [x] Documentation update

