### PR TITLE
Update README.md to include Foobara framework's mcp-connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[EasyMCP](https://github.com/zcaceres/easy-mcp/)** (TypeScript)
 - **[FastAPI to MCP auto generator](https://github.com/tadata-org/fastapi_mcp)** – A zero-configuration tool for automatically exposing FastAPI endpoints as MCP tools by **[Tadata](https://tadata.com/)**
 * **[FastMCP](https://github.com/punkpeye/fastmcp)** (TypeScript)
+* **[Foobara MCP Connector](https://github.com/foobara/mcp-connector)** - Easily expose Foobara commands written in Ruby as tools via MCP
 * **[Foxy Contexts](https://github.com/strowk/foxy-contexts)** – A library to build MCP servers in Golang by **[strowk](https://github.com/strowk)**
 * **[Higress MCP Server Hosting](https://github.com/alibaba/higress/tree/main/plugins/wasm-go/mcp-servers)** - A solution for hosting MCP Servers by extending the API Gateway (based on Envoy) with wasm plugins.
 * **[MCP-Framework](https://mcp-framework.com)** Build MCP servers with elegance and speed in Typescript. Comes with a CLI to create your project with `mcp create app`. Get started with your first server in under 5 minutes by **[Alex Andru](https://github.com/QuantGeekDev)**


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Adds Foobara framework's mcp-connector to the README.md

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

It seemed it'd be useful/fun/interesting to be able to have programs like Claude Code run my Foobara commands as tools via MCP. And it was!

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

Using Claude Code locally, I have successfully had it run my commands to complete the tasks I've requested of it.
Some tested scenarios can be seen in the README.md and the examples/ directory in the linked project.

Adherence to the protocol is also tested via a test suite with 100% line coverage.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

Everything there should be standard. I added the MCP server to my .mcp.json just as I've had to for every other MCP server.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] ~~I have updated the server's README accordingly~~
- [x] I have tested this with an LLM client
- [ ] ~~My code follows the repository's style guidelines~~
- [ ] ~~New and existing tests pass locally~~
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
