### PR TITLE
Memory - Fix: Update relation filter logic to use OR condition instead of AND

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -149,7 +149,7 @@ class KnowledgeGraphManager {
   
     // Filter relations to only include those between filtered entities
     const filteredRelations = graph.relations.filter(r => 
-      filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
   
     const filteredGraph: KnowledgeGraph = {
@@ -171,7 +171,7 @@ class KnowledgeGraphManager {
   
     // Filter relations to only include those between filtered entities
     const filteredRelations = graph.relations.filter(r => 
-      filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
   
     const filteredGraph: KnowledgeGraph = {


### PR DESCRIPTION
## Description
This PR updates the relation filtering logic in the memory server's `searchNodes` and `openNodes` methods to correctly include relations connected to at least one filtered entity.

## Server Details
- Server: memory
- Changes to: `searchNodes` and `openNodes` tools

## Motivation and Context
The current implementation filters relations using an `&&` condition, meaning a relation is only included if both its source and destination entities are present in the filtered entity list. This is incorrect behavior as it excludes relations that connect a filtered entity to an unfiltered one. The expected behavior is to include any relation where either the source or destination entity is in the filtered list.

## How Has This Been Tested?
- Manually tested with the `openNodes` tool to verify correct relation inclusion
- Verified that relations are now included when connected to at least one filtered entity

## Breaking Changes
None. This is a bug fix that maintains backward compatibility.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
The change replaces the `&&` condition with an `||` condition in both `searchNodes` and `openNodes` methods:
```typescript
const filteredRelations = graph.relations.filter(r => 
  filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
);