### PR TITLE
Add pagination to Slack channel history

### DIFF
--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -34,6 +34,7 @@ interface AddReactionArgs {
 interface GetChannelHistoryArgs {
   channel_id: string;
   limit?: number;
+  cursor?: string;
 }
 
 interface GetThreadRepliesArgs {
@@ -150,6 +151,10 @@ const getChannelHistoryTool: Tool = {
         type: "number",
         description: "Number of messages to retrieve (default 10)",
         default: 10,
+      },
+      cursor: {
+        type: "string",
+        description: "Pagination cursor for next page of results",
       },
     },
     required: ["channel_id"],
@@ -320,11 +325,16 @@ class SlackClient {
   async getChannelHistory(
     channel_id: string,
     limit: number = 10,
+    cursor?: string,
   ): Promise<any> {
     const params = new URLSearchParams({
       channel: channel_id,
       limit: limit.toString(),
     });
+
+    if (cursor) {
+      params.append("cursor", cursor);
+    }
 
     const response = await fetch(
       `https://slack.com/api/conversations.history?${params}`,
@@ -488,6 +498,7 @@ async function main() {
             const response = await slackClient.getChannelHistory(
               args.channel_id,
               args.limit,
+              args.cursor,
             );
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],


### PR DESCRIPTION
## Description
The Slack MCP Server is lacking pagination for the get channel history call. This PR adds this functionality.
Slack API reference: https://api.slack.com/methods/conversations.history#arg_cursor

## Server Details
- Server: Slack
- Changes to: tools

## Motivation and Context
Channels with a lot of messages/history are currently not possible to work with. This adds pagination to the tool call, helping to go through channels with more than 10 messages or whatever the limit of the Slack API is to retrieve in one api call.

## How Has This Been Tested?
Not yet tested. Help is appreciated on how to run my forked version locally.

## Breaking Changes
This does not introduce any breaking changes. This only adds an optional parameter to the existing tool.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
