### PR TITLE
adds the iMCP server to the list of 3rd party MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Hyperliquid](https://github.com/mektigboy/server-hyperliquid)** - An MCP server implementation that integrates the Hyperliquid SDK for exchange data.
 - **[iFlytek Workflow](https://github.com/iflytek/ifly-workflow-mcp-server)** - Connect to iFlytek Workflow via the MCP server and run your own Agent.
 - **[Image Generation](https://github.com/GongRzhe/Image-Generation-MCP-Server)** - This MCP server provides image generation capabilities using the Replicate Flux model.
-- **[iMCP](https://github.com/loopwork-ai/iMCP)** - Connect iMessage, Reminders, Mail and other Apple services via this native MacOS app and MCP server. 
+- **[iMCP](https://github.com/loopwork-ai/iMCP)** - A macOS app that provides an MCP server for your iMessage, Reminders, and other Apple services. 
 - **[InfluxDB](https://github.com/idoru/influxdb-mcp-server)** - Run queries against InfluxDB OSS API v2.
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
 - **[Intercom](https://github.com/raoulbia-ai/mcp-server-for-intercom)** - An MCP-compliant server for retrieving customer support tickets from Intercom. This tool enables AI assistants like Claude Desktop and Cline to access and analyze your Intercom support tickets.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Hyperliquid](https://github.com/mektigboy/server-hyperliquid)** - An MCP server implementation that integrates the Hyperliquid SDK for exchange data.
 - **[iFlytek Workflow](https://github.com/iflytek/ifly-workflow-mcp-server)** - Connect to iFlytek Workflow via the MCP server and run your own Agent.
 - **[Image Generation](https://github.com/GongRzhe/Image-Generation-MCP-Server)** - This MCP server provides image generation capabilities using the Replicate Flux model.
+- **[iMCP](https://github.com/loopwork-ai/iMCP)** - Connect iMessage, Reminders, Mail and other Apple services via this native MacOS app and MCP server. 
 - **[InfluxDB](https://github.com/idoru/influxdb-mcp-server)** - Run queries against InfluxDB OSS API v2.
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
 - **[Intercom](https://github.com/raoulbia-ai/mcp-server-for-intercom)** - An MCP-compliant server for retrieving customer support tickets from Intercom. This tool enables AI assistants like Claude Desktop and Cline to access and analyze your Intercom support tickets.


### PR DESCRIPTION
## Description
Hi, we are the maintainers of @modelcontextprotocol/swift-sdk . This adds iMCP, a mac native swift app to the list of community services. iMCP let's use connect to iMessage, Reminders, Maps, and other apple services. 

## Server Details
- Server: iMCP – Apple ecosystem services

## Motivation and Context
This provides the first example of how to use the @modelcontextprotocol/swift-sdk to build an MCP server. It is also valuable in its own right as a MCP server that lets you connect with tools in the apple ecosystem. 

## How Has This Been Tested?
Yes, it's been tested manually and by users. 
<img width="765" alt="image" src="https://github.com/user-attachments/assets/ed6e7f01-2b7b-43c0-8585-ee51e566851d" />

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options


