### PR TITLE
Fix bug with stack overflow on console calls

### DIFF
--- a/src/puppeteer/index.ts
+++ b/src/puppeteer/index.ts
@@ -351,17 +351,19 @@ async function handleToolCall(name: string, args: any): Promise<CallToolResult> 
     case "puppeteer_evaluate":
       try {
         await page.evaluate(() => {
-          window.mcpHelper = {
-            logs: [],
-            originalConsole: { ...console },
-          };
-
-          ['log', 'info', 'warn', 'error'].forEach(method => {
-            (console as any)[method] = (...args: any[]) => {
-              window.mcpHelper.logs.push(`[${method}] ${args.join(' ')}`);
-              (window.mcpHelper.originalConsole as any)[method](...args);
+          if (!window.mcpHelper) {
+            window.mcpHelper = {
+              logs: [],
+              originalConsole: { ...console },
             };
-          });
+  
+            ['log', 'info', 'warn', 'error'].forEach(method => {
+              (console as any)[method] = (...args: any[]) => {
+                window.mcpHelper.logs.push(`[${method}] ${args.join(' ')}`);
+                (window.mcpHelper.originalConsole as any)[method](...args);
+              };
+            });
+          }
         });
 
         const result = await page.evaluate(args.script);


### PR DESCRIPTION
Fixed a bug with the multiple tool call within a single window. It was overwriting console with its own methods, so that `console.log` was causing a stack overflow due to calling itself.

