### PR TITLE
[slack] Instruct users to add users.profile:read scope to token

### DIFF
--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -78,6 +78,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
    - `chat:write` - Send messages as the app
    - `reactions:write` - Add emoji reactions to messages
    - `users:read` - View users and their basic information
+   - `users.profile:read` - View detailed profiles about users
 
 4. Install App to Workspace:
    - Click "Install to Workspace" and authorize the app


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: slack
- Changes to: docs (readme)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
the tool `slack_get_user_profile` makes calls to slack's `users.profile.get` endpoint, which requires `users.profile:read` scope (ref: https://api.slack.com/methods/users.profile.get)

 However this scope is not documented in the setup instruction, and any calls to `slack-get_user_profile` tool will fail.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

* instructed cursor AI to call `slack_get_user_profile` and ensured that the call fails
* added the scope `users.profile:read`, tried the above again, and the call works.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
