### PR TITLE
[slack] Add tools to update or delete slack messages posted by the bot

### DIFF
--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -18,7 +18,18 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `text` (string): The message text to post
    - Returns: Message posting confirmation and timestamp
 
-3. `slack_reply_to_thread`
+3. `slack_update_message`
+(placeholder for now)
+
+4. `slack_delete_message`
+   - Delete a message from a Slack channel
+   - Required inputs:
+     - `channel_id` (string): The channel containing the message
+     - `timestamp` (string): Message timestamp to delete in format '1234567890.123456'
+   - Returns: Message deletion confirmation and timestamp
+
+
+5. `slack_reply_to_thread`
    - Reply to a specific message thread
    - Required inputs:
      - `channel_id` (string): The channel containing the thread
@@ -26,7 +37,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `text` (string): The reply text
    - Returns: Reply confirmation and timestamp
 
-4. `slack_add_reaction`
+6. `slack_add_reaction`
    - Add an emoji reaction to a message
    - Required inputs:
      - `channel_id` (string): The channel containing the message
@@ -34,7 +45,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `reaction` (string): Emoji name without colons
    - Returns: Reaction confirmation
 
-5. `slack_get_channel_history`
+7. `slack_get_channel_history`
    - Get recent messages from a channel
    - Required inputs:
      - `channel_id` (string): The channel ID
@@ -42,7 +53,7 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `limit` (number, default: 10): Number of messages to retrieve
    - Returns: List of messages with their content and metadata
 
-6. `slack_get_thread_replies`
+8. `slack_get_thread_replies`
    - Get all replies in a message thread
    - Required inputs:
      - `channel_id` (string): The channel containing the thread
@@ -50,14 +61,14 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
    - Returns: List of replies with their content and metadata
 
 
-7. `slack_get_users`
+9. `slack_get_users`
    - Get list of workspace users with basic profile information
    - Optional inputs:
      - `cursor` (string): Pagination cursor for next page
      - `limit` (number, default: 100, max: 200): Maximum users to return
    - Returns: List of users with their basic profiles
 
-8. `slack_get_user_profile`
+10. `slack_get_user_profile`
    - Get detailed profile information for a specific user
    - Required inputs:
      - `user_id` (string): The user's ID

--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -19,7 +19,12 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
    - Returns: Message posting confirmation and timestamp
 
 3. `slack_update_message`
-(placeholder for now)
+   - Update the text of an existing message in a Slack channel
+   - Required inputs:
+     - `channel_id` (string): The channel containing the message
+     - `timestamp` (string): Message timestamp to update in format '1234567890.123456'
+     - `text` (string): The new text for the message
+   - Returns: Message update confirmation and timestamp
 
 4. `slack_delete_message`
    - Delete a message from a Slack channel


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: slack
- Changes to: tools

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

We can instruct the AI agent to post the message to slack, but we cannot update or delete the message once it's posted, because the current slack MCP doesn't offer such functionality.

AIs will often make mistakes, so we should be able to instruct it to fix the message or remove the message.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

Instruct the Agent to post a message, then edit that message, then delete that message. all of them worked

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

the underlying API, `chat.update` and `chat.delete` needs `chat:write` scope only, so we shouldn't need to specify any additional scopes to README.
https://api.slack.com/methods/chat.update
https://api.slack.com/methods/chat.delete
