### PR TITLE
Add MCP server for aranet4

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Anki](https://github.com/scorzeth/anki-mcp-server)** - An MCP server for interacting with your [Anki](https://apps.ankiweb.net) decks and cards.
 - **[Any Chat Completions](https://github.com/pyroprompts/any-chat-completions-mcp)** - Interact with any OpenAI SDK Compatible Chat Completions API like OpenAI, Perplexity, Groq, xAI and many more.
 - **[Apple Calendar](https://github.com/Omar-v2/mcp-ical)** - An MCP server that allows you to interact with your MacOS Calendar through natural language, including features such as event creation, modification, schedule listing, finding free time slots etc.
+- **[Aranet4](https://github.com/diegobit/aranet4-mcp-server)** - MCP Server to manage your Aranet4 CO2 sensor. Fetch data and store in a local SQLite. Ask questions about historical data.
 - **[ArangoDB](https://github.com/ravenwits/mcp-server-arangodb)** - MCP Server that provides database interaction capabilities through [ArangoDB](https://arangodb.com/).
 - **[Arduino](https://github.com/vishalmysore/choturobo)** - MCP Server that enables AI-powered robotics using Claude AI and Arduino (ESP32) for real-world automation and interaction with robots.
 - **[Atlassian](https://github.com/sooperset/mcp-atlassian)** - Interact with Atlassian Cloud products (Confluence and Jira) including searching/reading Confluence spaces/pages, accessing Jira issues, and project metadata.


### PR DESCRIPTION
## Description

Add line in the community MCP servers with the link to the MCP server to handle an Aranet4 CO2 sensor: [aranet4-mcp-server](https://github.com/diegobit/aranet4-mcp-server).

The server allows to fetch measurements and save into a local SQLite. The server allows to ask questions about recent measures, or about a specific past daterange. It can also generate a plot.

## Motivation and Context
I wanted to ask questions about the CO2 measurements fetched from the Aranet4 CO2 sensors through Claude. 

The original Aranet4 device only keeps a week of data in the local memory (and in the mobile app), hence the need to fetch the data and store locally. The fetch can be run periodically with a launchd (provided in the repo) or a cronjob.

## How Has This Been Tested?
Tested on MacOS with Claude Desktop manually. I'm using it.

## Breaking Changes
No breaking changes

## Types of Changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Nothing.
