### PR TITLE
docs: add Raindrop.io MCP server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Qwen_Max](https://github.com/66julienmartin/MCP-server-Qwen_Max)** - A Model Context Protocol (MCP) server implementation for the Qwen models.
 - **[RabbitMQ](https://github.com/kenliao94/mcp-server-rabbitmq)** - The MCP server that interacts with RabbitMQ to publish and consume messages.
 - **[RAG Web Browser](https://github.com/apify/mcp-server-rag-web-browser)** An MCP server for Apify's open-source RAG Web Browser [Actor](https://apify.com/apify/rag-web-browser) to perform web searches, scrape URLs, and return content in Markdown.
+- **[Raindrop.io](https://github.com/hiromitsusasaki/raindrop-io-mcp-server)** - An integration that allows LLMs to interact with Raindrop.io bookmarks using the Model Context Protocol (MCP).
 - **[Reaper](https://github.com/dschuler36/reaper-mcp-server)** - Interact with your [Reaper](https://www.reaper.fm/) (Digital Audio Workstation) projects.
 - **[Redis](https://github.com/GongRzhe/REDIS-MCP-Server)** - Redis database operations and caching microservice server with support for key-value operations, expiration management, and pattern-based key listing.
 - **[Redis](https://github.com/prajwalnayak7/mcp-server-redis)** MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate


### PR DESCRIPTION
## Description
Add Raindrop.io MCP server to the Community Servers section in README.md. This server allows LLMs to interact with Raindrop.io bookmarks using the Model Context Protocol.

## Server Details
- Server: N/A (README update only)
- Changes to: Documentation (Community Servers section)

## Motivation and Context
Adding the Raindrop.io MCP server to the list helps users discover this integration option for managing bookmarks through LLMs. The entry is added in alphabetical order following the repository's guidelines.

## How Has This Been Tested?
The change is a documentation update only, involving the addition of a single line in the README.md file. The alphabetical ordering has been verified.

## Breaking Changes
None. This is a documentation-only change.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] My code follows the repository's style guidelines

## Additional context
The entry has been added following the repository's alphabetical ordering convention, placed between "RAG Web Browser" and "Reaper" entries.