### PR TITLE
Add ability to fetch GitHub issue comments

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -137,6 +137,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: zodToJsonSchema(issues.IssueCommentSchema)
       },
       {
+        name: "get_issue_comments",
+        description: "Get comments from a GitHub issue",
+        inputSchema: zodToJsonSchema(issues.GetIssueCommentsSchema)
+      },
+      {
         name: "search_code",
         description: "Search for code across GitHub repositories",
         inputSchema: zodToJsonSchema(search.SearchCodeSchema),
@@ -390,6 +395,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const result = await issues.addIssueComment(owner, repo, issue_number, body);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_issue_comments": {
+        const args = issues.GetIssueCommentsSchema.parse(request.params.arguments);
+        const { owner, repo, issue_number, page, per_page, since } = args;
+        const options = { page, per_page, since };
+        const comments = await issues.getIssueComments(owner, repo, issue_number, options);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
         };
       }
 

--- a/src/github/operations/issues.ts
+++ b/src/github/operations/issues.ts
@@ -14,6 +14,15 @@ export const IssueCommentSchema = z.object({
   body: z.string(),
 });
 
+export const GetIssueCommentsSchema = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  issue_number: z.number(),
+  page: z.number().optional(),
+  per_page: z.number().optional(),
+  since: z.string().optional(),
+});
+
 export const CreateIssueOptionsSchema = z.object({
   title: z.string(),
   body: z.string().optional(),
@@ -54,6 +63,27 @@ export const UpdateIssueOptionsSchema = z.object({
 
 export async function getIssue(owner: string, repo: string, issue_number: number) {
   return githubRequest(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}`);
+}
+
+export async function getIssueComments(
+  owner: string, 
+  repo: string, 
+  issue_number: number,
+  options: { 
+    page?: number; 
+    per_page?: number; 
+    since?: string;
+  } = {}
+) {
+  const urlParams: Record<string, string | undefined> = {
+    page: options.page?.toString(),
+    per_page: options.per_page?.toString(),
+    since: options.since
+  };
+
+  return githubRequest(
+    buildUrl(`https://api.github.com/repos/${owner}/${repo}/issues/${issue_number}/comments`, urlParams)
+  );
 }
 
 export async function addIssueComment(


### PR DESCRIPTION
This PR adds support for fetching GitHub issue comments via the MCP interface.

## Changes
- Added a new schema `GetIssueCommentsSchema` in `issues.ts`
- Added a new function `getIssueComments` to fetch issue comments from GitHub API
- Added a new MCP tool `get_issue_comments` in `index.ts` to expose this functionality

## Why
Current MCP GitHub server has support for adding issue comments but lacks the ability to retrieve them, which is essential for AI agents that need to read and analyze GitHub issue discussions.

## Usage
```javascript
{
  name: "get_issue_comments",
  arguments: {
    owner: "repoOwner",
    repo: "repoName",
    issue_number: 123,
    // optional params:
    page: 1,          // pagination
    per_page: 30,     // items per page
    since: "2023-01-01T00:00:00Z" // comments after this timestamp
  }
}
```