### PR TITLE
Add openai-gpt-image-mcp to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Official integrations are maintained by companies building production ready MCP 
 A growing set of community-developed and maintained servers demonstrates various applications of MCP across different domains.
 
 > **Note:** Community servers are **untested** and should be used at **your own risk**. They are not affiliated with or endorsed by Anthropic.
+- [openai-gpt-image-mcp](https://github.com/SureScaleAI/openai-gpt-image-mcp) – OpenAI GPT image generation/editing MCP server.
 - **[Ableton Live](https://github.com/Simon-Kansara/ableton-live-mcp-server)** - an MCP server to control Ableton Live.
 - **[Airbnb](https://github.com/openbnb-org/mcp-server-airbnb)** - Provides tools to search Airbnb and get listing details.
 - **[AI Agent Marketplace Index](https://github.com/AI-Agent-Hub/ai-agent-marketplace-index-mcp)** - MCP server to search more than 5000+ AI agents and tools of various categories from [AI Agent Marketplace Index](http://www.deepnlp.org/store/ai-agent) and monitor traffic of AI Agents.


### PR DESCRIPTION
Adds [openai-gpt-image-mcp](https://github.com/SureScaleAI/openai-gpt-image-mcp) to the community servers list. This server provides OpenAI GPT image generation and editing via MCP.