### PR TITLE
docs: add missing Conda installation instructions

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -87,6 +87,21 @@ Add to your Claude settings:
 ```
 </details>
 
+<details>
+<summary>Using conda installation</summary>
+
+> Use absolute paths with conda
+
+```json
+"mcpServers": {
+  "fetch": {
+    "command": "/{your_conda_path}/envs/{env_name}/bin/python",
+    "args": ["-m", "mcp_server_fetch"]
+  }
+}
+```
+</details>
+
 ### Configure for VS Code
 
 For quick installation, use one of the one-click install buttons below...


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
This PR updates the community-maintained README by adding Conda as an installation option for fetch-mcp-server.

> Use absolute paths with conda

```json
"mcpServers": {
  "fetch": {
    "command": "/{your_conda_path}/envs/{env_name}/bin/python",
    "args": ["-m", "mcp_server_fetch"]
  }
}
```
## Server Details
<!-- If modifying an existing server, provide details -->
- Server: fetch
- Changes to: Documentation only (README.md), add missing Conda installation instructions

## Motivation and Context
In the fetch MCP server project, the README originally described how to install the project using pip, uv, and Docker, but missed Conda. This update adds instructions for installing with Conda.

## How Has This Been Tested?
Tested locally using the Cline plugin in VSCode. Confirmed that the Conda installation instructions work as expected.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
