### PR TITLE
Added new option to compress a directory with zip on Linux systems.

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -60,6 +60,10 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
   - Creates parent directories if needed
   - Succeeds silently if directory exists
 
+- **compress_directory**
+  - Compress directory contents with zip
+  - Input: `path` (string)
+
 - **list_directory**
   - List directory contents with [FILE] or [DIR] prefixes
   - Input: `path` (string)


### PR DESCRIPTION
## Description
It introduces a new feature for compressing a given directory on Linux-based systems using zip.

## Server Details
- Server: filesystem
- Changes to: tools

## Motivation and Context
it would be useful to be able to compress a given directory.

## How Has This Been Tested?
I tested it using Claude Desktop on Kubuntu 22.04

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

