### PR TITLE
Add Pacman and Docy MCP servers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Deebo](https://github.com/snagasuri/deebo-prototype)** – Agentic debugging MCP server that helps AI coding agents delegate and fix hard bugs through isolated multi-agent hypothesis testing.
 - **[Deep Research](https://github.com/reading-plus-ai/mcp-server-deep-research)** - Lightweight MCP server offering Grok/OpenAI/Gemini/Perplexity-style automated deep research exploration and structured reporting.
 - **[DeepSeek MCP Server](https://github.com/DMontgomery40/deepseek-mcp-server)** - Model Context Protocol server integrating DeepSeek's advanced language models, in addition to [other useful API endpoints](https://github.com/DMontgomery40/deepseek-mcp-server?tab=readme-ov-file#features)
+- **[Docy](https://github.com/oborchers/mcp-server-docy)** - Docy gives your AI direct access to the technical documentation it needs, right when it needs it. No more outdated information, broken links, or rate limits - just accurate, real-time documentation access for more precise coding assistance.
 - **[Deepseek_R1](https://github.com/66julienmartin/MCP-server-Deepseek_R1)** - A Model Context Protocol (MCP) server implementation connecting Claude Desktop with DeepSeek's language models (R1/V3)
 - **[deepseek-thinker-mcp](https://github.com/ruixingshi/deepseek-thinker-mcp)** - A MCP (Model Context Protocol) provider Deepseek reasoning content to MCP-enabled AI Clients, like Claude Desktop. Supports access to Deepseek's thought processes from the Deepseek API service or from a local Ollama server.
 - **[Descope](https://github.com/descope-sample-apps/descope-mcp-server)** - An MCP server to integrate with [Descope](https://descope.com) to search audit logs, manage users, and more.
@@ -376,6 +377,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[PubChem](https://github.com/sssjiang/pubchem_mcp_server)** - extract drug information from pubchem API.
 - **[Pulumi](https://github.com/dogukanakkaya/pulumi-mcp-server)** - MCP Server to Interact with Pulumi API, creates and lists Stacks
 - **[Pushover](https://github.com/ashiknesin/pushover-mcp)** - Send instant notifications to your devices using [Pushover.net](https://pushover.net/)
+- **[Pacman](https://github.com/oborchers/mcp-server-pacman)** - An MCP server that provides package index querying capabilities. This server is able to search and retrieve information from package repositories like PyPI, npm, crates.io, Docker Hub, and Terraform Registry.
 - **[Quarkus](https://github.com/quarkiverse/quarkus-mcp-servers)** - MCP servers for the Quarkus Java framework.
 - **[QGIS](https://github.com/jjsantos01/qgis_mcp)** - connects QGIS to Claude AI through the MCP. This integration enables prompt-assisted project creation, layer loading, code execution, and more.
 - **[QuickChart](https://github.com/GongRzhe/Quickchart-MCP-Server)** - A Model Context Protocol server for generating charts using QuickChart.io


### PR DESCRIPTION
Add two new community MCP servers to the README.md file

  ## Description
  This PR adds links to two new community MCP servers in the README.md file:
  - Pacman: A server for package index querying
  - Docy: A server for technical documentation access

  ## Server Details
  <!-- If modifying an existing server, provide details -->
  - Server: N/A (adding links to community servers in README)
  - Changes to: N/A

  ## Motivation and Context
  <!-- Why is this change needed? What problem does it solve? -->
  Adding references to new community MCP servers to make them discoverable by other users, following the contribution guidelines for adding server links to the README.

  ## How Has This Been Tested?
  <!-- Have you tested this with an LLM client? Which scenarios were tested? -->
  Both servers have been developed and tested with Claude Desktop as the MCP client.

  ## Breaking Changes
  <!-- Will users need to update their MCP client configurations? -->
  None. This is a documentation-only change.

  ## Types of changes
  <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
  - [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
  - [x] My changes follows MCP security best practices
  - [x] I have updated the server's README accordingly
  - [x] I have tested this with an LLM client
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have documented all environment variables and configuration options

  ## Additional context
  <!-- Add any other context, implementation notes, or design decisions -->
  Both servers follow the alphabetical ordering as specified in the contribution guidelines.