### PR TITLE
feat: gitlab server list members of a project

### DIFF
--- a/src/gitlab/README.md
+++ b/src/gitlab/README.md
@@ -95,6 +95,15 @@ MCP Server for the GitLab API, enabling project management, file operations, and
      - `ref` (optional string): Source branch/commit for new branch
    - Returns: Created branch reference
 
+10. `list_members`
+    - List all members of a project
+    - Inputs:
+      - `project_id` (string): Project ID or URL-encoded path
+      - `include_inheritance` (optional boolean): Include inherited members  
+      - `page` (optional number): Page number for pagination (default: 1)
+      - `per_page` (optional number): Results per page (default: 20)
+    - Returns: List of members with their access levels and details
+
 ## Setup
 
 ### Personal Access Token

--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -7,6 +7,26 @@ export const GitLabAuthorSchema = z.object({
   date: z.string()
 });
 
+// Member schema
+export const GitLabMemberSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  name: z.string(),
+  state: z.string(),
+  avatar_url: z.string(),
+  web_url: z.string(),
+  access_level: z.number(),
+  email: z.string().optional(),
+  group_saml_identity: z.object({
+    extern_uid: z.string(),
+    provider: z.string(),
+    saml_provider_id: z.number()
+  }).nullable().optional(),
+  override: z.boolean().optional()
+});
+
+export const GitLabMembersResponseSchema = z.array(GitLabMemberSchema);
+
 // Repository related schemas
 export const GitLabOwnerSchema = z.object({
   username: z.string(), // Changed from login to match GitLab API
@@ -304,6 +324,13 @@ export const CreateBranchSchema = ProjectParamsSchema.extend({
     .describe("Source branch/commit for new branch")
 });
 
+export const ListMembersSchema = ProjectParamsSchema.extend({
+  include_inheritance: z.boolean().optional()
+    .describe("Include members inherited from parent groups (use 'all' endpoint)"),
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+  per_page: z.number().optional().describe("Number of results per page (default: 20)")
+});
+
 // Export types
 export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
 export type GitLabFork = z.infer<typeof GitLabForkSchema>;
@@ -323,3 +350,5 @@ export type CreateMergeRequestOptions = z.infer<typeof CreateMergeRequestOptions
 export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
 export type GitLabCreateUpdateFileResponse = z.infer<typeof GitLabCreateUpdateFileResponseSchema>;
 export type GitLabSearchResponse = z.infer<typeof GitLabSearchResponseSchema>;
+export type GitLabMember = z.infer<typeof GitLabMemberSchema>;
+export type GitLabMembersResponse = z.infer<typeof GitLabMembersResponseSchema>;


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
Added a new list_members tool to the GitLab MCP server that allows users to retrieve member information from GitLab projects. The tool supports pagination and can optionally include members inherited from parent groups.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: gitlab
- Changes to: tools

## Motivation and Context
GitLab projects often involve collaboration among team members with different access levels. This tool enables LLMs to list project members, understand team composition, and access permission levels, facilitating better collaboration awareness during conversations about GitLab projects.

## How Has This Been Tested?
Tested with Claude using both direct project members and inherited members scenarios. Verified proper pagination works and that the proper GitLab API endpoints are called depending on whether inheritance is requested.

## Breaking Changes
No breaking changes. This is an additive feature that doesn't modify existing functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ x] My changes follows MCP security best practices
- [ x] I have updated the server's README accordingly
- [ x] I have tested this with an LLM client
- [ x] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ x] I have added appropriate error handling
- [ x] I have documented all environment variables and configuration options

## Additional context
The implementation handles both direct project members (/members) and inherited members (/members/all) through the GitLab API. The response is typed using a Zod schema to ensure type safety and consistent response structure. Error handling includes appropriate HTTP error codes with status text for better debugging.
