### PR TITLE
Choose the server-everything transport on the command line

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -173,7 +173,7 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
 }
 ```
 
-## Run with [HTTP+SSE Transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) (deprecated as of [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports))
+## Running from source with [HTTP+SSE Transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) (deprecated as of [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports))
 
 ```shell
 cd src/everything
@@ -181,10 +181,37 @@ npm install
 npm run start:sse
 ```
 
-## Run with [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
+## Run from source with [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
 
 ```shell
 cd src/everything
 npm install
 npm run start:streamableHttp
 ```
+
+## Running as an installed package
+### Install 
+```shell
+npm install -g @modelcontextprotocol/server-everything@latest
+````
+
+### Run the default (stdio) server
+```shell
+npx @modelcontextprotocol/server-everything
+```
+
+### Or specify stdio explicitly
+```shell
+npx @modelcontextprotocol/server-everything stdio
+```
+
+### Run the SSE server
+```shell
+npx @modelcontextprotocol/server-everything sse
+```
+
+### Run the streamable HTTP server
+```shell
+npx @modelcontextprotocol/server-everything streamableHttp
+```
+

--- a/src/everything/index.ts
+++ b/src/everything/index.ts
@@ -1,23 +1,37 @@
 #!/usr/bin/env node
 
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { createServer } from "./everything.js";
+// Parse command line arguments first
+const args = process.argv.slice(2);
+const scriptName = args[0] || 'stdio';
 
-async function main() {
-  const transport = new StdioServerTransport();
-  const { server, cleanup } = createServer();
-
-  await server.connect(transport);
-
-  // Cleanup on exit
-  process.on("SIGINT", async () => {
-    await cleanup();
-    await server.close();
-    process.exit(0);
-  });
+async function run() {
+    try {
+        // Dynamically import only the requested module to prevent all modules from initializing
+        switch (scriptName) {
+            case 'stdio':
+                // Import and run the default server
+                await import('./stdio.js');
+                break;
+            case 'sse':
+                // Import and run the SSE server
+                await import('./sse.js');
+                break;
+            case 'streamableHttp':
+                // Import and run the streamable HTTP server
+                await import('./streamableHttp.js');
+                break;
+            default:
+                console.error(`Unknown script: ${scriptName}`);
+                console.log('Available scripts:');
+                console.log('- stdio');
+                console.log('- sse');
+                console.log('- streamableHttp');
+                process.exit(1);
+        }
+    } catch (error) {
+        console.error('Error running script:', error);
+        process.exit(1);
+    }
 }
 
-main().catch((error) => {
-  console.error("Server error:", error);
-  process.exit(1);
-});
+run();

--- a/src/everything/sse.ts
+++ b/src/everything/sse.ts
@@ -2,6 +2,8 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
 import { createServer } from "./everything.js";
 
+console.log('Starting SSE server...');
+
 const app = express();
 
 const { server, cleanup } = createServer();

--- a/src/everything/stdio.ts
+++ b/src/everything/stdio.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createServer } from "./everything.js";
+
+console.log('Starting default (STDIO) server...');
+
+async function main() {
+  const transport = new StdioServerTransport();
+  const {server, cleanup} = createServer();
+
+  await server.connect(transport);
+
+  // Cleanup on exit
+  process.on("SIGINT", async () => {
+    await cleanup();
+    await server.close();
+    process.exit(0);
+  });
+}
+
+main().catch((error) => {
+  console.error("Server error:", error);
+  process.exit(1);
+});
+

--- a/src/everything/streamableHttp.ts
+++ b/src/everything/streamableHttp.ts
@@ -4,6 +4,8 @@ import express, { Request, Response } from "express";
 import { createServer } from "./everything.js";
 import { randomUUID } from 'node:crypto';
 
+console.log('Starting Streamable HTTP server...');
+
 const app = express();
 
 const { server, cleanup } = createServer();


### PR DESCRIPTION
## Description

Update `server-everything` to allow choosing the transport on the command line.

* In src/everything/index.ts
  - refactor/extracted contents to stdio.ts
  - replaced with code that
    - Gets the single argument from the commandline as scriptName
    - switches on scriptName
    - imports the appropriate server script or outputs usage options
  - scripts run on import

* In src/everything/stdio.ts
  - added console log "Starting default (STDIO) server..."

* In src/everything/sse.ts
  - added console log "Starting SSE server..."

* In src/everything/streamableHttp.ts
  - added console log "Starting Streamable HTTP server..."

* In README.md
  - add details for launching 

## Server Details
<!-- If modifying an existing server, provide details -->
- Server:  everything
- Changes to: startup process

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
To allow specifying the transport to start the server with on the command line.

* This fixes #1594
## Valid commands 
### Run the default (stdio) server
```npx @modelcontextprotocol/server-everything```

### Or specify stdio explicitly
```npx @modelcontextprotocol/server-everything stdio```

### Run the SSE server
```npx @modelcontextprotocol/server-everything sse```

### Run the streamable HTTP server
```npx @modelcontextprotocol/server-everything streamableHttp```

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Run the startup script that npx will invoke with the args

<img width="500" alt="Screenshot 2025-05-05 at 1 17 13 PM" src="https://github.com/user-attachments/assets/de15a137-35ca-430d-afef-f69aff0b0b56" />

<img width="560" alt="Screenshot 2025-05-05 at 1 18 04 PM" src="https://github.com/user-attachments/assets/ad45b29c-4e8a-4505-b647-1527ade81b10" />

<img width="529" alt="Screenshot 2025-05-05 at 1 18 22 PM" src="https://github.com/user-attachments/assets/50c48d16-838b-491f-bea9-a2b149a47689" />

<img width="642" alt="Screenshot 2025-05-05 at 1 18 45 PM" src="https://github.com/user-attachments/assets/aa7285fe-dd5a-4f6e-ab0d-1ef2ec69e1ea" />

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [X] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
