### PR TITLE
Fixed README: Added NPX config for Claude Desktop

### DIFF
--- a/src/gdrive/README.md
+++ b/src/gdrive/README.md
@@ -84,7 +84,10 @@ Once authenticated, you can use the server in your app's server configuration:
       "args": [
         "-y",
         "@modelcontextprotocol/server-gdrive"
-      ]
+      ],
+      "env": {
+        "GDRIVE_CREDENTIALS_PATH": "/path/to/.gdrive-server-credentials.json"
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR adds environment variable configuration (GDRIVE_CREDENTIALS_PATH) to the NPX setup for the Google Drive server, allowing users to properly specify the path to their credentials file.

## Server Details
- Server: gdrive
- Changes to: configuration examples (added GDRIVE_CREDENTIALS_PATH to NPX setup)

## Motivation and Context
This PR addresses the issue where the credentials path wasn't explicitly specified in the NPX configuration. By providing clear examples in the README for how to set up after authentication, this reduces setup errors and improves user experience.

## How Has This Been Tested?
The configuration changes have been tested with Claude Desktop and Amazon Q Developer CLI when running the Google Drive server via NPX. It correctly reads credentials from the specified path after the authentication process is completed.

## Breaking Changes
Existing users don't need to update their configurations for this change, but explicitly specifying the credentials file path will make their setup more reliable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options