### PR TITLE
feat: add SSE (Server-Sent Events) transport option to MCP Git server

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -106,6 +106,25 @@ After installation, you can run it as a script using:
 python -m mcp_server_git
 ```
 
+## Transport Options
+
+You can control how the MCP Git server communicates with clients using the `--transport` argument:
+
+- `--transport stdio` (default): Communicates over standard input/output. Works with Claude Desktop, VS Code, Zed, etc.
+- `--transport sse`: Enables HTTP streaming via Server-Sent Events (SSE).
+
+When using `sse`, you can also specify:
+
+- `--host` (default: `127.0.0.1`): The network interface to listen on.
+- `--port` (default: `9000`): The port for the HTTP server.
+
+**Example (SSE):**
+```bash
+uv run --directory /path/to/servers/src/git -m mcp_server_git --repository /path/to/repo --transport sse --host 0.0.0.0 --port 9000
+```
+
+> If you don't specify `--transport`, it defaults to `stdio`.
+
 ## Configuration
 
 ### Usage with Claude Desktop

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -3,7 +3,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Sequence
 
-import uvicorn
 from mcp.server import Server
 from mcp.server.session import ServerSession
 from mcp.server.sse import SseServerTransport
@@ -26,58 +25,46 @@ import git
 class GitStatus(BaseModel):
     repo_path: str
 
-
 class GitDiffUnstaged(BaseModel):
     repo_path: str
 
-
 class GitDiffStaged(BaseModel):
     repo_path: str
-
 
 class GitDiff(BaseModel):
     repo_path: str
     target: str
 
-
 class GitCommit(BaseModel):
     repo_path: str
     message: str
-
 
 class GitAdd(BaseModel):
     repo_path: str
     files: list[str]
 
-
 class GitReset(BaseModel):
     repo_path: str
-
 
 class GitLog(BaseModel):
     repo_path: str
     max_count: int = 10
-
 
 class GitCreateBranch(BaseModel):
     repo_path: str
     branch_name: str
     base_branch: str | None = None
 
-
 class GitCheckout(BaseModel):
     repo_path: str
     branch_name: str
-
 
 class GitShow(BaseModel):
     repo_path: str
     revision: str
 
-
 class GitInit(BaseModel):
     repo_path: str
-
 
 class GitTools(str, Enum):
     STATUS = "git_status"
@@ -93,37 +80,29 @@ class GitTools(str, Enum):
     SHOW = "git_show"
     INIT = "git_init"
 
-
 def git_status(repo: git.Repo) -> str:
     return repo.git.status()
-
 
 def git_diff_unstaged(repo: git.Repo) -> str:
     return repo.git.diff()
 
-
 def git_diff_staged(repo: git.Repo) -> str:
     return repo.git.diff("--cached")
 
-
 def git_diff(repo: git.Repo, target: str) -> str:
     return repo.git.diff(target)
-
 
 def git_commit(repo: git.Repo, message: str) -> str:
     commit = repo.index.commit(message)
     return f"Changes committed successfully with hash {commit.hexsha}"
 
-
 def git_add(repo: git.Repo, files: list[str]) -> str:
     repo.index.add(files)
     return "Files staged successfully"
 
-
 def git_reset(repo: git.Repo) -> str:
     repo.index.reset()
     return "All staged changes reset"
-
 
 def git_log(repo: git.Repo, max_count: int = 10) -> list[str]:
     commits = list(repo.iter_commits(max_count=max_count))
@@ -137,10 +116,7 @@ def git_log(repo: git.Repo, max_count: int = 10) -> list[str]:
         )
     return log
 
-
-def git_create_branch(
-    repo: git.Repo, branch_name: str, base_branch: str | None = None
-) -> str:
+def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None = None) -> str:
     if base_branch:
         base = repo.refs[base_branch]
     else:
@@ -149,11 +125,9 @@ def git_create_branch(
     repo.create_head(branch_name, base)
     return f"Created branch '{branch_name}' from '{base.name}'"
 
-
 def git_checkout(repo: git.Repo, branch_name: str) -> str:
     repo.git.checkout(branch_name)
     return f"Switched to branch '{branch_name}'"
-
 
 def git_init(repo_path: str) -> str:
     try:
@@ -161,7 +135,6 @@ def git_init(repo_path: str) -> str:
         return f"Initialized empty Git repository in {repo.git_dir}"
     except Exception as e:
         return f"Error initializing repository: {str(e)}"
-
 
 def git_show(repo: git.Repo, revision: str) -> str:
     commit = repo.commit(revision)
@@ -178,9 +151,8 @@ def git_show(repo: git.Repo, revision: str) -> str:
         diff = commit.diff(git.NULL_TREE, create_patch=True)
     for d in diff:
         output.append(f"\n--- {d.a_path}\n+++ {d.b_path}\n")
-        output.append(d.diff.decode("utf-8"))
+        output.append(d.diff.decode('utf-8'))
     return "".join(output)
-
 
 async def serve(
     repository: Path | None,
@@ -262,24 +234,21 @@ async def serve(
                 name=GitTools.INIT,
                 description="Initialize a new Git repository",
                 inputSchema=GitInit.schema(),
-            ),
+            )
         ]
 
     async def list_repos() -> Sequence[str]:
         async def by_roots() -> Sequence[str]:
             if not isinstance(server.request_context.session, ServerSession):
-                raise TypeError(
-                    "server.request_context.session must be a ServerSession"
-                )
+                raise TypeError("server.request_context.session must be a ServerSession")
 
             if not server.request_context.session.check_client_capability(
                 ClientCapabilities(roots=RootsCapability())
             ):
                 return []
 
-            roots_result: ListRootsResult = (
-                await server.request_context.session.list_roots()
-            )
+            roots_result: ListRootsResult = await server.request_context.session.list_roots()
+            logger.debug(f"Roots result: {roots_result}")
             repo_paths = []
             for root in roots_result.roots:
                 path = root.uri.path
@@ -300,67 +269,99 @@ async def serve(
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         repo_path = Path(arguments["repo_path"])
-
+        
         # Handle git init separately since it doesn't require an existing repo
         if name == GitTools.INIT:
             result = git_init(str(repo_path))
-            return [TextContent(type="text", text=result)]
-
+            return [TextContent(
+                type="text",
+                text=result
+            )]
+            
         # For all other commands, we need an existing repo
         repo = git.Repo(repo_path)
 
         match name:
             case GitTools.STATUS:
                 status = git_status(repo)
-                return [TextContent(type="text", text=f"Repository status:\n{status}")]
+                return [TextContent(
+                    type="text",
+                    text=f"Repository status:\n{status}"
+                )]
 
             case GitTools.DIFF_UNSTAGED:
                 diff = git_diff_unstaged(repo)
-                return [TextContent(type="text", text=f"Unstaged changes:\n{diff}")]
+                return [TextContent(
+                    type="text",
+                    text=f"Unstaged changes:\n{diff}"
+                )]
 
             case GitTools.DIFF_STAGED:
                 diff = git_diff_staged(repo)
-                return [TextContent(type="text", text=f"Staged changes:\n{diff}")]
+                return [TextContent(
+                    type="text",
+                    text=f"Staged changes:\n{diff}"
+                )]
 
             case GitTools.DIFF:
                 diff = git_diff(repo, arguments["target"])
-                return [
-                    TextContent(
-                        type="text", text=f"Diff with {arguments['target']}:\n{diff}"
-                    )
-                ]
+                return [TextContent(
+                    type="text",
+                    text=f"Diff with {arguments['target']}:\n{diff}"
+                )]
 
             case GitTools.COMMIT:
                 result = git_commit(repo, arguments["message"])
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case GitTools.ADD:
                 result = git_add(repo, arguments["files"])
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case GitTools.RESET:
                 result = git_reset(repo)
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case GitTools.LOG:
                 log = git_log(repo, arguments.get("max_count", 10))
-                return [
-                    TextContent(type="text", text="Commit history:\n" + "\n".join(log))
-                ]
+                return [TextContent(
+                    type="text",
+                    text="Commit history:\n" + "\n".join(log)
+                )]
 
             case GitTools.CREATE_BRANCH:
                 result = git_create_branch(
-                    repo, arguments["branch_name"], arguments.get("base_branch")
+                    repo,
+                    arguments["branch_name"],
+                    arguments.get("base_branch")
                 )
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case GitTools.CHECKOUT:
                 result = git_checkout(repo, arguments["branch_name"])
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case GitTools.SHOW:
                 result = git_show(repo, arguments["revision"])
-                return [TextContent(type="text", text=result)]
+                return [TextContent(
+                    type="text",
+                    text=result
+                )]
 
             case _:
                 raise ValueError(f"Unknown tool: {name}")

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -1,63 +1,83 @@
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import Sequence
+
+import uvicorn
 from mcp.server import Server
 from mcp.server.session import ServerSession
+from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.types import (
     ClientCapabilities,
-    TextContent,
-    Tool,
     ListRootsResult,
     RootsCapability,
+    TextContent,
+    Tool,
 )
-from enum import Enum
-import git
 from pydantic import BaseModel
+from starlette.applications import Starlette
+from starlette.responses import Response
+from starlette.routing import Mount, Route
+
+import git
+
 
 class GitStatus(BaseModel):
     repo_path: str
 
+
 class GitDiffUnstaged(BaseModel):
     repo_path: str
 
+
 class GitDiffStaged(BaseModel):
     repo_path: str
+
 
 class GitDiff(BaseModel):
     repo_path: str
     target: str
 
+
 class GitCommit(BaseModel):
     repo_path: str
     message: str
+
 
 class GitAdd(BaseModel):
     repo_path: str
     files: list[str]
 
+
 class GitReset(BaseModel):
     repo_path: str
+
 
 class GitLog(BaseModel):
     repo_path: str
     max_count: int = 10
+
 
 class GitCreateBranch(BaseModel):
     repo_path: str
     branch_name: str
     base_branch: str | None = None
 
+
 class GitCheckout(BaseModel):
     repo_path: str
     branch_name: str
+
 
 class GitShow(BaseModel):
     repo_path: str
     revision: str
 
+
 class GitInit(BaseModel):
     repo_path: str
+
 
 class GitTools(str, Enum):
     STATUS = "git_status"
@@ -73,29 +93,37 @@ class GitTools(str, Enum):
     SHOW = "git_show"
     INIT = "git_init"
 
+
 def git_status(repo: git.Repo) -> str:
     return repo.git.status()
+
 
 def git_diff_unstaged(repo: git.Repo) -> str:
     return repo.git.diff()
 
+
 def git_diff_staged(repo: git.Repo) -> str:
     return repo.git.diff("--cached")
 
+
 def git_diff(repo: git.Repo, target: str) -> str:
     return repo.git.diff(target)
+
 
 def git_commit(repo: git.Repo, message: str) -> str:
     commit = repo.index.commit(message)
     return f"Changes committed successfully with hash {commit.hexsha}"
 
+
 def git_add(repo: git.Repo, files: list[str]) -> str:
     repo.index.add(files)
     return "Files staged successfully"
 
+
 def git_reset(repo: git.Repo) -> str:
     repo.index.reset()
     return "All staged changes reset"
+
 
 def git_log(repo: git.Repo, max_count: int = 10) -> list[str]:
     commits = list(repo.iter_commits(max_count=max_count))
@@ -109,7 +137,10 @@ def git_log(repo: git.Repo, max_count: int = 10) -> list[str]:
         )
     return log
 
-def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None = None) -> str:
+
+def git_create_branch(
+    repo: git.Repo, branch_name: str, base_branch: str | None = None
+) -> str:
     if base_branch:
         base = repo.refs[base_branch]
     else:
@@ -118,9 +149,11 @@ def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None 
     repo.create_head(branch_name, base)
     return f"Created branch '{branch_name}' from '{base.name}'"
 
+
 def git_checkout(repo: git.Repo, branch_name: str) -> str:
     repo.git.checkout(branch_name)
     return f"Switched to branch '{branch_name}'"
+
 
 def git_init(repo_path: str) -> str:
     try:
@@ -128,6 +161,7 @@ def git_init(repo_path: str) -> str:
         return f"Initialized empty Git repository in {repo.git_dir}"
     except Exception as e:
         return f"Error initializing repository: {str(e)}"
+
 
 def git_show(repo: git.Repo, revision: str) -> str:
     commit = repo.commit(revision)
@@ -144,19 +178,35 @@ def git_show(repo: git.Repo, revision: str) -> str:
         diff = commit.diff(git.NULL_TREE, create_patch=True)
     for d in diff:
         output.append(f"\n--- {d.a_path}\n+++ {d.b_path}\n")
-        output.append(d.diff.decode('utf-8'))
+        output.append(d.diff.decode("utf-8"))
     return "".join(output)
 
-async def serve(repository: Path | None) -> None:
+
+async def serve(
+    repository: Path | None,
+    transport: str = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 9000,
+) -> tuple[Starlette | None, str, int] | None:
     logger = logging.getLogger(__name__)
 
     if repository is not None:
         try:
-            git.Repo(repository)
+            logger.debug(f"Validating repository path: {repository}")
+            repo = git.Repo(repository)
             logger.info(f"Using repository at {repository}")
-        except git.InvalidGitRepositoryError:
-            logger.error(f"{repository} is not a valid Git repository")
-            return
+        except git.InvalidGitRepositoryError as e:
+            logger.error(f"{repository} is not a valid Git repository: {e}")
+            # Return a detailed error message for debugging
+            return [
+                TextContent(
+                    type="text",
+                    text=f"Error: {repository} is not a valid Git repository: {e}",
+                )
+            ]
+        except Exception as e:
+            logger.error(f"Unexpected error while validating repository: {e}")
+            return [TextContent(type="text", text=f"Unexpected error: {e}")]
 
     server = Server("mcp-git")
 
@@ -222,20 +272,24 @@ async def serve(repository: Path | None) -> None:
                 name=GitTools.INIT,
                 description="Initialize a new Git repository",
                 inputSchema=GitInit.schema(),
-            )
+            ),
         ]
 
     async def list_repos() -> Sequence[str]:
         async def by_roots() -> Sequence[str]:
             if not isinstance(server.request_context.session, ServerSession):
-                raise TypeError("server.request_context.session must be a ServerSession")
+                raise TypeError(
+                    "server.request_context.session must be a ServerSession"
+                )
 
             if not server.request_context.session.check_client_capability(
                 ClientCapabilities(roots=RootsCapability())
             ):
                 return []
 
-            roots_result: ListRootsResult = await server.request_context.session.list_roots()
+            roots_result: ListRootsResult = (
+                await server.request_context.session.list_roots()
+            )
             logger.debug(f"Roots result: {roots_result}")
             repo_paths = []
             for root in roots_result.roots:
@@ -257,103 +311,92 @@ async def serve(repository: Path | None) -> None:
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         repo_path = Path(arguments["repo_path"])
-        
+
         # Handle git init separately since it doesn't require an existing repo
         if name == GitTools.INIT:
             result = git_init(str(repo_path))
-            return [TextContent(
-                type="text",
-                text=result
-            )]
-            
+            return [TextContent(type="text", text=result)]
+
         # For all other commands, we need an existing repo
         repo = git.Repo(repo_path)
 
         match name:
             case GitTools.STATUS:
                 status = git_status(repo)
-                return [TextContent(
-                    type="text",
-                    text=f"Repository status:\n{status}"
-                )]
+                return [TextContent(type="text", text=f"Repository status:\n{status}")]
 
             case GitTools.DIFF_UNSTAGED:
                 diff = git_diff_unstaged(repo)
-                return [TextContent(
-                    type="text",
-                    text=f"Unstaged changes:\n{diff}"
-                )]
+                return [TextContent(type="text", text=f"Unstaged changes:\n{diff}")]
 
             case GitTools.DIFF_STAGED:
                 diff = git_diff_staged(repo)
-                return [TextContent(
-                    type="text",
-                    text=f"Staged changes:\n{diff}"
-                )]
+                return [TextContent(type="text", text=f"Staged changes:\n{diff}")]
 
             case GitTools.DIFF:
                 diff = git_diff(repo, arguments["target"])
-                return [TextContent(
-                    type="text",
-                    text=f"Diff with {arguments['target']}:\n{diff}"
-                )]
+                return [
+                    TextContent(
+                        type="text", text=f"Diff with {arguments['target']}:\n{diff}"
+                    )
+                ]
 
             case GitTools.COMMIT:
                 result = git_commit(repo, arguments["message"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.ADD:
                 result = git_add(repo, arguments["files"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.RESET:
                 result = git_reset(repo)
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.LOG:
                 log = git_log(repo, arguments.get("max_count", 10))
-                return [TextContent(
-                    type="text",
-                    text="Commit history:\n" + "\n".join(log)
-                )]
+                return [
+                    TextContent(type="text", text="Commit history:\n" + "\n".join(log))
+                ]
 
             case GitTools.CREATE_BRANCH:
                 result = git_create_branch(
-                    repo,
-                    arguments["branch_name"],
-                    arguments.get("base_branch")
+                    repo, arguments["branch_name"], arguments.get("base_branch")
                 )
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.CHECKOUT:
                 result = git_checkout(repo, arguments["branch_name"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.SHOW:
                 result = git_show(repo, arguments["revision"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case _:
                 raise ValueError(f"Unknown tool: {name}")
 
     options = server.create_initialization_options()
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+    if transport == "stdio":
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        return None
+    elif transport == "sse":
+        sse = SseServerTransport("/messages/")
+
+        async def handle_sse(request):
+            async with sse.connect_sse(
+                request.scope, request.receive, request._send
+            ) as streams:
+                await server.run(streams[0], streams[1], options)
+            return Response()
+
+        routes = [
+            Route("/sse", endpoint=handle_sse, methods=["GET"]),
+            Mount("/messages/", app=sse.handle_post_message),
+        ]
+        app = Starlette(routes=routes)
+        return app, host, port
+    else:
+        logger.error(f"Unknown transport: {transport}")
+        raise ValueError(f"Unknown transport: {transport}")

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -192,21 +192,11 @@ async def serve(
 
     if repository is not None:
         try:
-            logger.debug(f"Validating repository path: {repository}")
-            repo = git.Repo(repository)
+            git.Repo(repository)
             logger.info(f"Using repository at {repository}")
-        except git.InvalidGitRepositoryError as e:
-            logger.error(f"{repository} is not a valid Git repository: {e}")
-            # Return a detailed error message for debugging
-            return [
-                TextContent(
-                    type="text",
-                    text=f"Error: {repository} is not a valid Git repository: {e}",
-                )
-            ]
-        except Exception as e:
-            logger.error(f"Unexpected error while validating repository: {e}")
-            return [TextContent(type="text", text=f"Unexpected error: {e}")]
+        except git.InvalidGitRepositoryError:
+            logger.error(f"{repository} is not a valid Git repository")
+            return
 
     server = Server("mcp-git")
 
@@ -290,7 +280,6 @@ async def serve(
             roots_result: ListRootsResult = (
                 await server.request_context.session.list_roots()
             )
-            logger.debug(f"Roots result: {roots_result}")
             repo_paths = []
             for root in roots_result.roots:
                 path = root.uri.path


### PR DESCRIPTION
- Added --transport, --host, and --port CLI options
- Implemented SSE support using Starlette and SseServerTransport
- Maintains backward compatibility with stdio transport

<!-- Provide a brief description of your changes -->

## Description
This update adds support for Server-Sent Events (SSE) to the MCP Git server

## Server Details
- Server: git
- Changes to: server transport options, CLI, and server startup logic

## Motivation and Context
This change enables the MCP Git server to support real-time, streamable HTTP connections, making it compatible with modern LLM clients and web-based tools that require SSE.

## How Has This Been Tested?
Verified tool listing and tool execution via the MCP Inspector (@modelcontextprotocol/inspector)
I did not test it with Claude Desktop, as I'm not sure if that supports sse

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

