### PR TITLE
Add mcp-weather server using AccuWeather API to community server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[XMind](https://github.com/apeyroux/mcp-xmind)** - Read and search through your XMind directory containing XMind files.
 - **[YouTube](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/youtube)** - Extract Youtube video information (with proxies support).
 - **[YouTube](https://github.com/ZubeidHendricks/youtube-mcp-server)** - Comprehensive YouTube API integration for video management, Shorts creation, and analytics.
+- **[TimLukaHorstmann/mcp-weather](https://github.com/TimLukaHorstmann/mcp-weather)** - Accurate weather forecasts via the AccuWeather API (free tier available).
 - **[mcp_weather](https://github.com/isdaniel/mcp_weather_server)** - Get weather information from https://api.open-meteo.com API.
 
 ## 📚 Frameworks


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Added a link to the `mcp-weather` server to the community server list in the `README.md`.  
This server provides real-time weather data via AccuWeather and integrates with MCP-compatible clients.
It is thus different than other mcp-weather servers based on the Open Meteo API, for instance.

## Server Details

- Server: [mcp-weather](https://github.com/TimLukaHorstmann/mcp-weather)
- Changes to: README.md (added link under community servers section)

## Motivation and Context

This server allows large language models to retrieve accurate weather forecasts (hourly and daily) by location.  
It is built to be lightweight, easy to use, and fully MCP-compliant. Adding it to the official list helps others discover and use it.

## How Has This Been Tested?

Tested extensively with Claude Desktop via MCP, including:
- Hourly and daily forecast queries
- Metric and imperial unit toggles
- Multiple global locations

## Breaking Changes

No breaking changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

The `mcp-weather` server is published on npm: [@timlukahorstmann/mcp-weather](https://www.npmjs.com/package/@timlukahorstmann/mcp-weather)  
It supports both `npx`-based CLI usage and HTTP/REST via `supergateway`.  
Includes live deployment badge via [glama.ai](https://glama.ai/mcp/servers/@TimLukaHorstmann/mcp-weather) and a complete usage guide for integration with Claude Desktop and other clients.