### PR TITLE
Add zoom MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[XMind](https://github.com/apeyroux/mcp-xmind)** - Read and search through your XMind directory containing XMind files.
 - **[YouTube](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/youtube)** - Extract Youtube video information (with proxies support).
 - **[YouTube](https://github.com/ZubeidHendricks/youtube-mcp-server)** - Comprehensive YouTube API integration for video management, Shorts creation, and analytics.
+- **[Zoom](https://github.com/Prathamesh0901/zoom-mcp-server/tree/main)** - Create, update, read and delete your zoom meetings.
 - **[mcp_weather](https://github.com/isdaniel/mcp_weather_server)** - Get weather information from https://api.open-meteo.com API.
 
 ## 📚 Frameworks


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
Zoom MCP server let's you create, update, read and delete your zoom meetings with the help of clients like Claude or Cursor.
Just add your account tokens while configuring and you are good to go.