### PR TITLE
fetch - max_length customization

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -8,7 +8,7 @@ The fetch tool will truncate the response, but by using the `start_index` argume
 
 - `fetch` - Fetches a URL from the internet and extracts its contents as markdown.
     - `url` (string, required): URL to fetch
-    - `max_length` (integer, optional): Maximum number of characters to return (default: 5000)
+    - `max_length` (integer, optional): Maximum number of characters to return (default: 5000). This can be overridden (see customization below)
     - `start_index` (integer, optional): Start content from this character index (default: 0)
     - `raw` (boolean, optional): Get raw content without markdown conversion (default: false)
 
@@ -158,6 +158,39 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 ### Customization - Proxy
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
+
+### Customization - Max Length
+
+By default, the maximum length of content returned is 5000 characters. This can be customized by setting the `MAX_LENGTH` environment variable.
+
+<details>
+<summary>Using uvx</summary>
+
+```json
+"mcpServers": {
+  "fetch": {
+    "command": "uvx",
+    "args": ["mcp-server-fetch"],
+    "env": {
+      "MAX_LENGTH": "10000"
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Using Docker</summary>
+
+```json
+"mcpServers": {
+  "fetch": {
+    "command": "docker",
+    "args": ["run", "-i", "--rm", "-e", "MAX_LENGTH=10000", "mcp/fetch"]
+  }
+}
+```
+</details>
 
 ## Debugging
 

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Tuple
 from urllib.parse import urlparse, urlunparse
+import os
 
 import markdownify
 import readabilipy.simple_json
@@ -22,6 +23,7 @@ from pydantic import BaseModel, Field, AnyUrl
 
 DEFAULT_USER_AGENT_AUTONOMOUS = "ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)"
 DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://github.com/modelcontextprotocol/servers)"
+MAX_LENGTH = os.environ.get("MAX_LENGTH", 5000)
 
 
 def extract_content_from_html(html: str) -> str:
@@ -155,7 +157,7 @@ class Fetch(BaseModel):
     max_length: Annotated[
         int,
         Field(
-            default=5000,
+            default=MAX_LENGTH,
             description="Maximum number of characters to return.",
             gt=0,
             lt=1000000,


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

For the `fetch` MCP server, allows overriding of the default `max_length` argument using a `MAX_LENGTH` environment variable.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: fetch
- Changes to: tools

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The default max_length of 5000 is sometimes too low and requires too many HTTP requests. It would be nice to be able to increase this value on a case by case basis.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
I tested this change with Amazon Q CLI.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
