### PR TITLE
Fix server-everything output and disconnect behavior

### DIFF
--- a/src/everything/sse.ts
+++ b/src/everything/sse.ts
@@ -19,6 +19,7 @@ app.get("/sse", async (req, res) => {
     await cleanup();
     await server.close();
   };
+
 });
 
 app.post("/message", async (req, res) => {
@@ -27,7 +28,14 @@ app.post("/message", async (req, res) => {
   await transport.handlePostMessage(req, res);
 });
 
+process.on("SIGINT", async () => {
+  await cleanup();
+  await server.close();
+  process.exit(0);
+});
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.error(`Server is running on port ${PORT}`);
 });
+

--- a/src/everything/sse.ts
+++ b/src/everything/sse.ts
@@ -11,24 +11,23 @@ const { server, cleanup } = createServer();
 let transport: SSEServerTransport;
 
 app.get("/sse", async (req, res) => {
-  console.log("Received connection");
+  console.error("Received connection");
   transport = new SSEServerTransport("/message", res);
   await server.connect(transport);
 
   server.onclose = async () => {
     await cleanup();
     await server.close();
-    process.exit(0);
   };
 });
 
 app.post("/message", async (req, res) => {
-  console.log("Received message");
+  console.error("Received message");
 
   await transport.handlePostMessage(req, res);
 });
 
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
+  console.error(`Server is running on port ${PORT}`);
 });

--- a/src/everything/streamableHttp.ts
+++ b/src/everything/streamableHttp.ts
@@ -13,7 +13,7 @@ const { server, cleanup } = createServer();
 const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 
 app.post('/mcp', async (req: Request, res: Response) => {
-  console.log('Received MCP POST request');
+  console.error('Received MCP POST request');
   try {
     // Check for existing session ID
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
@@ -31,7 +31,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
         onsessioninitialized: (sessionId) => {
           // Store the transport by session ID when session is initialized
           // This avoids race conditions where requests might come in before the session is stored
-          console.log(`Session initialized with ID: ${sessionId}`);
+          console.error(`Session initialized with ID: ${sessionId}`);
           transports[sessionId] = transport;
         }
       });
@@ -40,7 +40,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
       transport.onclose = () => {
         const sid = transport.sessionId;
         if (sid && transports[sid]) {
-          console.log(`Transport closed for session ${sid}, removing from transports map`);
+          console.error(`Transport closed for session ${sid}, removing from transports map`);
           delete transports[sid];
         }
       };
@@ -85,7 +85,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 
 // Handle GET requests for SSE streams (using built-in support from StreamableHTTP)
 app.get('/mcp', async (req: Request, res: Response) => {
-  console.log('Received MCP GET request');
+  console.error('Received MCP GET request');
   const sessionId = req.headers['mcp-session-id'] as string | undefined;
   if (!sessionId || !transports[sessionId]) {
     res.status(400).json({
@@ -102,9 +102,9 @@ app.get('/mcp', async (req: Request, res: Response) => {
   // Check for Last-Event-ID header for resumability
   const lastEventId = req.headers['last-event-id'] as string | undefined;
   if (lastEventId) {
-    console.log(`Client reconnecting with Last-Event-ID: ${lastEventId}`);
+    console.error(`Client reconnecting with Last-Event-ID: ${lastEventId}`);
   } else {
-    console.log(`Establishing new SSE stream for session ${sessionId}`);
+    console.error(`Establishing new SSE stream for session ${sessionId}`);
   }
 
   const transport = transports[sessionId];
@@ -126,7 +126,7 @@ app.delete('/mcp', async (req: Request, res: Response) => {
     return;
   }
 
-  console.log(`Received session termination request for session ${sessionId}`);
+  console.error(`Received session termination request for session ${sessionId}`);
 
   try {
     const transport = transports[sessionId];
@@ -150,17 +150,17 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 // Start the server
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
-  console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
+  console.error(`MCP Streamable HTTP Server listening on port ${PORT}`);
 });
 
 // Handle server shutdown
 process.on('SIGINT', async () => {
-  console.log('Shutting down server...');
+  console.error('Shutting down server...');
 
   // Close all active transports to properly clean up resources
   for (const sessionId in transports) {
     try {
-      console.log(`Closing transport for session ${sessionId}`);
+      console.error(`Closing transport for session ${sessionId}`);
       await transports[sessionId].close();
       delete transports[sessionId];
     } catch (error) {
@@ -169,6 +169,6 @@ process.on('SIGINT', async () => {
   }
   await cleanup();
   await server.close();
-  console.log('Server shutdown complete');
+  console.error('Server shutdown complete');
   process.exit(0);
 });


### PR DESCRIPTION
## Description
* In src/everything/sse.ts and streamableHttp.ts
  - Replace `console.log` with `console.error` throughout
* In src/everything/sse.ts
  - remove the `process.exit()` in the `server.onclose` handler so reconnections are possible
  - add SIGINT handler that does cleanup, server.close, and process.exit (same as in stdio.ts and streamableHttp.ts)

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: server-everything
- Changes to: suppress non-json output, handle SIGINT and allow reconnections to sse server

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While looking at [this PR for the inspector](https://github.com/modelcontextprotocol/inspector/pull/380) it became obvious that we need to suppress all console.log output as per the spec, even in SSE/StreamableHttp (STDIO was already using only `console.error`). 

Also since that PR was testing ability to reconnect, I fixed the long-annoying behavior of the SSE server of closing entirely when the client disconnects.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Local testing with current Inspector, SSE, StreamableHttp, and STDIO.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
