### PR TITLE
Adopt recommended `uv` dependency sync behavior 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: src/${{ matrix.package }}
-        run: uv sync --frozen --all-extras --dev
+        run: uv sync --locked --all-extras --dev
 
       - name: Run pyright
         working-directory: src/${{ matrix.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: src/${{ matrix.package }}
-        run: uv sync --frozen --all-extras --dev
+        run: uv sync --locked --all-extras --dev
 
       - name: Run pyright
         working-directory: src/${{ matrix.package }}

--- a/src/fetch/Dockerfile
+++ b/src/fetch/Dockerfile
@@ -14,13 +14,13 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 

--- a/src/git/Dockerfile
+++ b/src/git/Dockerfile
@@ -14,13 +14,13 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 

--- a/src/sentry/Dockerfile
+++ b/src/sentry/Dockerfile
@@ -14,13 +14,13 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 

--- a/src/sqlite/Dockerfile
+++ b/src/sqlite/Dockerfile
@@ -14,13 +14,13 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 

--- a/src/time/Dockerfile
+++ b/src/time/Dockerfile
@@ -14,13 +14,13 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --locked --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
 ADD . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --locked --no-dev --no-editable
 
 FROM python:3.12-slim-bookworm
 


### PR DESCRIPTION
## Description
This PR introduces a patch to align the `uv` command for dependency synchronization with best practices and recommendations. It replaces all occurrences of `uv sync --frozen` with `uv sync --locked`.

**Note:** Applied update to the following files:
```bash
➜  mcp-servers git:(main) grep -ri 'uv sync' .
./src/fetch/Dockerfile:    uv sync --frozen --no-install-project --no-dev --no-editable
./src/fetch/Dockerfile:    uv sync --frozen --no-dev --no-editable
./src/git/Dockerfile:    uv sync --frozen --no-install-project --no-dev --no-editable
./src/git/Dockerfile:    uv sync --frozen --no-dev --no-editable
./src/sentry/Dockerfile:    uv sync --frozen --no-install-project --no-dev --no-editable
./src/sentry/Dockerfile:    uv sync --frozen --no-dev --no-editable
./src/sqlite/Dockerfile:    uv sync --frozen --no-install-project --no-dev --no-editable
./src/sqlite/Dockerfile:    uv sync --frozen --no-dev --no-editable
./src/time/Dockerfile:    uv sync --frozen --no-install-project --no-dev --no-editable
./src/time/Dockerfile:    uv sync --frozen --no-dev --no-editable
./.github/workflows/release.yml:        run: uv sync --frozen --all-extras --dev
./.github/workflows/python.yml:        run: uv sync --frozen --all-extras --dev
➜  mcp-servers git:(main)
```

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The Python-related Dockerfiles used in `modelcontextprotocol/servers` are sourced from `uv`'s maintained example Dockerfiles [repo](https://github.com/astral-sh/uv-docker-example). This PR introduces new updates from the upstream repo to stay up-to-date and align with best practices. The patch aims to promote consistent and reproducible builds and potentially address open issues that identify dependency inconsistencies (see issue #997)

#### Key Differences between `--locked` and `--frozen`

- `--frozen`: Proceed with the existing lockfile without checking for consistency with `pyproject.toml`. This means `uv` proceeds, without error, with a lockfile _as-is_ (regardless of its state), potentially leading to inconsistencies.
- `--locked`: Check if `uv.lock` is aligned/up-to-date with the dependencies defined in `pyproject.toml`. This ensures `uv` _fails-fast_ if the lock file is outdated, preventing unintended changes and enforcing consistency across environments.

#### More info from the official [docs](https://docs.astral.sh/uv/concepts/projects/sync/):
> "Locking is the process of resolving your project's dependencies into a [lockfile](https://docs.astral.sh/uv/concepts/projects/layout/#the-lockfile). Syncing is the process of installing a subset of packages from the lockfile into the [project environment](https://docs.astral.sh/uv/concepts/projects/layout/#the-project-environment)."

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Acknowledgements
This patch was influenced by a recent [PR](https://github.com/astral-sh/uv-docker-example/pull/53/) made by @zanieb from @astral-sh. They would be best to further advise or contribute to this.