### PR TITLE
Added Fal ai MCP to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[EVM MCP Server](https://github.com/mcpdotdirect/evm-mcp-server)** - Comprehensive blockchain services for 30+ EVM networks, supporting native tokens, ERC20, NFTs, smart contracts, transactions, and ENS resolution.
 - **[Everything Search](https://github.com/mamertofabian/mcp-everything-search)** - Fast file searching capabilities across Windows (using [Everything SDK](https://www.voidtools.com/support/everything/sdk/)), macOS (using mdfind command), and Linux (using locate/plocate command).
 - **[Excel](https://github.com/haris-musa/excel-mcp-server)** - Excel manipulation including data reading/writing, worksheet management, formatting, charts, and pivot table.
+- **[falai](https://github.com/universal-mcp/falai)** - Fal.ai mcp server from **[agentr](https://agentr.dev/)** that provides support for generating media using fast inference engine.
 - **[Fantasy PL](https://github.com/rishijatia/fantasy-pl-mcp)** - Give your coding agent direct access to up-to date Fantasy Premier League data
 - **[fastn.ai – Unified API MCP Server](https://github.com/fastnai/mcp-fastn)** - A remote, dynamic MCP server with a unified API that connects to 1,000+ tools, actions, and workflows, featuring built-in authentication and monitoring.
 - **[Federal Reserve Economic Data (FRED)](https://github.com/stefanoamorelli/fred-mcp-server)** (by Stefano Amorelli) - Community developed MCP server to interact with the Federal Reserve Economic Data.


### PR DESCRIPTION
## Description

## Server Details

- Server: fal.ai mcp server
- Changes to: README.md (add new community server reference)

## Motivation and Context
This change adds visibility for the FAL Ai MCP Server, allowing the MCP community to discover and use a server that provides fast media genration using fal ai inference engine. It expands the ecosystem of available MCP servers and demonstrates integration with LLM clients such as Claude Desktop.

## How Has This Been Tested?
The server has been tested with Claude Desktop and the official MCP Python client.

## Breaking Changes
No breaking changes. This is an addition to the community servers list. Users who wish to use the FAL AI MCP Server will need to add its configuration to their MCP client.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The [Quickstart](https://agentr.dev/quickstart) includes setup instructions and example usage with Claude Desktop.
