### PR TITLE
docs: Add Calendly MCP Server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[browser-use](https://github.com/co-browser/browser-use-mcp-server)** (by co-browser) - browser-use MCP server with dockerized playwright + chromium + vnc. supports stdio & resumable http.
 - **[Bsc-mcp](https://github.com/TermiX-official/bsc-mcp)** The first MCP server that serves as the bridge between AI and BNB Chain, enabling AI agents to execute complex on-chain operations through seamless integration with the BNB Chain, including transfer, swap, launch, security check on any token and even more.
 - **[Calculator](https://github.com/githejie/mcp-server-calculator)** - This server enables LLMs to use calculator for precise numerical calculations.
+- **[Calendly](https://github.com/universal-mcp/calendly)** - Calendly MCP server from **[agentr](https://agentr.dev/)** that provides support for managing events and scheduling via Calendly.
 - **[CFBD API](https://github.com/lenwood/cfbd-mcp-server)** - An MCP server for the [College Football Data API](https://collegefootballdata.com/).
 - **[ChatMCP](https://github.com/AI-QL/chat-mcp)** – An Open Source Cross-platform GUI Desktop application compatible with Linux, macOS, and Windows, enabling seamless interaction with MCP servers across dynamically selectable LLMs, by **[AIQL](https://github.com/AI-QL)**
 - **[ChatSum](https://github.com/mcpso/mcp-server-chatsum)** - Query and Summarize chat messages with LLM. by [mcpso](https://mcp.so)


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
- Server: Calendly MCP Server
- Changes to: README.md (add new community server reference)

## Motivation and Context
This change adds visibility for the Calendly MCP Server, allowing the MCP community to discover and use a server that provides robust capabilities for managing events and scheduling via Calendly. It expands the ecosystem of available MCP servers and demonstrates integration with LLM clients such as Claude Desktop.

## How Has This Been Tested?
The Calendly MCP Server has been tested with Claude Desktop and the official MCP Python client to ensure proper functionality for managing events and scheduling.

## Breaking Changes
No breaking changes. This is an addition to the community servers list. Users who wish to use the Calendly MCP Server will need to add its configuration to their MCP client.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The [Quickstart](https://agentr.dev/quickstart) includes setup instructions and example usage with Claude Desktop.
