### PR TITLE
Add basic mitigation against postgres queries injecting to trigger writes or other dangerous actions

### DIFF
--- a/src/postgres/README.md
+++ b/src/postgres/README.md
@@ -2,6 +2,9 @@
 
 A Model Context Protocol server that provides read-only access to PostgreSQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.
 
+> [!CAUTION]
+> This server provides database access to AI models. If you need to enforce read-only access for security, create a separate database user with only SELECT permissions instead of relying on this server's built-in restrictions.
+
 ## Components
 
 ### Tools


### PR DESCRIPTION
This mitigates the trick of injecting `COMMIT` and `END` to bypass the read-only restrictions. I believe this should fully fix the issue, but I added a warning to encourage people to also enforce this through postgres permissions. 

Note: This is based on the approach used by @smola [here](https://github.com/zed-industries/postgres-context-server/commit/c68598004db5e33c39cc9917aecb07a213d8f27e), so thank you Santiago for the idea of using a parameterized query to accomplish this. 