### PR TITLE
Slack(feat): add ability to filter by oldest and latest timerange 

### DIFF
--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -40,6 +40,8 @@ MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.
      - `channel_id` (string): The channel ID
    - Optional inputs:
      - `limit` (number, default: 10): Number of messages to retrieve
+     - `latest` (string): Unix timestamp of the latest message to retrieve
+     - `oldest` (number, default: 10): Unix timestamp of the oldest message to retrieve
    - Returns: List of messages with their content and metadata
 
 6. `slack_get_thread_replies`


### PR DESCRIPTION
## Description
Added oldest and latest message as parameter to help filter down messages in a range


## Server Details
- Server: Slack
- Changes to: Tools

## Motivation and Context
It helps the LLM to chunk messages that can be retrieved from Slack itself, so that it does not hit the maximum amount of tokens when retrieving slack channels with lots of messages

## How Has This Been Tested?
- Existing backward compatibility test which includes the LLM not providing new parameters
- New feature test by providing the oldest param
- New feature test by providing the oldest param and the latest param
- New feature test by providing the oldest param and the latest param

## Breaking Changes
No breaking changes introduced in this change


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
