### PR TITLE
Add DynamoDB-Toolbox to Community MCP Servers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[DPLP](https://github.com/szeider/mcp-dblp)**  - Searches the [DBLP](https://dblp.org) computer science bibliography database.
 - **[Drupal](https://github.com/Omedia/mcp-server-drupal)** - Server for interacting with [Drupal](https://www.drupal.org/project/mcp) using STDIO transport layer.
 - **[dune-analytics-mcp](https://github.com/kukapay/dune-analytics-mcp)** -  A mcp server that bridges Dune Analytics data to AI agents.
+- **[DynamoDB-Toolbox](https://www.dynamodbtoolbox.com/docs/databases/actions/mcp-toolkit)** - Leverages your Schemas and Access Patterns to interact with your [DynamoDB](https://aws.amazon.com/dynamodb) Database using natural language.
 - **[EdgeOne Pages MCP](https://github.com/TencentEdgeOne/edgeone-pages-mcp)** - An MCP service for deploying HTML content to EdgeOne Pages and obtaining a publicly accessible URL.
 - **[Edwin](https://github.com/edwin-finance/edwin/tree/main/examples/mcp-server)** - MCP server for edwin SDK - enabling AI agents to interact with DeFi protocols across EVM, Solana and other blockchains.
 - **[Elasticsearch](https://github.com/cr7258/elasticsearch-mcp-server)** - MCP server implementation that provides Elasticsearch interaction.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Adding https://www.dynamodbtoolbox.com/ as a MCP Server.

## Server Details

- Server: DynamoDB-Toolbox
- Changes to: Add tools to a MCP Server to query and insert items quickly in DynamoDB

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?

Yes, tested with Claude and wrote an article showing the capabilities: https://dev.to/thomasaribart/mcp-client-building-a-smart-and-robust-integration-to-dynamodb-with-dynamodb-toolbox-2oeh

## Breaking Changes

No

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
