### PR TITLE
docs: Add Braze MCP Server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Bing Web Search API](https://github.com/leehanchung/bing-search-mcp)** (by hanchunglee) - Server implementation for Microsoft Bing Web Search API.
 - **[Bitable MCP](https://github.com/lloydzhou/bitable-mcp)** (by lloydzhou) - MCP server provides access to Lark Bitable through the Model Context Protocol. It allows users to interact with Bitable tables using predefined tools.
 - **[Blender](https://github.com/ahujasid/blender-mcp)** (by ahujasid) - Blender integration allowing prompt enabled 3D scene creation, modeling and manipulation.
+- **[Braze](https://github.com/universal-mcp/braze)** - Braze MCP server from **[agentr](https://agentr.dev/)** that provides support for managing customer engagement, user profiles, and messaging campaigns.
 - **[BreakoutRoom](https://github.com/agree-able/room-mcp)** - Agents accomplishing goals together in p2p rooms 
 - **[browser-use](https://github.com/co-browser/browser-use-mcp-server)** (by co-browser) - browser-use MCP server with dockerized playwright + chromium + vnc. supports stdio & resumable http.
 - **[BrowserLoop](https://github.com/mattiasw/browserloop)** - An MCP server for taking screenshots of web pages using Playwright. Supports high-quality capture with configurable formats, viewport sizes, cookie-based authentication, and both full page and element-specific screenshots.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->
## Description

## Server Details
- Server: Braze MCP Server
- Changes to: README.md (add new community server reference)

## Motivation and Context
This change adds visibility for the Braze MCP Server, allowing the MCP community to discover and use a server that provides robust capabilities for managing customer engagement, user profiles, and orchestrating cross-channel messaging campaigns. It expands the ecosystem of available MCP servers and demonstrates integration with LLM clients such as Claude Desktop for enhanced customer lifecycle management.

## How Has This Been Tested?
The Braze MCP Server has been tested with Claude Desktop and the official MCP Python client to ensure proper functionality for interacting with Braze's API for user data and campaign management.

## Breaking Changes
No breaking changes. This is an addition to the community servers list. Users who wish to use the Braze MCP Server will need to add its configuration to their MCP client.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The [Quickstart](https://agentr.dev/quickstart) includes setup instructions and example usage with Claude Desktop.