### PR TITLE
doc: update the SECURITY.md to better reflect the scope of the repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 Thank you for helping us keep our MCP servers secure.
 
-These servers are maintained by [Anthropic](https://www.anthropic.com/) as part of the Model Context Protocol project. 
+The **reference servers** in this repo are maintained by [Anthropic](https://www.anthropic.com/) as part of the Model Context Protocol project.
 
 The security of our systems and user data is Anthropic’s top priority. We appreciate the work of security researchers acting in good faith in identifying and reporting potential vulnerabilities.
 


### PR DESCRIPTION
## Description
This PR is aiming at restricting the responsibility in regards to the security assessment to the reference servers the sources of which are included of the repo.

## Motivation and Context
The SECURITY.md in this repo states:

These servers are maintained by [Anthropic](https://www.anthropic.com/) as part of the Model Context Protocol project.

I think this is a very confusing and in fact misleading claim. It gives people who look at the list of the servers which goes in well over 500 (most of them are community driven) a false sense of security.


## Types of changes
- [x] Documentation update


## Additional context
/fixes: #2164 
