### PR TITLE
Add python tests to CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,8 +23,45 @@ jobs:
           PACKAGES=$(find . -name pyproject.toml -exec dirname {} \; | sed 's/^\.\///' | jq -R -s -c 'split("\n")[:-1]')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
-  build:
+  test:
     needs: [detect-packages]
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.detect-packages.outputs.packages) }}
+    name: Test ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "src/${{ matrix.package }}/.python-version"
+
+      - name: Install dependencies
+        working-directory: src/${{ matrix.package }}
+        run: uv sync --frozen --all-extras --dev
+
+      - name: Check if tests exist
+        id: check-tests
+        working-directory: src/${{ matrix.package }}
+        run: |
+          if [ -d "tests" ] || [ -d "test" ] || grep -q "pytest" pyproject.toml; then
+            echo "has-tests=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-tests=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run tests
+        if: steps.check-tests.outputs.has-tests == 'true'
+        working-directory: src/${{ matrix.package }}
+        run: uv run pytest
+
+  build:
+    needs: [detect-packages, test]
     strategy:
       matrix:
         package: ${{ fromJson(needs.detect-packages.outputs.packages) }}


### PR DESCRIPTION
## Description

Added automated testing support to the Python CI workflow to run pytest tests for Python MCP servers. The workflow now detects packages with tests and runs them .

## Server Details
- Server: CI/CD Infrastructure (affects all 3 Python servers, although fetch doesn't appear to have any tests yet)
- Changes to: GitHub Actions workflow for Python packages

## Motivation and Context
The repository lacked test automation for Python servers. This change ensures that:
- Python server tests are automatically run on every push and PR
- Tests must pass before packages are built and published

## How Has This Been Tested?
- Verified the workflow detects Python packages correctly (git, time servers screenshots below)

![time](https://github.com/user-attachments/assets/8cb99a5a-cc7f-47de-99b1-29d53cfce2dc)

![git](https://github.com/user-attachments/assets/a543598a-19ca-452c-9cf3-46821ce24ef4)


## Breaking Changes
No breaking changes. This is purely a CI/CD enhancement that doesn't affect server functionality or client configurations.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
