### PR TITLE
Add Facebook Ads MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ Additional resources on MCP.
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
+- **[Facebook Ads](https://github.com/fortytwode/10xer)** - Access Facebook advertising data, insights, and account information through natural language conversations with Claude.
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Fabric MCP](https://github.com/aci-labs/ms-fabric-mcp)** - Microsoft Fabric MCP server to accelerate working in your Fabric Tenant with the help of your favorite LLM models.
 - **[fabric-mcp-server](https://github.com/adapoet/fabric-mcp-server)** - The fabric-mcp-server is an MCP server that integrates [Fabric](https://github.com/danielmiessler/fabric) patterns with [Cline](https://cline.bot/), exposing them as tools for AI-driven task execution and enhancing Cline's capabilities.
 - **[Facebook Ads](https://github.com/gomarble-ai/facebook-ads-mcp-server)** - MCP server acting as an interface to the Facebook Ads, enabling programmatic access to Facebook Ads data and management features.
+- **[Facebook Ads](https://github.com/fortytwode/10xer)** - Access Facebook advertising data, insights, and account information through natural language conversations with Claude.
 - **[Facebook Ads Library](https://github.com/trypeggy/facebook-ads-library-mcp)** - Get any answer from the Facebook Ads Library, conduct deep research including messaging, creative testing and comparisons in seconds.
 - **[falai](https://github.com/universal-mcp/falai)** - Fal.ai mcp server from **[agentr](https://agentr.dev/)** that provides support for generating media using fast inference engine.
 - **[Fantasy PL](https://github.com/rishijatia/fantasy-pl-mcp)** - Give your coding agent direct access to up-to date Fantasy Premier League data
@@ -947,7 +948,6 @@ Additional resources on MCP.
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
-- **[Facebook Ads](https://github.com/fortytwode/10xer)** - Access Facebook advertising data, insights, and account information through natural language conversations with Claude.
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Typically, each MCP server is implemented with an MCP SDK:
 > Note: Lists in this README are maintained in alphabetical order to minimize merge conflicts when adding new items.
 
 ## 🌟 Reference Servers
-
 These servers aim to demonstrate MCP features and the official SDKs.
 
 - **[Everything](src/everything)** - Reference / test server with prompts, resources, and tools


### PR DESCRIPTION
 ## Overview
  Adding Facebook Ads MCP Server with OAuth authentication to the official MCP
  registry.

  ## ✨ OAuth Authentication (v1.1.3)
  - **Browser-based login**: Secure OAuth 2.0 flow - no manual token setup
  required
  - **One-click authentication**: Just ask Claude "Login to Facebook"
  - **Automatic token management**: Secure storage using OS keychain

  ## Server Details
  - **Repository**: https://github.com/fortytwode/10xer
  - **NPM Package**: `facebook-ads-mcp-server@1.1.3`
  - **Author**: Shamanth M. Rao (@fortytwode)

  ## Features
  - List all accessible Facebook ad accounts
  - Get detailed account information and status
  - Retrieve performance metrics and analytics
  - Access account activity logs
  - Handle paginated API responses

  ## Installation
  ```bash
  npm install -g facebook-ads-mcp-server

  Security

  Uses official Facebook Graph API with user's own access token. No data stored
  or transmitted to third parties.
