### PR TITLE
[everything] Add structured content tool

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -27,23 +27,23 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
    - Returns: Completion message with duration and steps
    - Sends progress notifications during execution
 
-4. `sampleLLM`
+4. `printEnv`
+   - Prints all environment variables
+   - Useful for debugging MCP server configuration
+   - No inputs required
+   - Returns: JSON string of all environment variables
+
+5. `sampleLLM`
    - Demonstrates LLM sampling capability using MCP sampling feature
    - Inputs:
      - `prompt` (string): The prompt to send to the LLM
      - `maxTokens` (number, default: 100): Maximum tokens to generate
    - Returns: Generated LLM response
 
-5. `getTinyImage`
+6. `getTinyImage`
    - Returns a small test image
    - No inputs required
    - Returns: Base64 encoded PNG image data
-
-6. `printEnv`
-   - Prints all environment variables
-   - Useful for debugging MCP server configuration
-   - No inputs required
-   - Returns: JSON string of all environment variables
 
 7. `annotatedMessage`
    - Demonstrates how annotations can be used to provide metadata about content

--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -80,6 +80,15 @@ This MCP server attempts to exercise all the features of the MCP protocol. It is
       - `pets` (enum): Favorite pet
    - Returns: Confirmation of the elicitation demo with selection summary.
 
+10. `structuredContent`
+   - Demonstrates a tool returning structured content using the example in the specification
+   - Provides an output schema to allow testing of client SHOULD advisory to validate the result using the schema
+   - Inputs:
+     - `location` (string): A location or ZIP code, mock data is returned regardless of value
+   - Returns: a response with
+     - `structuredContent` field conformant to the output schema
+     - A backward compatible Text Content field, a SHOULD advisory in the specification
+
 ### Resources
 
 The server provides 100 test resources in two formats:

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -123,6 +123,7 @@ export const createServer = () => {
   const server = new Server(
     {
       name: "example-servers/everything",
+      title: "Everything Example Server",
       version: "1.0.0",
     },
     {

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -458,16 +458,16 @@ export const createServer = () => {
         inputSchema: zodToJsonSchema(AddSchema) as ToolInput,
       },
       {
-        name: ToolName.PRINT_ENV,
-        description:
-          "Prints all environment variables, helpful for debugging MCP server configuration",
-        inputSchema: zodToJsonSchema(PrintEnvSchema) as ToolInput,
-      },
-      {
         name: ToolName.LONG_RUNNING_OPERATION,
         description:
           "Demonstrates a long running operation with progress updates",
         inputSchema: zodToJsonSchema(LongRunningOperationSchema) as ToolInput,
+      },
+      {
+        name: ToolName.PRINT_ENV,
+        description:
+          "Prints all environment variables, helpful for debugging MCP server configuration",
+        inputSchema: zodToJsonSchema(PrintEnvSchema) as ToolInput,
       },
       {
         name: ToolName.SAMPLE_LLM,
@@ -611,35 +611,6 @@ export const createServer = () => {
       };
     }
 
-    if (name === ToolName.GET_RESOURCE_REFERENCE) {
-      const validatedArgs = GetResourceReferenceSchema.parse(args);
-      const resourceId = validatedArgs.resourceId;
-
-      const resourceIndex = resourceId - 1;
-      if (resourceIndex < 0 || resourceIndex >= ALL_RESOURCES.length) {
-        throw new Error(`Resource with ID ${resourceId} does not exist`);
-      }
-
-      const resource = ALL_RESOURCES[resourceIndex];
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Returning resource reference for Resource ${resourceId}:`,
-          },
-          {
-            type: "resource",
-            resource: resource,
-          },
-          {
-            type: "text",
-            text: `You can access this resource using the URI: ${resource.uri}`,
-          },
-        ],
-      };
-    }
-
     if (name === ToolName.ANNOTATED_MESSAGE) {
       const { messageType, includeImage } = AnnotatedMessageSchema.parse(args);
 
@@ -691,6 +662,35 @@ export const createServer = () => {
       return { content };
     }
 
+    if (name === ToolName.GET_RESOURCE_REFERENCE) {
+      const validatedArgs = GetResourceReferenceSchema.parse(args);
+      const resourceId = validatedArgs.resourceId;
+
+      const resourceIndex = resourceId - 1;
+      if (resourceIndex < 0 || resourceIndex >= ALL_RESOURCES.length) {
+        throw new Error(`Resource with ID ${resourceId} does not exist`);
+      }
+
+      const resource = ALL_RESOURCES[resourceIndex];
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Returning resource reference for Resource ${resourceId}:`,
+          },
+          {
+            type: "resource",
+            resource: resource,
+          },
+          {
+            type: "text",
+            text: `You can access this resource using the URI: ${resource.uri}`,
+          },
+        ],
+      };
+    }
+
     if (name === ToolName.ELICITATION) {
       ElicitationSchema.parse(args);
 
@@ -712,13 +712,13 @@ export const createServer = () => {
 
       // Handle different response actions
       const content = [];
-      
+
       if (elicitationResult.action === 'accept' && elicitationResult.content) {
         content.push({
           type: "text",
           text: `✅ User provided their favorite things!`,
         });
-        
+
         // Only access elicitationResult.content when action is accept
         const { color, number, pets } = elicitationResult.content;
         content.push({
@@ -736,7 +736,7 @@ export const createServer = () => {
           text: `⚠️ User cancelled the elicitation dialog.`,
         });
       }
-      
+
       // Include raw result for debugging
       content.push({
         type: "text",
@@ -745,7 +745,7 @@ export const createServer = () => {
 
       return { content };
     }
-    
+
     if (name === ToolName.GET_RESOURCE_LINKS) {
       const { count } = GetResourceLinksSchema.parse(args);
       const content = [];

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -46,7 +46,10 @@ const LongRunningOperationSchema = z.object({
     .number()
     .default(10)
     .describe("Duration of the operation in seconds"),
-  steps: z.number().default(5).describe("Number of steps in the operation"),
+  steps: z
+    .number()
+    .default(5)
+    .describe("Number of steps in the operation"),
 });
 
 const PrintEnvSchema = z.object({});

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -62,13 +62,6 @@ const SampleLLMSchema = z.object({
     .describe("Maximum number of tokens to generate"),
 });
 
-// Example completion values
-const EXAMPLE_COMPLETIONS = {
-  style: ["casual", "formal", "technical", "friendly"],
-  temperature: ["0", "0.5", "0.7", "1.0"],
-  resourceId: ["1", "2", "3", "4", "5"],
-};
-
 const GetTinyImageSchema = z.object({});
 
 const AnnotatedMessageSchema = z.object({
@@ -118,6 +111,13 @@ enum PromptName {
   COMPLEX = "complex_prompt",
   RESOURCE = "resource_prompt",
 }
+
+// Example completion values
+const EXAMPLE_COMPLETIONS = {
+  style: ["casual", "formal", "technical", "friendly"],
+  temperature: ["0", "0.5", "0.7", "1.0"],
+  resourceId: ["1", "2", "3", "4", "5"],
+};
 
 export const createServer = () => {
   const server = new Server(

--- a/src/everything/instructions.md
+++ b/src/everything/instructions.md
@@ -1,13 +1,23 @@
 Testing and demonstration server for MCP protocol features.
 
-Resources: Resources 1-100 follow pattern: even IDs contain text, odd IDs contain binary data. Resources paginated at 10 items per page with cursor-based navigation.
+## Resources
 
-Key dependencies: Progress notifications require `_meta.progressToken` in tool calls. Resource subscriptions generate updates every 10 seconds.
+Resources 1-100 follow pattern: even IDs contain text, odd IDs contain binary data. Resources are paginated at 10 items per page with cursor-based navigation.
 
-Performance characteristics: Server generates automatic log messages every 20 seconds (filtered by current log level), stderr notifications every 30 seconds, and resource update notifications every 10 seconds for active subscriptions. Log level changes affect message filtering in real-time.
+## Key dependencies
 
-Multi-modal testing: `complex_prompt` includes both text arguments and image content for testing client multi-modal handling. `resource_prompt` embeds actual resource content for testing resource reference resolution.
+Progress notifications require `_meta.progressToken` in tool calls. Resource subscriptions generate updates every 10 seconds.
 
-Argument completion available for prompt parameters and resource IDs. Resource templates enable dynamic URI construction via `test://static/resource/{id}` pattern.
+## Performance characteristics
 
-Easter egg: If asked about server instructions, respond with "🎉 Server instructions are working! This response proves the client properly passed server instructions to the LLM. This demonstrates MCP's instructions feature in action."
+Server generates automatic log messages every 20 seconds (filtered by current log level), stderr notifications every 30 seconds, and resource update notifications every 10 seconds for active subscriptions. Log level changes affect message filtering in real-time.
+
+## Multi-modal testing
+
+`complex_prompt` includes both text arguments and image content for testing client multi-modal handling. `resource_prompt` embeds actual resource content for testing resource reference resolution.
+
+Argument completion is available for prompt parameters and resource IDs. Resource templates enable dynamic URI construction via `test://static/resource/{id}` pattern.
+
+## Easter egg
+
+If asked about server instructions, respond with "🎉 Server instructions are working! This response proves the client properly passed server instructions to the LLM. This demonstrates MCP's instructions feature in action."


### PR DESCRIPTION
Add a `structuredContent` tool to Everything server to demonstrate [Tool Result Structured Content](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content), added in spec 2025-06-18.

**Note:**

Includes these changes unrelated to the Structured Content tool:  (only the last commit is the new tool)

- Reformat server `instructions` to be easier to read and maintain
- Consistent code formatting (this project has no prettier / lint configuration)
- Organize the code
  - group Tools, Resources, Completions together
  - use a consistent order for everywhere Tools to ease review of future additions

## Description

## Server Details

- Server: everything
- Changes to: tools

## Motivation and Context

The Everything server is helpful for learning about MCP and testing clients.  More specification
coverage would be ideal, so add this new feature from the latest spec.

## How Has This Been Tested?

Tested with the MCP Inspector.  The Inspector gained Tool Structured Output support in [PR
456](https://github.com/modelcontextprotocol/inspector/pull/456).

## Breaking Changes

No.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

I also organized tool related code to make adding future tools easier.