### PR TITLE
remove the RepositoryDispatchEvent (building every six hours)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,10 +212,3 @@ jobs:
             --title "Release $VERSION" \
             --notes-file RELEASE_NOTES.md
 
-      - name: Docker MCP images
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.DOCKER_TOKEN }}
-          repository: docker/labs-ai-tools-for-devs
-          event-type: build-mcp-images
-          client-payload: '{"ref": "${{ needs.create-metadata.outputs.version }}"}'


### PR DESCRIPTION
Remove the repository dispatch event from the release GHA workflow

## Description

We're still checking for new releases, and then building and pushing them, but we'll do this on a separate schedule, instead of using this repository dispatch mechanism.

## Motivation and Context

The repository dispatch mechanism was put in place to signal the Docker Build cloud to pull the release and build it.  We'll still do this but we'll poll for releases instead.

## Breaking Changes

Should be none.  This is just removing a step from an existing workflow.
