### PR TITLE
docs(readme): add HeatPump MCP Server to third-party list

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Hashing MCP Server](https://github.com/kanad13/MCP-Server-for-Hashing)** - MCP Server with cryptographic hashing functions e.g. SHA256, MD5, etc.
 - **[Hashnode](https://github.com/universal-mcp/hashnode)** - Hashnode MCP server from **[agentr](https://agentr.dev/)** that provides support for managing blog posts and content on Hashnode.
 - **[HDW LinkedIn](https://github.com/horizondatawave/hdw-mcp-server)** - Access to profile data and management of user account with [HorizonDataWave.ai](https://horizondatawave.ai/).
+- **[HeatPump](https://github.com/jiweiqi/heatpump-mcp-server)** — Residential heat-pump sizing & cost-estimation tools by **HeatPumpHQ**.
 - **[Helm Chart CLI](https://github.com/jeff-nasseri/helm-chart-cli-mcp)** - Helm MCP provides a bridge between AI assistants and the Helm package manager for Kubernetes. It allows AI assistants to interact with Helm through natural language requests, executing commands like installing charts, managing repositories, and more.
 - **[Heurist Mesh Agent](https://github.com/heurist-network/heurist-mesh-mcp-server)** - Access specialized web3 AI agents for blockchain analysis, smart contract security, token metrics, and blockchain interactions through the [Heurist Mesh network](https://github.com/heurist-network/heurist-agent-framework/tree/main/mesh).
 - **[Holaspirit](https://github.com/syucream/holaspirit-mcp-server)** - Interact with [Holaspirit](https://www.holaspirit.com/).


### PR DESCRIPTION
No source code or build artifacts are introduced—this is purely a documentation change so that users can discover and integrate the HeatPump MCP Server.

## Server Details
- Server: HeatPump 
- Changes to: `README.md` only (documentation)

## Motivation and Context
Including HeatPump in the official community list increases visibility for users looking for HVAC-focused tools and ensures consistent discovery alongside other third-party MCP servers.

## How Has This Been Tested?
- Verified rendered Markdown locally—link and formatting display correctly.  
- Confirmed alphabetical ordering to avoid merge conflicts.  
- Ran repository markdown linter (`npm run lint:md`) to ensure style compliance (passes).

## Breaking Changes
None. No client configurations or server interfaces are affected.

## Types of changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
<!-- Put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follow MCP security best practices (N/A for docs, but no sensitive info added)
- [x] I have updated the server's README accordingly (entry contains description & maintainers)
- [ ] I have tested this with an LLM client (N/A for docs)
- [x] My code follows the repository's style guidelines (Markdown style/lint passes)
- [ ] New and existing tests pass locally (N/A)
- [ ] I have added appropriate error handling (N/A)
- [ ] I have documented all environment variables and configuration options (N/A)

## Additional context
HeatPump provides a suite of residential HVAC calculators that leverage MCP to expose its sizing, cost-estimation, and cold-climate verification tools via secure, agent-friendly APIs. The link helps builders quickly discover these capabilities without requiring a full source contribution.