### PR TITLE
Add Apple Docs MCP server to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Apple Books](https://github.com/vgnshiyer/apple-books-mcp)** - Interact with your library on Apple Books, manage your book collection, summarize highlights, notes, and much more.
 - **[Apple Calendar](https://github.com/Omar-v2/mcp-ical)** - An MCP server that allows you to interact with your MacOS Calendar through natural language, including features such as event creation, modification, schedule listing, finding free time slots etc.
 - **[Apple Script](https://github.com/peakmojo/applescript-mcp)** - MCP server that lets LLM run AppleScript code to to fully control anything on Mac, no setup needed.
+- **[Apple Docs](https://github.com/kimsungwhee/apple-docs-mcp)** - A powerful Model Context Protocol (MCP) server that provides seamless access to Apple Developer Documentation through natural language queries. Search, explore, and get detailed information about Apple frameworks, APIs, sample code, and more directly in your AI-powered development environment.
 - **[APT MCP](https://github.com/GdMacmillan/apt-mcp-server)** - MCP server which runs debian package manager (apt) commands for you using ai agents.
 - **[Aranet4](https://github.com/diegobit/aranet4-mcp-server)** - MCP Server to manage your Aranet4 CO2 sensor. Fetch data and store in a local SQLite. Ask questions about historical data.
 - **[ArangoDB](https://github.com/ravenwits/mcp-server-arangodb)** - MCP Server that provides database interaction capabilities through [ArangoDB](https://arangodb.com/).


### PR DESCRIPTION
## Description
Added [Apple Docs MCP](https://github.com/kimsungwhee/apple-docs-mcp) server to the community servers list. This is a powerful Model Context Protocol (MCP) server that provides seamless access to Apple Developer Documentation through natural language queries.

## Motivation and Context
This change adds the Apple Docs MCP server to the community servers list, providing developers with access to Apple Developer Documentation through AI-powered development environments. The server enables natural language queries to search, explore, and get detailed information about Apple frameworks, APIs, sample code, and more.

## How Has This Been Tested?
The server has been tested with various LLM clients including Claude Desktop, Cursor, VS Code, and others. Tested scenarios include:
Smart search across Apple Developer Documentation
Framework exploration and API discovery
Platform compatibility analysis
Cache management and performance optimization

## Breaking Changes
None - this is a new server addition that doesn't affect existing functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
The Apple Docs MCP server provides comprehensive access to Apple's developer documentation with features including:
- Smart search with enhanced result formatting
- Complete documentation access via Apple's JSON API
- Framework index with hierarchical API structure browsing
- Technology catalog with organized listings by category
- Related APIs discovery with intelligent recommendations
- Platform compatibility analysis across Apple's ecosystem
- High-performance memory-based caching system
- Multi-platform support for iOS, macOS, watchOS, tvOS, and visionOS
- Beta and status tracking for APIs
- The server is MIT licensed and available on npm as @kimsungwhee/apple-docs-mcp.
