### PR TITLE
Add persistproc community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,6 +825,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[PDF reader MCP](https://github.com/gpetraroli/mcp_pdf_reader)** - MCP server to read and search text in a local PDF file.
 - **[PDF Tools MCP](https://github.com/Sohaib-2/pdf-mcp-server)** - Comprehensive PDF manipulation toolkit (merge, split, encrypt, optimize and much more)
 - **[Peacock for VS Code](https://github.com/johnpapa/peacock-mcp)** - MCP Server for the Peacock extension for VS Code, coloring your world, one Code editor at a time. The main goal of the project is to show how an MCP server can be used to interact with APIs.
+- **[persistproc](https://github.com/irskep/persistproc)** - MCP server + command line tool that allows agents to see & control long-running processes like web servers.
 - **[Phone MCP](https://github.com/hao-cyber/phone-mcp)** - 📱 A powerful plugin that lets you control your Android phone. Enables AI agents to perform complex tasks like automatically playing music based on weather or making calls and sending texts.
 - **[PIF](https://github.com/hungryrobot1/MCP-PIF)** - A Personal Intelligence Framework (PIF), providing tools for file operations, structured reasoning, and journal-based documentation to support continuity and evolving human-AI collaboration across sessions.
 - **[Pinecone](https://github.com/sirmews/mcp-pinecone)** - MCP server for searching and uploading records to Pinecone. Allows for simple RAG features, leveraging Pinecone's Inference API.


### PR DESCRIPTION
Updates list of community servers to include [persistproc](https://steveasleep.com/persistproc/).

## Description

Process management tool that allows agents and humans to see and control long-running processes like web servers, providing streaming output and unified process control for AI-assisted development workflows.

## Server Details

- Server: https://github.com/irskep/persistproc
- Changes to: README.md

## Motivation and Context

I run more than one agent while doing my work, sometimes Claude Code, sometimes Gemini, sometimes Cursor. I routinely need the agent to respond to output in a webpack devserver. persistproc allows this output to be available over a tool call for any of these agents, and also allows agents to restart the server if there was a config change.

## How Has This Been Tested?

I use it in my daily workflow.

## Breaking Changes

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

n/a