### PR TITLE
docs: Add Nikto MCP Server to MCP Servers List

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[NS Travel Information](https://github.com/r-huijts/ns-mcp-server)** - Access Dutch Railways (NS) real-time train travel information and disruptions through the official NS API.
 - **[ntfy-mcp](https://github.com/teddyzxcv/ntfy-mcp)** (by teddyzxcv) - The MCP server that keeps you informed by sending the notification on phone using ntfy
 - **[ntfy-me-mcp](https://github.com/gitmotion/ntfy-me-mcp)** (by gitmotion) - An ntfy MCP server for sending/fetching ntfy notifications to your self-hosted ntfy server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)
+- **[Nikto MCP](https://github.com/weldpua2008/nikto-mcp)** (by weldpua2008) - A secure MCP server that enables AI agents to interact with Nikto web server scanner](- use with npx or docker).
 - **[oatpp-mcp](https://github.com/oatpp/oatpp-mcp)** - C++ MCP integration for Oat++. Use [Oat++](https://oatpp.io) to build MCP servers.
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through your Obsidian vault or any directory containing Markdown notes
 - **[obsidian-mcp](https://github.com/StevenStavrakis/obsidian-mcp)** - (by Steven Stavrakis) An MCP server for Obsidian.md with tools for searching, reading, writing, and organizing notes.


### PR DESCRIPTION
This PR adds a new MCP server entry to the `README.md` file in the `modelcontextprotocol/servers` repository.

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: https://github.com/weldpua2008/nikto-mcp
- Changes to: Documentation (README.md)

## Motivation and Context
This addition introduces a secure MCP server that integrates with the https://github.com/sullo/nikto, enabling AI agents to perform comprehensive web security scans. It expands the MCP ecosystem with a valuable tool for cybersecurity use cases.

## How Has This Been Tested?
The server has been tested with LLM clients to initiate and retrieve results from Nikto scans on various web targets. Scenarios tested include:
- Launching scans with custom parameters
- Retrieving scan results in structured formats
- Handling scan errors and timeouts gracefully

## Breaking Changes
No breaking changes. This is a documentation update only.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [x] Documentation update  

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- https://modelcontextprotocol.io  
- [x] My changes follow MCP security best practices  
- [x] I have updated the server's README accordingly  
- [x] I have tested this with an LLM client  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [x] I have added appropriate error handling  
- [x] I have documented all environment variables and configuration options  

---