### PR TITLE
Make package publishing job runs contingent upon changes existing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
 
   publish-pypi:
     needs: [update-packages, create-metadata]
+    if: ${{ needs.create-metadata.outputs.pypi_packages != '[]' && needs.create-metadata.outputs.pypi_packages != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +146,7 @@ jobs:
 
   publish-npm:
     needs: [update-packages, create-metadata]
+    if: ${{ needs.create-metadata.outputs.npm_packages != '[]' && needs.create-metadata.outputs.npm_packages != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

In release.yml
  - In the `publish-pypi` job,
    - only run if there are Python packages to publish

  - In the `publish-npm` job,
      - only run if there are Typescript packages to publish

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Multiple attempts to [approve a release](https://github.com/modelcontextprotocol/servers/actions/runs/16608192857) have failed. 

The process includes gathering the metadata about the release, simultaneously publishing both Python (pypi) and Typescript (npm) packages that may be in the release, and then finishing up with a final step that creates the actual release description and downloadable artifacts on the repo itself.
<img width="1467" height="519" alt="Screenshot 2025-07-31 at 4 45 58 PM" src="https://github.com/user-attachments/assets/10243892-d804-4dd4-8e22-24ca99894a65" />

The Typescript packages appear to have been published:
<img width="1198" height="532" alt="Screenshot 2025-07-31 at 5 21 19 PM" src="https://github.com/user-attachments/assets/91a163eb-2a9e-4959-ae98-179d59f57b90" />

However, it appears we had no Python packages to publish this time around, and an assumption in the `release.yml` that there would always be changes in both has brought that fork of the publish process to a halt. And therefore, the next step of finalizing the release has not been run.
<img width="1472" height="720" alt="Screenshot 2025-07-31 at 4 43 03 PM" src="https://github.com/user-attachments/assets/37069674-aeff-4a96-aa54-20cc5cb0add2" />

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
This is a speculative fix since I cannot actually publish the packages myself.

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options