### PR TITLE
Feat/add hypertool mcp to servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Human-use](https://github.com/RapidataAI/human-use)** - Instant human feedback through an MCP, have your AI interact with humans around the world. Powered by [Rapidata](https://www.rapidata.ai/)
 - **[Hyperledger Fabric Agent Suite](https://github.com/padmarajkore/hlf-fabric-agent)** - Modular toolkit for managing Fabric test networks and chaincode lifecycle via MCP tools.
 - **[Hyperliquid](https://github.com/mektigboy/server-hyperliquid)** - An MCP server implementation that integrates the Hyperliquid SDK for exchange data.
-- **[hypertool-mcp](https://github.com/toolprint/hypertool-mcp)** – An MCP that exposes hot-swappable, persona-specific sets of tools from multiple MCP servers to cut down on tool overload and get around tool-binding limits with many MCPs.
+- **[Hypertool](https://github.com/toolprint/hypertool-mcp)** – MCP that let's you create hot-swappable, "persona toolsets" from multiple MCP servers to reduce tool overload and improve tool execution.
 - **[hyprmcp](https://github.com/stefanoamorelli/hyprmcp)** (by Stefano Amorelli) - Lightweight MCP server for `hyprland`.
 - **[iFlytek SparkAgent Platform](https://github.com/iflytek/ifly-spark-agent-mcp)** - This is a simple example of using MCP Server to invoke the task chain of the  iFlytek SparkAgent Platform.
 - **[iFlytek Workflow](https://github.com/iflytek/ifly-workflow-mcp-server)** - Connect to iFlytek Workflow via the MCP server and run your own Agent.

--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Human-use](https://github.com/RapidataAI/human-use)** - Instant human feedback through an MCP, have your AI interact with humans around the world. Powered by [Rapidata](https://www.rapidata.ai/)
 - **[Hyperledger Fabric Agent Suite](https://github.com/padmarajkore/hlf-fabric-agent)** - Modular toolkit for managing Fabric test networks and chaincode lifecycle via MCP tools.
 - **[Hyperliquid](https://github.com/mektigboy/server-hyperliquid)** - An MCP server implementation that integrates the Hyperliquid SDK for exchange data.
+- **[hypertool-mcp](https://github.com/toolprint/hypertool-mcp)** – An MCP that exposes hot-swappable, persona-specific sets of tools from multiple MCP servers to cut down on tool overload and get around tool-binding limits with many MCPs.
 - **[hyprmcp](https://github.com/stefanoamorelli/hyprmcp)** (by Stefano Amorelli) - Lightweight MCP server for `hyprland`.
 - **[iFlytek SparkAgent Platform](https://github.com/iflytek/ifly-spark-agent-mcp)** - This is a simple example of using MCP Server to invoke the task chain of the  iFlytek SparkAgent Platform.
 - **[iFlytek Workflow](https://github.com/iflytek/ifly-workflow-mcp-server)** - Connect to iFlytek Workflow via the MCP server and run your own Agent.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Server Details
- Server: [hypertool-mcp)[https://github.com/toolprint/hypertool-mcp]
- Changes to: docs

## Motivation and Context
Adds https://github.com/toolprint/hypertool-mcp to the list of community servers

## How Has This Been Tested?
This has been tested with multiple applications including claude-code and cursor in different transport modes such as stdio and streamable http.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
