### PR TITLE
docs(fetch): Add Windows PYTHONIOENCODING configuration

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -168,6 +168,48 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
 
+## Windows Configuration
+
+If you're experiencing timeout issues on Windows, you may need to set the `PYTHONIOENCODING` environment variable to ensure proper character encoding:
+
+<details>
+<summary>Windows configuration (uvx)</summary>
+
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch"],
+      "env": {
+        "PYTHONIOENCODING": "utf-8"
+      }
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Windows configuration (pip)</summary>
+
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "python",
+      "args": ["-m", "mcp_server_fetch"],
+      "env": {
+        "PYTHONIOENCODING": "utf-8"
+      }
+    }
+  }
+}
+```
+</details>
+
+This addresses character encoding issues that can cause the server to timeout on Windows systems.
+
 ## Debugging
 
 You can use the MCP inspector to debug the server. For uvx installations:


### PR DESCRIPTION
Add troubleshooting section for Windows users experiencing timeout issues.

Setting PYTHONIOENCODING=utf-8 fixes character encoding problems that can cause the server to timeout on Windows systems.

Fixes #65

Generated with [Claude Code](https://claude.ai/code)