### PR TITLE
fix: remove incorrect resources claim from filesystem server README

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -64,10 +64,6 @@ The server's directory access control follows this flow:
 
 ## API
 
-### Resources
-
-- `file://system`: File system operations interface
-
 ### Tools
 
 - **read_text_file**


### PR DESCRIPTION
The filesystem server does not actually implement MCP Resources capability but the README incorrectly claimed it provides 'file://system' resource interface.

Fixes #399

Generated with [Claude Code](https://claude.ai/code)

Also linking separate issue for feature request to add Resources support: https://github.com/modelcontextprotocol/servers/issues/2534