### PR TITLE
Add host allowlisting and IP blocking to Fetch server

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -2,8 +2,17 @@
 
 A Model Context Protocol server that provides web content fetching capabilities. This server enables LLMs to retrieve and process content from web pages, converting HTML to markdown for easier consumption.
 
-> [!CAUTION]
-> This server can access local/internal IP addresses and may represent a security risk. Exercise caution when using this MCP server to ensure this does not expose any sensitive data.
+## Security
+
+**By default, this server blocks access to local/internal IP addresses** (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, etc.) to prevent access to internal networks and services. This provides security against potential misuse.
+
+You can customize security settings using the following options:
+- `--allowed-hosts`: Specify allowed hostnames/domains (supports wildcards like *.example.com)
+- `--allow-private-ips`: Allow access to private/internal IP ranges  
+- `--blocked-ip-ranges`: Specify additional CIDR ranges to block
+
+> [!TIP]
+> For maximum security in production environments, use `--allowed-hosts` to explicitly whitelist only the domains you need to access.
 
 The fetch tool will truncate the response, but by using the `start_index` argument, you can specify where to start the content extraction. This lets models read a webpage in chunks, until they find the information they need.
 
@@ -167,6 +176,44 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 ### Customization - Proxy
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
+
+### Security Configuration Examples
+
+**Allow specific domains only:**
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch", "--allowed-hosts", "example.com", "*.github.com", "docs.python.org"]
+    }
+  }
+}
+```
+
+**Allow internal IPs for development (NOT recommended for production):**
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx", 
+      "args": ["mcp-server-fetch", "--allow-private-ips"]
+    }
+  }
+}
+```
+
+**Custom blocked IP ranges:**
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch", "--blocked-ip-ranges", "203.0.113.0/24", "198.51.100.0/24"]
+    }
+  }
+}
+```
 
 ## Debugging
 

--- a/src/fetch/src/mcp_server_fetch/__init__.py
+++ b/src/fetch/src/mcp_server_fetch/__init__.py
@@ -16,9 +16,33 @@ def main():
         help="Ignore robots.txt restrictions",
     )
     parser.add_argument("--proxy-url", type=str, help="Proxy URL to use for requests")
+    parser.add_argument(
+        "--allowed-hosts",
+        type=str,
+        nargs="*",
+        help="List of allowed hostnames/domains (supports wildcards like *.example.com). If not specified, all hosts are allowed unless blocked by IP restrictions.",
+    )
+    parser.add_argument(
+        "--allow-private-ips",
+        action="store_true",
+        help="Allow access to private/internal IP ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, etc.)",
+    )
+    parser.add_argument(
+        "--blocked-ip-ranges",
+        type=str,
+        nargs="*",
+        help="Custom list of CIDR ranges to block (in addition to or instead of default private ranges)",
+    )
 
     args = parser.parse_args()
-    asyncio.run(serve(args.user_agent, args.ignore_robots_txt, args.proxy_url))
+    asyncio.run(serve(
+        args.user_agent, 
+        args.ignore_robots_txt, 
+        args.proxy_url,
+        args.allowed_hosts,
+        args.allow_private_ips,
+        args.blocked_ip_ranges,
+    ))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements security feature to prevent access to local/internal IP addresses by default. Addresses issue #2317.

## Changes
- Block access to private IP ranges by default
- Add host allowlisting with wildcard support
- Add configuration options for security customization
- Implement socket-level validation to prevent TOCTOU attacks
- Update documentation with security examples

Generated with [Claude Code](https://claude.ai/code)