### PR TITLE
Fix SSE server crash by starting notification timers only after client connects

### DIFF
--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -169,16 +169,6 @@ export const createServer = () => {
   let subsUpdateInterval: NodeJS.Timeout | undefined;
   let stdErrUpdateInterval: NodeJS.Timeout | undefined;
 
-  // Set up update interval for subscribed resources
-  subsUpdateInterval = setInterval(() => {
-    for (const uri of subscriptions) {
-      server.notification({
-        method: "notifications/resources/updated",
-        params: { uri },
-      });
-    }
-  }, 10000);
-
   let logLevel: LoggingLevel = "debug";
   let logsUpdateInterval: NodeJS.Timeout | undefined;
   const messages = [
@@ -198,15 +188,30 @@ export const createServer = () => {
     return messageLevel < currentLevel;
   };
 
-  // Set up update interval for random log messages
-  logsUpdateInterval = setInterval(() => {
-    let message = {
-      method: "notifications/message",
-      params: messages[Math.floor(Math.random() * messages.length)],
-    };
-    if (!isMessageIgnored(message.params.level as LoggingLevel))
-      server.notification(message);
-  }, 20000);
+  // Function to start notification intervals when a client connects
+  const startNotificationIntervals = () => {
+    if (!subsUpdateInterval) {
+      subsUpdateInterval = setInterval(() => {
+        for (const uri of subscriptions) {
+          server.notification({
+            method: "notifications/resources/updated",
+            params: { uri },
+          });
+        }
+      }, 10000);
+    }
+
+    if (!logsUpdateInterval) {
+      logsUpdateInterval = setInterval(() => {
+        let message = {
+          method: "notifications/message",
+          params: messages[Math.floor(Math.random() * messages.length)],
+        };
+        if (!isMessageIgnored(message.params.level as LoggingLevel))
+          server.notification(message);
+      }, 20000);
+    }
+  };
 
 
 
@@ -874,7 +879,7 @@ export const createServer = () => {
     if (stdErrUpdateInterval) clearInterval(stdErrUpdateInterval);
   };
 
-  return { server, cleanup };
+  return { server, cleanup, startNotificationIntervals };
 };
 
 const MCP_TINY_IMAGE =

--- a/src/everything/sse.ts
+++ b/src/everything/sse.ts
@@ -10,7 +10,7 @@ const transports: Map<string, SSEServerTransport> = new Map<string, SSEServerTra
 
 app.get("/sse", async (req, res) => {
   let transport: SSEServerTransport;
-  const { server, cleanup } = createServer();
+  const { server, cleanup, startNotificationIntervals } = createServer();
 
   if (req?.query?.sessionId) {
     const sessionId = (req?.query?.sessionId as string);
@@ -24,6 +24,9 @@ app.get("/sse", async (req, res) => {
     // Connect server to transport
     await server.connect(transport);
     console.error("Client Connected: ", transport.sessionId);
+
+    // Start notification intervals after client connects
+    startNotificationIntervals();
 
     // Handle close of connection
     server.onclose = async () => {


### PR DESCRIPTION
Resolves #1948

The `npx @modelcontextprotocol/server-everything sse` command was crashing with "Not connected" error after 5 seconds because notification timers were starting immediately when the server was created, but trying to send messages before any client connected.

## Changes
- Move setInterval calls from server creation to startNotificationIntervals function
- Only start notification timers when a client actually connects to the SSE server
- Prevents 'Not connected' error when server tries to send notifications before client connection

Generated with [Claude Code](https://claude.ai/code)