### PR TITLE
fix: align everything server resource URI numbering with array indices

### DIFF
--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -254,7 +254,7 @@ export const createServer = () => {
   };
 
   const ALL_RESOURCES: Resource[] = Array.from({ length: 100 }, (_, i) => {
-    const uri = `test://static/resource/${i + 1}`;
+    const uri = `test://static/resource/${i}`;
     if (i % 2 === 0) {
       return {
         uri,
@@ -316,7 +316,7 @@ export const createServer = () => {
     const uri = request.params.uri;
 
     if (uri.startsWith("test://static/resource/")) {
-      const index = parseInt(uri.split("/").pop() ?? "", 10) - 1;
+      const index = parseInt(uri.split("/").pop() ?? "", 10);
       if (index >= 0 && index < ALL_RESOURCES.length) {
         const resource = ALL_RESOURCES[index];
         return {


### PR DESCRIPTION
Fixes issue #475 where array indices (0-based) didn't match URI numbers (1-based), causing confusion.

## Changes
- Resource URIs now use 0-based numbering to match array indices
- Resource 0 is now accessed via `test://static/resource/0`
- Even indices now map to even URI numbers (more intuitive)

Resolves #475

Note: this is technically a breaking change, but since this is a demo server for testing, it seems like this shouldn't actually be an issue?

Generated with [Claude Code](https://claude.ai/code)