### PR TITLE
fix: clarify list_allowed_directories description to mention subdirectory access

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -615,8 +615,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: "list_allowed_directories",
         description:
-          "Returns the list of root directories that this server is allowed to access. " +
-          "Use this to understand which directories are available before trying to access files. ",
+          "Returns the list of directories that this server is allowed to access. " +
+          "Subdirectories within these allowed directories are also accessible. " +
+          "Use this to understand which directories and their nested paths are available " +
+          "before trying to access files.",
         inputSchema: {
           type: "object",
           properties: {},


### PR DESCRIPTION
The tool description was ambiguous about subdirectory access within allowed directories.
Updated the description to explicitly state that subdirectories are also accessible.

Fixes #670

🤖 Generated with [Claude Code](https://claude.ai/code)