### PR TITLE
Add finmap.org MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Figma](https://github.com/paulvandermeijs/figma-mcp)** - A blazingly fast MCP server to read and export your Figma design files.
 - **[Files](https://github.com/flesler/mcp-files)** - Enables agents to quickly find and edit code in a codebase with surgical precision. Find symbols, edit them everywhere.
 - **[FileSystem Server](https://github.com/Oncorporation/filesystem_server)** - Local MCP server for Visual Studio 2022 that provides code-workspace functionality by giving AI agents selective access to project folders and files
+- **[finmap.org](https://github.com/finmap-org/mcp-server)** MCP server provides comprehensive historical data from the US, UK, Russian and Turkish stock exchanges. Access sectors, tickers, company profiles, market cap, volume, value, and trade counts, as well as treemap and histogram visualizations.
 - **[Firebase](https://github.com/gannonh/firebase-mcp)** - Server to interact with Firebase services including Firebase Authentication, Firestore, and Firebase Storage.
 - **[FireCrawl](https://github.com/vrknetha/mcp-server-firecrawl)** - Advanced web scraping with JavaScript rendering, PDF support, and smart rate limiting
 - **[Fish Audio](https://github.com/da-okazaki/mcp-fish-audio-server)** - Text-to-Speech integration with Fish Audio's API, supporting multiple voices, streaming, and real-time playback


### PR DESCRIPTION
This PR adds the finmap.org MCP server to the community servers section.

## Description

[finmap.org](https://github.com/finmap-org/mcp-server) MCP server provides comprehensive historical data from the US, UK, Russian and Turkish stock exchanges. Access sectors, tickers, company profiles, market cap, volume, value, and trade counts, as well as treemap and histogram visualizations.

## Server Details
- Repository: https://github.com/finmap-org/mcp-server
- NPM Package: https://www.npmjs.com/package/finmap-mcp
- Remote MCP server: https://mcp.finmap.org

## Tools Provided

- `get-marketdata` - Get market overview with sector breakdown for any exchange
- `get-tickers` - List all available company tickers for an exchange with optional sector filtering
- `get-marketdata-by-ticker` - Get detailed information for a specific company ticker
- `get-top-marketdata` - Get top performing companies sorted by various metrics
- `get-company-info` - Get detailed company information including business description (US market only)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
