### PR TITLE
chore: rename hermes-mcp to anubis-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,6 +1202,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 
 ### For servers
 
+* **[Anubis MCP](https://github.com/zoedsoupe/anubis-mcp)** (Elixir) - A high-performance and high-level Model Context Protocol (MCP) implementation in Elixir. Think like "Live View" for MCP.
 * **[ModelFetch](https://github.com/phuctm97/modelfetch/)** (TypeScript) - Runtime-agnostic SDK to create and deploy MCP servers anywhere TypeScript/JavaScript runs
 * **[EasyMCP](https://github.com/zcaceres/easy-mcp/)** (TypeScript)
 * **[FastAPI to MCP auto generator](https://github.com/tadata-org/fastapi_mcp)** – A zero-configuration tool for automatically exposing FastAPI endpoints as MCP tools by **[Tadata](https://tadata.com/)**
@@ -1224,7 +1225,6 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[Template MCP Server](https://github.com/mcpdotdirect/template-mcp-server)** - A CLI tool to create a new Model Context Protocol server project with TypeScript support, dual transport options, and an extensible structure
 * **[AgentR Universal MCP SDK](https://github.com/universal-mcp/universal-mcp)** - A python SDK to build MCP Servers with inbuilt credential management by **[Agentr](https://agentr.dev/home)**
 * **[Vercel MCP Adapter](https://github.com/vercel/mcp-adapter)** (TypeScript) - A simple package to start serving an MCP server on most major JS meta-frameworks including Next, Nuxt, Svelte, and more.
-* **[Hermes MCP](https://github.com/cloudwalk/hermes-mcp)** (Elixir) - A high-performance and high-level Model Context Protocol (MCP) implementation in Elixir. Think like "Live View" for MCP.
 * **[PHP MCP Server](https://github.com/php-mcp/server)** (PHP) - Core PHP implementation for the Model Context Protocol (MCP) server
 
 ### For clients


### PR DESCRIPTION
i (was) am the core maintainer of https://github.com/cloudwalk/hermes-mcp, but since i was fired i needed to transfer the intelectual property for them, so i decided to fork it as an independent/revamped project since `v0.13.0` to https://github.com/zoedsoupe/anubis-mcp so i can guarantee that ill still maintain the sdk/library.

the "original" one already hit 40k+ downloads on https://hex.pm

## Description

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: Hermes MCP
- Changes to: Anubis MCP (name)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
https://github.com/cloudwalk/hermes-mcp got proprietary and since i don't work there anymore, i can't guarantee that it will continue to be maintained

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
N/A

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
N/A
