### PR TITLE
fix: update temperature argument type from number to string in everything server docs

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -117,7 +117,7 @@ Resource features:
 2. `complex_prompt`
    - Advanced prompt demonstrating argument handling
    - Required arguments:
-     - `temperature` (number): Temperature setting
+     - `temperature` (string): Temperature setting
    - Optional arguments:
      - `style` (string): Output style preference
    - Returns: Multi-turn conversation with images


### PR DESCRIPTION
Fixes issue #474 - documentation mismatch where temperature parameter for prompt input argument was documented as (number) but TypeScript SDK only accepts string arguments via z.record(z.string())

Generated with [Claude Code](https://claude.ai/code)