### PR TITLE
Improve parameter descriptions in sequential-thinking for better LLM type safety

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -206,12 +206,12 @@ You should:
       },
       thoughtNumber: {
         type: "integer",
-        description: "Current thought number",
+        description: "Current thought number (numeric value, e.g., 1, 2, 3)",
         minimum: 1
       },
       totalThoughts: {
         type: "integer",
-        description: "Estimated total thoughts needed",
+        description: "Estimated total thoughts needed (numeric value, e.g., 5, 10)",
         minimum: 1
       },
       isRevision: {


### PR DESCRIPTION
Update thoughtNumber and totalThoughts parameter descriptions to use positive-only examples that guide LLMs toward correct numeric type usage. This addresses the issue where LLMs sometimes generate string values (e.g. "/1") instead of numeric values (e.g. 1) for integer parameters.

Fixes #2598

Generated with [Claude Code](https://claude.ai/code)