### PR TITLE
Add triplyfy-mcp to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,6 +1155,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Trello MCP Server](https://github.com/lioarce01/trello-mcp-server)** - An MCP server that interact with user Trello boards, modifying them with prompting.
 - **[Trino](https://github.com/tuannvm/mcp-trino)** - A high-performance Model Context Protocol (MCP) server for Trino implemented in Go.
 - **[Tripadvisor](https://github.com/pab1it0/tripadvisor-mcp)** - An MCP server that enables LLMs to interact with Tripadvisor API, supporting location data, reviews, and photos through standardized MCP interfaces
+- **[Triplyfy MCP](https://github.com/helpful-AIs/triplyfy-mcp)** - An MCP server that lets LLMs plan and manage itineraries with interactive maps in Triplyfy; manage itineraries, places and notes, and search/save flights.
 - **[TrueNAS Core MCP](https://github.com/vespo92/TrueNasCoreMCP)** - An MCP server for interacting with TrueNAS Core.
 - **[TuriX Computer Automation MCP](https://github.com/TurixAI/TuriX-CUA/tree/mac_mcp)** - MCP server for helping automation control your computer complete your pre-setting task.
 - **[Tyk API Management](https://github.com/TykTechnologies/tyk-dashboard-mcp)** - Chat with all of your organization's managed APIs and perform other API lifecycle operations, managing tokens, users, analytics, and more.


### PR DESCRIPTION
## Description

Add Triplyfy MCP server for interactive itinerary planning with maps, places, and flights.

## Server Details
- Server: triplyfy-mcp
- Changes to: Adding new MCP server to the registry

## Motivation and Context
This MCP server enables AI assistants to plan and manage itineraries in Triplyfy with interactive maps. It lets users create/read/update trips, organize places and notes via drag-and-drop, and search/save flights—secured by Google sign-in. This fills a practical trip-planning gap in the MCP ecosystem with a real, user-facing service.

## How Has This Been Tested?
- Tested with Claude Desktop (Command-based MCP) via SSE: https://triplyfy.com/mcp/sse
- Verified OAuth sign-in (Google) and token exchange (authorization_code, refresh)
- Validated session handling (30-day session tokens) and error responses
- Confirmed HEAD /mcp/sse probes, discovery endpoints, and CORS behavior
- Exercised tools end-to-end:
  - whoami, readAllPlans, readOnePlan
  - createPlan, updatePlan
  - getFlights (search + save to plan)

## Breaking Changes
None - this is a new server addition

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
- Tech: Next.js route handlers, Vercel MCP adapter (HTTP/SSE), Prisma + PostgreSQL
- Auth: Google OAuth → issues Triplyfy session tokens (not Google tokens), ~30 days
- Functions: whoami, readAllPlans, readOnePlan, createPlan, updatePlan, getFlights
- Privacy: Uses only basic profile (email, name, avatar) to attach plans

