### PR TITLE
feat(filesystem): ignore dot directories by default to reduce token usage

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -15,6 +15,20 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 
 The server uses a flexible directory access control system. Directories can be specified via command-line arguments or dynamically via [Roots](https://modelcontextprotocol.io/docs/learn/client-concepts#roots).
 
+### Hidden Files and Directories
+
+By default, the filesystem server **ignores dot-prefixed files and directories** (like `.git`, `.env`, `.terraform`, etc.) to:
+- Reduce token usage (especially from large directories like `.git`)
+- Enhance security by avoiding exposure of potentially sensitive hidden files
+- Follow the convention that dot-prefixed items are typically "hidden" for good reason
+
+To include hidden files and directories, set the environment variable:
+```bash
+export MCP_FILESYSTEM_INCLUDE_HIDDEN=true
+```
+
+This affects the following operations: `list_directory`, `list_directory_with_sizes`, `directory_tree`, and `search_files`.
+
 ### Method 1: Command-line Arguments
 Specify Allowed directories when starting the server:
 ```bash

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -40,6 +40,17 @@ export interface SearchResult {
   isDirectory: boolean;
 }
 
+// Check if hidden files/directories should be included
+// Environment variable MCP_FILESYSTEM_INCLUDE_HIDDEN controls this (default: false)
+export function shouldIncludeHidden(): boolean {
+  return process.env.MCP_FILESYSTEM_INCLUDE_HIDDEN === 'true';
+}
+
+// Check if a file/directory name should be filtered out (dot-prefixed items)
+export function shouldFilterHiddenEntry(name: string): boolean {
+  return !shouldIncludeHidden() && name.startsWith('.');
+}
+
 // Pure Utility Functions
 export function formatSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -361,6 +372,9 @@ export async function searchFilesWithValidation(
     const entries = await fs.readdir(currentPath, { withFileTypes: true });
 
     for (const entry of entries) {
+      // Skip hidden files/directories unless explicitly enabled
+      if (shouldFilterHiddenEntry(entry.name)) continue;
+
       const fullPath = path.join(currentPath, entry.name);
 
       try {


### PR DESCRIPTION
This PR addresses issue #2219 by implementing default filtering of dot-prefixed files and directories in the filesystem MCP server.

## Changes
- Add environment variable `MCP_FILESYSTEM_INCLUDE_HIDDEN` (default: false)
- Filter dot-prefixed files/directories in `list_directory`, `directory_tree`, `search_files`
- Reduce token usage from large directories like `.git`, `.terraform`, etc.
- Enhance security by avoiding exposure of potentially sensitive hidden files
- Include comprehensive tests for the new filtering functionality
- Update documentation to explain the new behavior and environment variable

## Backward Compatibility
Existing behavior is maintained by setting `MCP_FILESYSTEM_INCLUDE_HIDDEN=true`

Fixes #2219

Generated with [Claude Code](https://claude.ai/code)