### PR TITLE
Make presence of `startElicitation` tool conditional on client support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5818,7 +5818,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@modelcontextprotocol/sdk": "^1.17.4",
         "express": "^4.21.1",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5"
@@ -5833,9 +5833,9 @@
       }
     },
     "src/everything/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.3.tgz",
-      "integrity": "sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
+      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -5843,6 +5843,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -164,8 +164,7 @@ export const createServer = () => {
         resources: { subscribe: true },
         tools: {},
         logging: {},
-        completions: {},
-        elicitation: {},
+        completions: {}
       },
       instructions
     }
@@ -177,7 +176,7 @@ export const createServer = () => {
 
   let logLevel: LoggingLevel = "debug";
   let logsUpdateInterval: NodeJS.Timeout | undefined;
-  // Store client capabilities 
+  // Store client capabilities
   let clientCapabilities: ClientCapabilities | undefined;
 
   // Roots state management
@@ -524,11 +523,6 @@ export const createServer = () => {
         inputSchema: zodToJsonSchema(GetResourceReferenceSchema) as ToolInput,
       },
       {
-        name: ToolName.ELICITATION,
-        description: "Demonstrates the Elicitation feature by asking the user to provide information about their favorite color, number, and pets.",
-        inputSchema: zodToJsonSchema(ElicitationSchema) as ToolInput,
-      },
-      {
         name: ToolName.GET_RESOURCE_LINKS,
         description:
           "Returns multiple resource links that reference different types of resources",
@@ -548,7 +542,12 @@ export const createServer = () => {
             "Lists the current MCP roots provided by the client. Demonstrates the roots protocol capability even though this server doesn't access files.",
         inputSchema: zodToJsonSchema(ListRootsSchema) as ToolInput,
     });
-    
+    if (clientCapabilities!.elicitation) tools.push ({
+        name: ToolName.ELICITATION,
+        description: "Demonstrates the Elicitation feature by asking the user to provide information about their favorite color, number, and pets.",
+        inputSchema: zodToJsonSchema(ElicitationSchema) as ToolInput,
+    });
+
     return { tools };
   });
 

--- a/src/everything/package.json
+++ b/src/everything/package.json
@@ -22,7 +22,7 @@
     "start:streamableHttp": "node dist/streamableHttp.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "^1.17.4",
     "express": "^4.21.1",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.5"


### PR DESCRIPTION
## Description
In `server-everything`, suppress `startElicitation` tool if client does not advertise support for elicitation capability.

* In `everything.ts`
  - Remove inappropriate elicitation entry from server capabilities (this is a client capability)
  - When creating tool list, only add `ToolName.ELICITATION` definition to tools array if `clientCapabilities` includes `elicitation`

* In `package.json` & `package-lock.json`
  - bump `@modelcontextprotocol/sdk` to `^1.17.4`, adding `elicitation` to `ClientCapabilities` type

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: `everything`
- Changes to: tools

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
If the client does not support elicitations, the `startElicitation` tool will cause an error when run.

### Currently, When Client Doesn't Support Elicitation
<img width="764" height="288" alt="Screenshot 2025-08-28 at 2 18 55 PM" src="https://github.com/user-attachments/assets/a57c46cf-8657-4863-9943-18206035447e" />

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Commented out elicitation support in the Inspector. Tried with and without elicitiations, showing that the `startElicitation` tool is only shown if the client supports it.

### When Client Supports Elicitation
<img width="770" height="565" alt="Screenshot 2025-08-28 at 2 03 55 PM" src="https://github.com/user-attachments/assets/eae4c6f2-e7e3-4d43-ab11-f780231f76ac" />

### When Client Doesn't Support Elicitation
<img width="765" height="564" alt="Screenshot 2025-08-28 at 2 04 40 PM" src="https://github.com/user-attachments/assets/28ac6dde-fbc8-40da-b3cf-fac6a9f2463b" />

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
