### PR TITLE
fix: only run scheduled release pipeline on modelcontextprotocol org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   create-metadata:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'modelcontextprotocol'
     outputs:
       hash: ${{ steps.last-release.outputs.hash }}
       version: ${{ steps.create-version.outputs.version}}


### PR DESCRIPTION
Add condition to only run scheduled release pipeline if repository owner is 'modelcontextprotocol'

This ensures the automated release workflow only runs on the official repository, not on forks.

Use case: I pushed to some people's forks to fix their PRs. Now I get spammed everyday with an email telling me the pipeline failed on their fork. I want to avoid this in future.