### PR TITLE
Everything server - fix regression + auto log level handling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Jetbrains IDEs
+.idea/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/package-lock.json
+++ b/package-lock.json
@@ -5818,7 +5818,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.4",
+        "@modelcontextprotocol/sdk": "^1.17.5",
         "express": "^4.21.1",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5"
@@ -5833,9 +5833,9 @@
       }
     },
     "src/everything/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
-      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
+      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/everything/package.json
+++ b/src/everything/package.json
@@ -22,7 +22,7 @@
     "start:streamableHttp": "node dist/streamableHttp.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.4",
+    "@modelcontextprotocol/sdk": "^1.17.5",
     "express": "^4.21.1",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.5"

--- a/src/everything/sse.ts
+++ b/src/everything/sse.ts
@@ -26,7 +26,7 @@ app.get("/sse", async (req, res) => {
     console.error("Client Connected: ", transport.sessionId);
 
     // Start notification intervals after client connects
-    startNotificationIntervals();
+    startNotificationIntervals(transport.sessionId);
 
     // Handle close of connection
     server.onclose = async () => {

--- a/src/everything/stdio.ts
+++ b/src/everything/stdio.ts
@@ -2,21 +2,58 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./everything.js";
+import {
+    LoggingLevel,
+    LoggingLevelSchema,
+    LoggingMessageNotification,
+    SetLevelRequestSchema
+} from "@modelcontextprotocol/sdk/types.js";
 
 console.error('Starting default (STDIO) server...');
 
 async function main() {
-  const transport = new StdioServerTransport();
-  const {server, cleanup} = createServer();
+    const transport = new StdioServerTransport();
+    const {server, cleanup, startNotificationIntervals } = createServer();
 
-  await server.connect(transport);
+    // Currently, for STDIO servers, automatic log-level support is not available, as levels are tracked by sessionId.
+    // The listener will be set, so if the STDIO server advertises support for logging, and the client sends a setLevel
+    // request, it will be handled and thus not throw a "Method not found" error. However, the STDIO server will need to
+    // implement its own listener and level handling for now. This will be remediated in a future SDK version.
 
-  // Cleanup on exit
-  process.on("SIGINT", async () => {
-    await cleanup();
-    await server.close();
-    process.exit(0);
-  });
+    let logLevel: LoggingLevel = "debug";
+    server.setRequestHandler(SetLevelRequestSchema, async (request) => {
+        const { level } = request.params;
+        logLevel = level;
+        return {};
+    });
+
+    server.sendLoggingMessage =  async (params: LoggingMessageNotification["params"], _: string|undefined): Promise<void>  => {
+        const LOG_LEVEL_SEVERITY = new Map(
+            LoggingLevelSchema.options.map((level, index) => [level, index])
+        );
+
+        const isMessageIgnored = (level: LoggingLevel): boolean => {
+            const currentLevel = logLevel;
+            return (currentLevel)
+                ? LOG_LEVEL_SEVERITY.get(level)! < LOG_LEVEL_SEVERITY.get(currentLevel)!
+                : false;
+        };
+
+        if (!isMessageIgnored(params.level)) {
+            return server.notification({method: "notifications/message", params})
+        }
+
+    }
+
+    await server.connect(transport);
+    startNotificationIntervals();
+
+    // Cleanup on exit
+    process.on("SIGINT", async () => {
+        await cleanup();
+        await server.close();
+        process.exit(0);
+    });
 }
 
 main().catch((error) => {

--- a/src/everything/streamableHttp.ts
+++ b/src/everything/streamableHttp.ts
@@ -22,7 +22,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
       transport = transports.get(sessionId)!;
     } else if (!sessionId) {
 
-      const { server, cleanup } = createServer();
+      const { server, cleanup, startNotificationIntervals } = createServer();
 
       // New initialization request
       const eventStore = new InMemoryEventStore();
@@ -53,7 +53,11 @@ app.post('/mcp', async (req: Request, res: Response) => {
       await server.connect(transport);
 
       await transport.handleRequest(req, res);
-      return; // Already handled
+
+      // Wait until initialize is complete and transport will have a sessionId
+      startNotificationIntervals(transport.sessionId);
+
+        return; // Already handled
     } else {
       // Invalid request - no session ID or not initialization request
       res.status(400).json({


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->

* in .gitignore
  - add .idea/ for Jetbrains IDEs
* in everything.ts
  - remove import of SetLevelRequestSchema
  - remove logLevel var
  - add sessionId var
  - in startNotificationIntervals function
    - add optional sid argument
    - set sessionId to sid
    - define messages to be sent, adding sessionId if present
  - remove setRequestHandler call for SetLevelRequestSchema
  - replace server.notification calls that sent "notifications/message" objects with calls to server.sendLoggingMessage, passing just the parameters and sessionId.
* In package.json & package-lock.json
  - bump TS SDK version to 1.17.5
* In sse.ts, pass transport.sessionId to startNotificationIntervals call
* In stdio.ts
  - destructure startNotificationIntervals from createServer call
  - implement custom logging request handler and server.sendLoggingMessage implementation, as a workaround for the fact that the SDK's automatic log level handling currently only tracks requested log level by session id. This will be fixed in a followup PR for the SDK
  - call the startNotificationIntervals function after connecting the transport to the server
* In streamableHttp.ts
  - destructure startNotificationIntervals from createServer call
  - call startNotificationIntervals passing the transport.sessionId after connecting the transport to the server

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: Everything
- Changes to: logging

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
1) A Regression: The Everything server has stopped sending regular subscription update and log notifications for the streamableHttp and stdio servers. This happened in [2569 - Fix SSE server crash by starting notification timers only after client connects](https://github.com/modelcontextprotocol/servers/pull/2569). It returns a `startNotificationIntervals` function reference from the `createServer` function, but the non-sse callers never invoke it.
2) The TypeScript SDK now has support for [automatic log level handling](https://github.com/modelcontextprotocol/typescript-sdk/pull/882). This PR updates the SDK version to get that functionality, and refactors the Everything servers to remove its internal log level handling functionality and use the `server.sendLoggingMessage` function rather than `send.notification` which is required for the log level filtering to be applied.
3) The TypeScript SDK's automatic log level handling **currently** tracks the requested level by sessionId. However STDIO doesn't have sessionIds, so this PR adds a workaround for the Everything STDIO server so that it tracks its own logging level. _This will be removed after a followup PR to the SDK to allow tracking when there isn't a sessionId._

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
### With StreamableHttps transport
<img width="1920" height="718" alt="SHTTP" src="https://github.com/user-attachments/assets/7059575c-1f29-4d12-9680-3d86b2543935" />

### With SSE transport
<img width="1919" height="655" alt="SSE" src="https://github.com/user-attachments/assets/f823c86d-516a-499e-96ce-93051abd6168" />

### With STDIO transport
<img width="1920" height="1118" alt="STDIO" src="https://github.com/user-attachments/assets/9f2a07fa-fd09-4da0-ad9b-890711012a83" />

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Companion to this [Inspector PR](https://github.com/modelcontextprotocol/inspector/pull/774)