### PR TITLE
Add Microsoft Playwright MCP server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following reference servers are now archived and can be found at [servers-ar
 - **[GitLab](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gitlab)** - GitLab API, enabling project management.
 - **[Google Drive](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gdrive)** - File access and search capabilities for Google Drive.
 - **[Google Maps](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/google-maps)** - Location services, directions, and place details.
+- **[Playwright](https://github.com/microsoft/playwright-mcp)** — Official Microsoft Playwright MCP server for browser automation and testing.
 - **[PostgreSQL](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/postgres)** - Read-only database access with schema inspection.
 - **[Puppeteer](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer)** - Browser automation and web scraping.
 - **[Redis](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/redis)** - Interact with Redis key-value stores.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The following reference servers are now archived and can be found at [servers-ar
 - **[GitLab](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gitlab)** - GitLab API, enabling project management.
 - **[Google Drive](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gdrive)** - File access and search capabilities for Google Drive.
 - **[Google Maps](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/google-maps)** - Location services, directions, and place details.
-- **[Playwright](https://github.com/microsoft/playwright-mcp)** — Official Microsoft Playwright MCP server for browser automation and testing.
 - **[PostgreSQL](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/postgres)** - Read-only database access with schema inspection.
 - **[Puppeteer](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer)** - Browser automation and web scraping.
 - **[Redis](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/redis)** - Interact with Redis key-value stores.
@@ -343,6 +342,7 @@ Official integrations are maintained by companies building production ready MCP 
 - <img height="12" width="12" src="https://avatars.githubusercontent.com/u/54333248" /> **[Pinecone Assistant](https://github.com/pinecone-io/assistant-mcp)** - Retrieves context from your [Pinecone Assistant](https://docs.pinecone.io/guides/assistant/mcp-server) knowledge base.
 - <img height="12" width="12" src="https://pipedream.com/favicon.ico" alt="Pipedream Logo" /> **[Pipedream](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol)** - Connect with 2,500 APIs with 8,000+ prebuilt tools.
 - <img height="12" width="12" src="https://playcanvas.com/static-assets/images/icons/favicon.png" alt="PlayCanvas Logo" /> **[PlayCanvas](https://github.com/playcanvas/editor-mcp-server)** - Create interactive 3D web apps with the PlayCanvas Editor.
+- <img height="12" width="12" src="https://playwright.dev/img/playwright-logo.ico" alt="Playwright Logo" /> **[Playwright](https://github.com/microsoft/playwright-mcp)** — Browser automation MCP server using Playwright to run tests, navigate pages, capture screenshots, scrape content, and automate web interactions reliably.
 - <img height="12" width="12" src="https://www.plugged.in/favicon.ico" alt="Plugged.in Logo" /> **[Plugged.in](https://github.com/VeriTeknik/pluggedin-mcp)** - A comprehensive proxy that combines multiple MCP servers into a single MCP. It provides discovery and management of tools, prompts, resources, and templates across servers, plus a playground for debugging when building MCP servers.
 - <img height="12" width="12" src="https://github.com/port-labs/port-mcp-server/blob/main/assets/port_symbol_white.svg" alt="Port Logo" /> **[Port IO](https://github.com/port-labs/port-mcp-server)** - Access and manage your software catalog to improve service quality and compliance.
 - **[PostHog](https://github.com/posthog/mcp)** - Interact with PostHog analytics, feature flags, error tracking and more with the official PostHog MCP server.


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->
## Description
Add the official Microsoft Playwright MCP server to the README under "Official Integrations". This adds a single README entry linking to https://github.com/microsoft/playwright-mcp and keeps the list alphabetical.

## Server Details
- Server: Playwright (official Microsoft implementation)
- Changes to: README.md (Third-Party Servers → Official Integrations)

## Motivation and Context
The Playwright MCP server is an official integration maintained by Microsoft. Adding it to the README improves discoverability for users looking for browser automation and testing integrations and keeps the registry complete and up to date.

## How Has This Been Tested?
- Verified the link and README entry locally using Markdown preview.
- Confirmed insertion point follows the README's alphabetical ordering convention.

## Breaking Changes
- None. Documentation-only change; no runtime or client configuration changes required.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follow MCP security best practices (documentation-only change)
- [x] I have updated the repository README accordingly
- [ ] I have tested this with an LLM client
- [x] My changes follow the repository's style guidelines (README formatting / alphabetical ordering)
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
