### PR TITLE
Let Everything's STDIO server use SDK's automatic log level handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5818,7 +5818,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.18.0",
         "express": "^4.21.1",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5"
@@ -5833,9 +5833,9 @@
       }
     },
     "src/everything/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
-      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.18.0.tgz",
+      "integrity": "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/everything/everything.ts
+++ b/src/everything/everything.ts
@@ -196,7 +196,6 @@ export const createServer = () => {
         }, 10000);
       }
 
-      console.log(sessionId)
       const maybeAppendSessionId = sessionId ? ` - SessionId ${sessionId}`: "";
       const messages: { level: LoggingLevel; data: string }[] = [
           { level: "debug", data: `Debug-level message${maybeAppendSessionId}` },

--- a/src/everything/package.json
+++ b/src/everything/package.json
@@ -22,7 +22,7 @@
     "start:streamableHttp": "node dist/streamableHttp.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.18.0",
     "express": "^4.21.1",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.5"

--- a/src/everything/stdio.ts
+++ b/src/everything/stdio.ts
@@ -2,48 +2,12 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./everything.js";
-import {
-    LoggingLevel,
-    LoggingLevelSchema,
-    LoggingMessageNotification,
-    SetLevelRequestSchema
-} from "@modelcontextprotocol/sdk/types.js";
 
 console.error('Starting default (STDIO) server...');
 
 async function main() {
     const transport = new StdioServerTransport();
-    const {server, cleanup, startNotificationIntervals } = createServer();
-
-    // Currently, for STDIO servers, automatic log-level support is not available, as levels are tracked by sessionId.
-    // The listener will be set, so if the STDIO server advertises support for logging, and the client sends a setLevel
-    // request, it will be handled and thus not throw a "Method not found" error. However, the STDIO server will need to
-    // implement its own listener and level handling for now. This will be remediated in a future SDK version.
-
-    let logLevel: LoggingLevel = "debug";
-    server.setRequestHandler(SetLevelRequestSchema, async (request) => {
-        const { level } = request.params;
-        logLevel = level;
-        return {};
-    });
-
-    server.sendLoggingMessage =  async (params: LoggingMessageNotification["params"], _: string|undefined): Promise<void>  => {
-        const LOG_LEVEL_SEVERITY = new Map(
-            LoggingLevelSchema.options.map((level, index) => [level, index])
-        );
-
-        const isMessageIgnored = (level: LoggingLevel): boolean => {
-            const currentLevel = logLevel;
-            return (currentLevel)
-                ? LOG_LEVEL_SEVERITY.get(level)! < LOG_LEVEL_SEVERITY.get(currentLevel)!
-                : false;
-        };
-
-        if (!isMessageIgnored(params.level)) {
-            return server.notification({method: "notifications/message", params})
-        }
-
-    }
+    const {server, cleanup, startNotificationIntervals} = createServer();
 
     await server.connect(transport);
     startNotificationIntervals();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->
* In src/everything/package.json
  - bump TS SDK to 1.18.0
* In src/everything/stdio.ts
  - remove logging related imports
  - remove custom log-level handling, now handled automatically by the SDK
* In src/everything/everything.ts
  - remove console.log of sessionId

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: Everything / stdio
- Changes to: log level handling

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The automatic log level handling [fix for stdio servers](https://github.com/modelcontextprotocol/typescript-sdk/pull/917) has been merged and included in the new SDK release. As a temporary workaround until this fix could happen, the Everything stdio server previously had a custom log level handling implementation. This has been removed, and now, all three transports use the SDK's log level handling feature.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Used inspector to test the Everything / stdio server. 
  - Initially negotiated log level of `debug` allowed some `info` level messages to pass
  - Subsequently negotiated log level of `alert` only allowed `alert` and `emergency` messages to pass

### Log Level Set to `debug`
<img width="1593" height="796" alt="debug" src="https://github.com/user-attachments/assets/1d2bc8cc-0a2b-459a-9e9a-860e37645a11" />

### Log Level Set to `alert`
<img width="1601" height="616" alt="alert" src="https://github.com/user-attachments/assets/7c45d3fc-0829-4e45-a38a-7527f2b6d189" />

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
