### PR TITLE
docs: Fix duplicate directory_tree tool entry in README.md

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -128,15 +128,6 @@ The server's directory access control follows this flow:
   - Returns detailed listing with file sizes and summary statistics
   - Shows total files, directories, and combined size
 
-- **directory_tree**
-  - Get a recursive tree view of files and directories as a JSON structure
-  - Input: `path` (string): Starting directory path
-  - Returns JSON structure with:
-    - `name`: File/directory name
-    - `type`: "file" or "directory"
-    - `children`: Array of child entries (for directories only)
-  - Output is formatted with 2-space indentation for readability
-
 - **move_file**
   - Move or rename files and directories
   - Inputs:
@@ -165,6 +156,7 @@ The server's directory access control follows this flow:
       - `children` (array): Present only for directories
         - Empty array for empty directories
         - Omitted for files
+  - Output is formatted with 2-space indentation for readability
     
 - **get_file_info**
   - Get detailed file/directory metadata


### PR DESCRIPTION
## Description
Removed the duplicate `directory_tree` tool entry from the API documentation section. The documentation now correctly shows only one entry for this tool, which matches the actual implementation that supports both `path` and `excludePatterns` parameters.

## Server Details
- Server: filesystem
- Changes to: README.md

## Motivation and Context
The API documentation contained two separate entries for the `directory_tree` tool, which was confusing and inconsistent. The first entry was incomplete (only describing the `path` parameter), while the second entry correctly described both `path` and `excludePatterns` parameters. This change ensures the documentation accurately reflects the implemented functionality.

## How Has This Been Tested?
- Verified that the actual implementation in `src/filesystem/index.js` supports both parameters
- Reviewed the modified documentation for clarity and accuracy
- Confirmed that the remaining documentation entry matches the code implementation

## Breaking Changes
No breaking changes. This is purely a documentation fix.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] I have updated the server's README accordingly
- [x] My changes follows MCP security best practices

## Additional context
The duplicate entry appeared to be a copy-paste error during documentation writing. The fix ensures users see the correct and complete tool specification.