### PR TITLE
feat(readme): add Storybook MCP server to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Stellar](https://github.com/syronlabs/stellar-mcp/)** - This MCP server enables LLMs to interact with the Stellar blockchain to create accounts, check address balances, analyze transactions, view transaction history, mint new assets, interact with smart contracts and much more.
 - **[Stitch AI](https://github.com/StitchAI/stitch-ai-mcp/)** - Knowledge management system for AI agents with memory space creation and retrieval capabilities.
 - **[Stockfish](https://github.com/sonirico/mcp-stockfish)** - MCP server connecting AI systems to Stockfish chess engine
+- **[Storybook](https://github.com/stefanoamorelli/storybook-mcp-server)** (by Stefano Amorelli) - Interact with Storybook component libraries, enabling component discovery, story management, prop inspection, and visual testing across different viewports.
 - **[Strava](https://github.com/r-huijts/strava-mcp)** - Connect to the Strava API to access activity data, athlete profiles, segments, and routes, enabling fitness tracking and analysis with Claude.
 - **[Strava API](https://github.com/tomekkorbak/strava-mcp-server)** - MCP server for Strava API to retrieve one's activities
 - **[Stripe](https://github.com/atharvagupta2003/mcp-stripe)** - This MCP allows integration with Stripe for handling payments, customers, and refunds.


### PR DESCRIPTION
## Summary
- Added Storybook MCP server to the community servers list in README.md
- Placed alphabetically between Stockfish and Strava entries
- Provides MCP integration for Storybook component libraries

## Details
This PR adds the [Storybook MCP server](https://github.com/stefanoamorelli/storybook-mcp-server) to the community servers list. The server enables AI assistants to interact with Storybook component libraries, providing capabilities for component discovery, story management, prop inspection, and visual testing across different viewports.

## Test plan
- [x] Entry added in correct alphabetical position
- [x] Link points to correct GitHub repository
- [x] Description follows existing format and style