### PR TITLE
Add Reddit MCP Buddy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Reaper](https://github.com/dschuler36/reaper-mcp-server)** - Interact with your [Reaper](https://www.reaper.fm/) (Digital Audio Workstation) projects.
 - **[Redbee](https://github.com/Tamsi/redbee-mcp)** - Redbee MCP server that provides support for interacting with Redbee API.
 - **[Redfish](https://github.com/nokia/mcp-redfish)** - Redfish MCP server that provides support for interacting with [DMTF Redfish API](https://www.dmtf.org/standards/redfish).
+- **[Reddit Buddy](https://github.com/karanb192/reddit-buddy-mcp)** - Browse Reddit posts, search content, and analyze user activity without API keys.
 - **[Redis](https://github.com/GongRzhe/REDIS-MCP-Server)** - Redis database operations and caching microservice server with support for key-value operations, expiration management, and pattern-based key listing.
 - **[Redis](https://github.com/prajwalnayak7/mcp-server-redis)** MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate
 - **[RedNote MCP](https://github.com/ifuryst/rednote-mcp)** - MCP server for accessing RedNote(XiaoHongShu, xhs) content


### PR DESCRIPTION
## Description
  This PR adds Reddit Buddy MCP to the community servers list. Reddit Buddy enables Claude Desktop and other AI
   assistants to browse Reddit content, search posts, and analyze user activity without requiring API keys.

  ## Server Details
  - Server: New addition - Reddit Buddy MCP
  - Changes to: Community servers list in README.md

  ## Motivation and Context
  Reddit Buddy MCP fills a gap in the ecosystem by providing Reddit access to AI assistants without requiring
  API keys or authentication. This enables:
  - Easy Reddit content analysis for research
  - Trend monitoring across subreddits
  - User activity analysis
  - Access to discussions and comments
  All through a simple MCP interface that works out-of-the-box with Claude Desktop.

  ## How Has This Been Tested?
  Tested extensively with Claude Desktop on macOS and Windows. Scenarios tested include:
  - Browsing multiple subreddits (hot/new/top/rising posts)
  - Searching Reddit with various queries
  - Analyzing user profiles and post history
  - Reading full comment threads
  - Error handling for private/NSFW subreddits

  ## Breaking Changes
  No breaking changes - this is a new server addition.

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  - [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
  - [x] My changes follows MCP security best practices
  - [x] I have updated the server's README accordingly
  - [x] I have tested this with an LLM client
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have documented all environment variables and configuration options

  ## Additional context
  - **npm package**: [@karanb192/reddit-buddy-mcp](https://www.npmjs.com/package/@karanb192/reddit-buddy-mcp)
  - **GitHub repo**: [reddit-buddy-mcp](https://github.com/karanb192/reddit-buddy-mcp)
  - **Installation**: `npm install -g @karanb192/reddit-buddy-mcp` or `npx @karanb192/reddit-buddy-mcp`
  - No API keys required - uses public web scraping
  - Respects Reddit's rate limits and robots.txt
  - Returns clean, LLM-optimized responses