### PR TITLE
Fix insufficient create-release condition in GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,9 @@ jobs:
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]
     if: |
-       (needs.update-packages.outputs.changes_made == 'true' && always()) &&
-       ((needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'skipped') || 
-       (needs.publish-pypi.result == 'skipped' && needs.publish-npm.result == 'success') || 
-       (needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'success'))
+      always() &&
+      needs.update-packages.outputs.changes_made == 'true' &&
+      (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'success')
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,11 +194,10 @@ jobs:
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]
     if: |
-      needs.update-packages.outputs.changes_made == 'true' && 
-       (always() && 
-       (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'skipped') && 
-       (needs.publish-pypi.result == 'skipped' || needs.publish-npm.result == 'success') && 
-       (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'success'))
+       (needs.update-packages.outputs.changes_made == 'true' && always()) &&
+       ((needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'skipped') || 
+       (needs.publish-pypi.result == 'skipped' && needs.publish-npm.result == 'success') || 
+       (needs.publish-pypi.result == 'success' && needs.publish-npm.result == 'success'))
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,8 @@ jobs:
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]
     if: |
+      # Always evaluate this condition, even if a dependency failed
+      # Create a release if changes were made and at least one publish succeeded
       always() &&
       needs.update-packages.outputs.changes_made == 'true' &&
       (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'success')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,12 @@ jobs:
 
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]
-    if: needs.update-packages.outputs.changes_made == 'true'
+    if: |
+      needs.update-packages.outputs.changes_made == 'true' && 
+       (always() && 
+       (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped') && 
+       (needs.publish-pypi.result == 'skipped' || needs.publish-npm.result == 'success') && 
+       (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'success'))
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
     if: |
       needs.update-packages.outputs.changes_made == 'true' && 
        (always() && 
-       (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped') && 
+       (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'skipped') && 
        (needs.publish-pypi.result == 'skipped' || needs.publish-npm.result == 'success') && 
        (needs.publish-pypi.result == 'success' || needs.publish-npm.result == 'success'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- Provide a brief description of your changes -->
* In `.github/workflows/release.yml`
  - in `create-release` job condition
    - use `always()` to force evaluation, even if one or more dependencies failed or was skipped
    - check for all combinations of publish results that should lead to a release creation
      - pypi = success / npm = skipped
      - pypi = skipped / npm = success 
      - pypi = success / npm = success

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
We still have a problem with Automatic Release Creation where if there are only changes to be published to npm OR pypi BUT NOT both, the final `create-release` job will not be run. See [this recent Action](https://github.com/modelcontextprotocol/servers/actions/runs/17671290638) where TypeScript changes were published to npm, but the `create-release` job was not run.

### The problem
The original condition `needs.update-packages.outputs.changes_made == 'true'` in the `create-release` job was insufficient because it only checked whether changes were made to packages, but completely ignored the success or failure status of the dependent publishing jobs (`publish-pypi` and `publish-npm`). Also, since `always()` was not part of the condition, it was actually never evaluated in a mixed success case, because the `needs` field dependencies must all succeed before the condition is evaluated.

### The fix
* Use `always()` to ensure the condition is evaluated even if some dependent jobs fail or are skipped. Without `always()`, if either `publish-pypi` or `publish-npm` failed or were skipped, the release job would be automatically skipped, even if the other publishing job succeeded.
* Verify that at least one publishing job was successful.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
🤞🏻

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [X] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
**NOTE:** When there have only been changes to the README, i.e., adding official/community servers to the list, but neither npm nor pypi changes to publish, the `create-release` script would not run.