### PR TITLE
Fix time server to default to UTC when tzinfo is unavailable

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -46,7 +46,8 @@ def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
     local_tzname = get_localzone_name()
     if local_tzname is not None:
         return ZoneInfo(local_tzname)
-    raise McpError("Could not determine local timezone - tzinfo is None")
+    # Default to UTC if local timezone cannot be determined
+    return ZoneInfo("UTC")
 
 
 def get_zoneinfo(timezone_name: str) -> ZoneInfo:


### PR DESCRIPTION
When get_localzone_name() returns None, the server now defaults to UTC instead of raising an error. This makes the server more robust in environments where the local timezone cannot be determined.