### PR TITLE
Add claude-faf-mcp to MCP servers registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,6 @@ A growing set of community-developed and maintained servers demonstrates various
 > [!NOTE]
 > Community servers are **untested** and should be used at **your own risk**. They are not affiliated with or endorsed by Anthropic.
 
-- **[claude-faf-mcp](https://github.com/Wolfe-Jam/claude-faf-mcp)** - MCP server for .faf format. Context scoring engine with project context management.
 - **[1mcpserver](https://github.com/particlefuture/1mcpserver)** - MCP of MCPs. Automatically discover, configure, and add MCP servers on your local machine.
 - **[1Panel](https://github.com/1Panel-dev/mcp-1panel)** - MCP server implementation that provides 1Panel interaction.
 - **[A2A](https://github.com/GongRzhe/A2A-MCP-Server)** - An MCP server that bridges the Model Context Protocol (MCP) with the Agent-to-Agent (A2A) protocol, enabling MCP-compatible AI assistants (like Claude) to seamlessly interact with A2A agents.
@@ -615,6 +614,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Chroma](https://github.com/privetin/chroma)** - Vector database server for semantic document search and metadata filtering, built on Chroma
 - **[Chrome history](https://github.com/vincent-pli/chrome-history-mcp)** - Talk with AI about your browser history, get fun ^_^
 - **[CIViC](https://github.com/QuentinCody/civic-mcp-server)** - MCP server for the Clinical Interpretation of Variants in Cancer (CIViC) database, providing access to clinical variant interpretations and genomic evidence for cancer research.
+- **[claude-faf-mcp](https://github.com/Wolfe-Jam/claude-faf-mcp)** - MCP server for .faf format. Context scoring engine with project context management.
 - **[Claude Thread Continuity](https://github.com/peless/claude-thread-continuity)** - Persistent memory system enabling Claude Desktop conversations to resume with full context across sessions. Maintains conversation history, project states, and user preferences for seamless multi-session workflows.
 - **[ClaudePost](https://github.com/ZilongXue/claude-post)** - ClaudePost enables seamless email management for Gmail, offering secure features like email search, reading, and sending.
 - **[CLDGeminiPDF Analyzer](https://github.com/tfll37/CLDGeminiPDF-Analyzer)** - MCP server tool enabling sharing large PDF files to Google LLMs via API for further/additional analysis and response retrieval to Claude Desktop.


### PR DESCRIPTION
## Summary
Adding claude-faf-mcp to the MCP servers registry - a zero-dependency MCP server that provides .faf format context management for Claude Desktop.

## What is .faf?
The JPEG for AI - Foundational AI-context Format - Universal, shareable AI-Context for any AI, human or team, regardless of size, location, languages, stack, setup or documentation.
Website: https://faf.one

## Details
- **Package**: [claude-faf-mcp](https://www.npmjs.com/package/claude-faf-mcp) 
- **Downloads**: 240+ on NPM >> Update: now 1125 as of Sep 27 2025
- **Dependencies**: 1 (only @modelcontextprotocol/sdk)
- **License**: MIT
- **Description**: Universal AI context management with 33+ tools for Claude Desktop

## Testing
- Tested with Claude Desktop on macOS
- 11,000+ automated tests pass
- <50ms operation performance

## Checklist
- [x] Added server entry to registry
- [x] Follows MCP server format
- [x] MIT licensed
- [x] Available on NPM
- [x] Works with Claude Desktop