### PR TITLE
Add YetiBrowser MCP to Community registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[XiYan](https://github.com/XGenerationLab/xiyan_mcp_server)** - 🗄️ An MCP server that supports fetching data from a database using natural language queries, powered by XiyanSQL as the text-to-SQL LLM.
 - **[XMind](https://github.com/apeyroux/mcp-xmind)** - Read and search through your XMind directory containing XMind files.
 - **[Yahoo Finance](https://github.com/AgentX-ai/yahoo-finance-server)** - 📈 Lets your AI interact with Yahoo Finance to get comprehensive stock market data, news, financials, and more. Proxy supported.
+- **[YetiBrowser MCP](https://github.com/yetidevworks/yetibrowser-mcp)** - A fully open-source implementation of the Browser MCP workflow with standout features such as optimized screenshots, dom diffs, console access, multi-websocket support + more.
 - **[yfinance](https://github.com/Adity-star/mcp-yfinance-server)** -💹The MCP YFinance Stock Server provides real-time and historical stock data in a standard format, powering dashboards, AI agents,and research tools with seamless financial insights.
 - **[YNAB](https://github.com/ChuckBryan/ynabmcpserver)** - A Model Context Protocol (MCP) server for integrating with YNAB (You Need A Budget), allowing AI assistants to securely access and analyze your financial data.
 - **[YouTrack](https://github.com/tonyzorin/youtrack-mcp)** - A Model Context Protocol (MCP) server implementation for JetBrains YouTrack, allowing AI assistants to interact with YouTrack issue tracking system.


### PR DESCRIPTION
Adding [YetiBrowser MCP](https://github.com/yetidevworks/yetibrowser-mcp) to Community Registry

## Description

## Motivation and Context

YetiBrowser MCP is a fully open-source implementation of the Browser MCP workflow. It links a Node-based MCP server with Chrome/Firefox extensions so Model Context Protocol clients—Codex/Claude Code, Cursor, Windsurf, MCP Inspector, or your own tools—can automate a real browser tab while keeping every byte on your machine and auditable.

Other MCP options I tried didn't have the scope of browser tools I needed, were closed source, nor did they work well with multiple AI assistant instances. I needed something that was more powerful, and also let me configure which instance was pointing to the browser extensions

## How Has This Been Tested?

This is a local MCP server and Chrome browser extension. I've been using this MCP exclusively for weeks, and it's been working great.   It took a few iterations to get the auto-connecting port functionality to work as intended, but all good now.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

Originally I had planned for both Chrome and Firefox extensions, but due to limitations with the current state of Manifest v3, Firefox extension is on hold until better support is in the stable builds. Currently requires 'nightly' builds and explicit background processing enabled.  
