### PR TITLE
Add Source to Knowledge Base (src-to-kb) MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Solver](https://github.com/szeider/mcp-solver)** - Solves constraint satisfaction and optimization problems .
 - **[Solvitor](https://github.com/Adeptus-Innovatio/solvitor-mcp)** – Solvitor MCP server provides tools to access reverse engineering tools that help developers extract IDL files from closed - source Solana smart contracts and decompile them.
 - **[Sourcerer](https://github.com/st3v3nmw/sourcerer-mcp)** - MCP for semantic code search & navigation that reduces token waste.
+- **[Source to Knowledge Base](https://github.com/vezlo/src-to-kb)** - Convert source code repositories into searchable knowledge bases with AI-powered search using GPT-5, intelligent chunking, and OpenAI embeddings for semantic code understanding.
 - **[Specbridge](https://github.com/TBosak/specbridge)** - Easily turn your OpenAPI specs into MCP Tools.
 - **[Splunk](https://github.com/jkosik/mcp-server-splunk)** - Golang MCP server for Splunk (lists saved searches, alerts, indexes, macros...). Supports SSE and STDIO.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify.


### PR DESCRIPTION
## Summary
Adds the Source to Knowledge Base (src-to-kb) MCP server to the community servers list.

## Description
src-to-kb is an MCP server that converts source code repositories into searchable knowledge bases with:
- AI-powered search using OpenAI GPT-5
- Intelligent code chunking with configurable overlap
- OpenAI embeddings for semantic search
- Support for 20+ programming languages
- MCP tools for generating, searching, and managing knowledge bases

## Links
- GitHub: https://github.com/vezlo/src-to-kb
- npm: https://www.npmjs.com/package/@vezlo/src-to-kb
- License: AGPL-3.0

## Checklist
- [x] Added to correct alphabetical position in Community Servers section
- [x] Follows existing format and style
- [x] Repository is public and accessible
- [x] MCP server is functional and documented