### PR TITLE
Add MLflow MCP server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Mikrotik](https://github.com/jeff-nasseri/mikrotik-mcp)** - Mikrotik MCP server which cover networking operations (IP, DHCP, Firewall, etc)
 - **[Mindmap](https://github.com/YuChenSSR/mindmap-mcp-server)** (by YuChenSSR) - A server that generates mindmaps from input containing markdown code.
 - **[Minima](https://github.com/dmayboroda/minima)** - MCP server for RAG on local files
+- **[MLflow](https://github.com/kkruglik/mlflow-mcp)** - MLflow MCP server for ML experiment tracking with advanced querying, run comparison, artifact access, and model registry.
 - **[Modao Proto MCP](https://github.com/modao-dev/modao-proto-mcp)** - AI-powered HTML prototype generation server that converts natural language descriptions into complete HTML code with modern design and responsive layouts. Supports design description expansion and seamless integration with Modao workspace.
 - **[Mobile MCP](https://github.com/mobile-next/mobile-mcp)** (by Mobile Next) - MCP server for Mobile(iOS/Android) automation, app scraping and development using physical devices or simulators/emulators.
 - **[Monday.com (unofficial)](https://github.com/sakce/mcp-server-monday)** - MCP Server to interact with Monday.com boards and items.


### PR DESCRIPTION
## Description

Adding MLflow MCP server to the community servers list in README.md.

## Server Details

  - Server: MLflow (new entry)
  - Changes to: Community servers documentation section

## Motivation and Context

This adds the MLflow MCP server (https://github.com/kkruglik/mlflow-mcp) to the community servers list, making it discoverable for users who want to interact with MLflow tracking servers through natural language. The server enables querying experiments, analyzing runs, comparing metrics, and accessing the model registry.

The server is published on PyPI and can be installed via `pip install mlflow-mcp` or run directly with `uvx mlflow-mcp`.

## How Has This Been Tested?

The server has been tested with Claude Desktop. Testing included:
  - Querying experiments and runs
  - Comparing metrics across multiple runs
  - Browsing and downloading artifacts
  - Accessing the model registry
  - Tag-based run filtering and sorting

## Breaking Changes

None - this is a documentation update only.

## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

## Checklist

  - [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
  - [x] My changes follows MCP security best practices
  - [x] I have updated the server's README accordingly
  - [x] I have tested this with an LLM client
  - [x] My code follows the repository's style guidelines
  - [ ] New and existing tests pass locally (no test suite in project)
  - [x] I have added appropriate error handling
  - [x] I have documented all environment variables and configuration options