### PR TITLE
Add NetSuite MCP server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Neovim](https://github.com/bigcodegen/mcp-neovim-server)** - An MCP Server for your Neovim session.
 - **[Netbird](https://github.com/aantti/mcp-netbird)** - List and analyze Netbird network peers, groups, policies, and more.
 - **[NetMind ParsePro](https://github.com/protagolabs/Netmind-Parse-PDF-MCP)** - The PDF Parser AI service, built and customized by the [NetMind](https://www.netmind.ai/) team.
+- **[NetSuite](https://github.com/dsvantien/netsuite-mcp-server)** - MCP server for NetSuite ERP integration with OAuth 2.0 authentication, enabling natural language access to NetSuite data through SuiteQL queries, reports, saved searches, and REST API operations.
 - **[Nikto MCP](https://github.com/weldpua2008/nikto-mcp)** (by weldpua2008) - A secure MCP server that enables AI agents to interact with Nikto web server scanner](- use with npx or docker).
 - **[NocoDB](https://github.com/edwinbernadus/nocodb-mcp-server)** - Read and write access to NocoDB database.
 - **[Node Code Sandbox](https://github.com/alfonsograziano/node-code-sandbox-mcp)** – A Node.js MCP server that spins up isolated Docker - based sandboxes for executing JavaScript snippets with on-the-fly npm dependency installation


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
Adding NetSuite MCP server to the community servers list in README.md. This server provides secure OAuth 2.0 based integration with NetSuite ERP, enabling AI assistants to interact with NetSuite data through natural language queries.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
NetSuite provides an official AI Connector SuiteApp that enables AI-powered interactions with NetSuite data. However, NetSuite's AI Connector currently only supports:
  - Claude via Anthropic's web interface
  - ChatGPT via custom GPT connections

  The problem: Developers using MCP-compatible tools like Claude Code, Cursor IDE, Windsurf, or other CLI/IDE environments cannot leverage NetSuite's AI capabilities
  because there's no MCP server implementation.

  This MCP server solves that gap by:
  - Providing the missing bridge between MCP clients (Claude Code, Cursor, Gemini CLI, etc.) and NetSuite's AI Connector
  - Enabling the exact same functionality that NetSuite's AI Connector provides, but accessible through any MCP-compatible client
  - Allowing developers to interact with NetSuite data using natural language directly within their development environment
  - Maintaining the same security standards (OAuth 2.0 with PKCE) required by NetSuite's official AI Connector

  In essence, this MCP server brings NetSuite's AI capabilities to the broader MCP ecosystem, allowing developers to query business data, generate reports, and automate
  NetSuite operations without leaving their IDE or CLI.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
  The NetSuite MCP server has been tested with:
  - Claude Code, Cursor IDE, Gemini CLI, Codex, VScode, Claude Desktop: Successfully authenticated and executed SuiteQL queries, retrieved customer data, and generated financial reports
  Test scenarios included:
  - Customer search and detail retrieval
  - SuiteQL custom queries for transaction analysis
  - Running saved searches and standard NetSuite reports

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
No breaking changes. This is purely a documentation update adding a new community server entry to the README.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
  The NetSuite MCP server implements:
  - Security: OAuth 2.0 with PKCE flow (RFC 7636) - no client secrets required
  - Persistence: Automatic token refresh and session management
  - Modularity: Separate components for auth, token exchange, and NetSuite operations
  - Compatibility: Works with NetSuite's official AI Connector SuiteApp

  The server follows NetSuite's official OAuth implementation guidelines as documented in their
  https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html.

  Repository: https://github.com/dsvantien/netsuite-mcp-server
  npm: https://www.npmjs.com/package/@suiteinsider/netsuite-mcp

