### PR TITLE
Add Producer Pal to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,7 +1102,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Postman](https://github.com/shannonlal/mcp-postman)** - MCP server for running Postman Collections locally via Newman. Allows for simple execution of Postman Server and returns the results of whether the collection passed all the tests.
 - **[Powerdrill](https://github.com/powerdrillai/powerdrill-mcp)** - Interact with Powerdrill datasets, authenticated with [Powerdrill](https://powerdrill.ai) User ID and Project API Key.
 - **[Prefect](https://github.com/allen-munsch/mcp-prefect)** - MCP Server for workflow orchestration and ELT/ETL with Prefect Server, and Prefect Cloud [https://www.prefect.io/] using the `prefect` python client.
-- **[Producer Pal](https://github.com/adamjmurray/producer-pal)** - MCP server for controlling Ableton Live, emedded in a Max for Live device for easy drag and drop installation.
+- **[Producer Pal](https://github.com/adamjmurray/producer-pal)** - MCP server for controlling Ableton Live, embedded in a Max for Live device for easy drag and drop installation.
 - **[Productboard](https://github.com/kenjihikmatullah/productboard-mcp)** - Integrate the Productboard API into agentic workflows via MCP.
 - **[Prometheus](https://github.com/pab1it0/prometheus-mcp-server)** - Query and analyze Prometheus - open-source monitoring system.
 - **[Prometheus (TypeScript)](https://github.com/yanmxa/prometheus-mcp-server)** - Enable AI assistants to query Prometheus using natural language with TypeScript implementation.


### PR DESCRIPTION
## Description

## Server Details
[Producer Pal](https://github.com/adamjmurray/producer-pal#readme) is an MCP server for controlling Ableton Live with a focus on useful music production workflows. It's different from the couple Ableton MCP servers already listed because it's actively maintained and specifically designed for ease of use with little technical knowledge required - just drag and drop the Ableton plugin (a Max for Live device) into Ableton Live and you have an MCP server ready to go. Simply say "connect to Ableton" in a connected AI app and it just works.

## Motivation and Context
I recently released the 1.0.0 version. It's stable and useful and I want people to discover it.

## How Has This Been Tested?
I use it nearly every day with Claude Desktop, primarily Claude Sonnet 4.5 and a little Haiku 4.5 as well. I have tested with:
- Claude Sonnet 4.5 & Haiku 4.5 in Claude Desktop
- Claude Sonnet 4.5 in Claude Code
- Claude Sonnet 4.5 in the claude.ai webapp using a custom connector and Cloudflare tunnels
- Gemini 2.5 Pro & Flash in Gemini CLI
- OpenAI Codex CLI - various models
- OpenAI's ChatGPT 5 webapp using a custom connector and Cloudflare tunnels
- Various locally running models in LM Studio including Qwen, OpenAI's OSS GPT, and Mistral Magistral

## Checklist
I'm pretty sure most of these do not apply to a server listing:
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
