### PR TITLE
Add aws-open-data-mcp to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[AWS Athena](https://github.com/lishenxydlgzs/aws-athena-mcp)** - An MCP server for AWS Athena to run SQL queries on Glue Catalog.
 - **[AWS Cognito](https://github.com/gitCarrot/mcp-server-aws-cognito)** - An MCP server that connects to AWS Cognito for authentication and user management.
 - **[AWS Cost Explorer](https://github.com/aarora79/aws-cost-explorer-mcp-server)** - Optimize your AWS spend (including Amazon Bedrock spend) with this MCP server by examining spend across regions, services, instance types and foundation models ([demo video](https://www.youtube.com/watch?v=WuVOmYLRFmI&feature=youtu.be)).
+- **[AWS Open Data](https://github.com/domdomegg/aws-open-data-mcp)** - Search and explore datasets from the AWS Open Data Registry with fuzzy matching and detailed dataset information.
 - **[AWS Resources Operations](https://github.com/baryhuang/mcp-server-aws-resources-python)** - Run generated python code to securely query or modify any AWS resources supported by boto3.
 - **[AWS S3](https://github.com/aws-samples/sample-mcp-server-s3)** - A sample MCP server for AWS S3 that flexibly fetches objects from S3 such as PDF documents.
 - **[AWS SES](https://github.com/aws-samples/sample-for-amazon-ses-mcp)** Sample MCP Server for Amazon SES (SESv2). See [AWS blog post](https://aws.amazon.com/blogs/messaging - and-targeting/use-ai-agents-and-the-model-context-protocol-with-amazon-ses/) for more details.


### PR DESCRIPTION
## Summary
- Adds [aws-open-data-mcp](https://github.com/domdomegg/aws-open-data-mcp) to the community servers section
- Entry placed in alphabetical order between AWS Cost Explorer and AWS Resources Operations
- Provides search and exploration capabilities for AWS Open Data Registry datasets with fuzzy matching