### PR TITLE
Add MCP Toolz to third-party servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,7 +972,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[MCPfinder](https://github.com/mcpfinder/server)** - The AI Agent's "App Store": Discover, install, and monetize AI capabilities — all within the MCP ecosystem.
 - **[MCPIgnore Filesytem](https://github.com/CyberhavenInc/filesystem-mcpignore)** - A Data Security First filesystem MCP server that implements .mcpignore to prevent MCP clients from accessing sensitive data.
 - **[MCPJungle](https://github.com/mcpjungle/MCPJungle)** - Self-hosted MCP Registry and Gateway for enterprise AI Agents
-- **[MCP Toolz](https://github.com/taylorleese/mcp-toolz)** - Context management, todo persistence, and AI second opinions for Claude Code. Share contexts across sessions and get feedback from ChatGPT, Claude, Gemini, and DeepSeek.
+- **[MCP Toolz](https://github.com/taylorleese/mcp-toolz)** - Context management, todo persistence, and AI second opinions for Claude Code. Save and restore contexts, code snippets, and todo lists across sessions and get feedback from ChatGPT, Claude, Gemini, and DeepSeek.
 - **[Md2doc](https://github.com/Yorick-Ryu/md2doc-mcp)** - Convert Markdown text to DOCX format using an external conversion service
 - **[MeasureSpace MCP](https://github.com/MeasureSpace/measure-space-mcp-server)** - A free [Model Context Protocol (MCP) Server](https://smithery.ai/server/@MeasureSpace/measure-space-mcp-server) that provides global weather, climate, air quality forecast and geocoding services by [measurespace.io](https://measurespace.io).
 - **[MediaWiki](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server)** - A Model Context Protocol (MCP) Server that interacts with any MediaWiki wiki


### PR DESCRIPTION
## Summary

This PR adds **MCP Toolz** to the list of third-party MCP servers.

## Server Details

- **Name:** MCP Toolz
- **Repository:** https://github.com/taylorleese/mcp-toolz
- **PyPI Package:** https://pypi.org/project/mcp-toolz/
- **Version:** 0.3.8
- **Description:** Save contexts and todos across Claude Code sessions, get feedback from ChatGPT, Claude, Gemini, and DeepSeek.

## Features

- **Context Management:** Save and retrieve conversation contexts, code snippets, suggestions, and errors
- **Todo Persistence:** Create snapshots of todo lists that persist across sessions
- **AI Feedback:** Get feedback from ChatGPT (OpenAI), Claude (Anthropic), Gemini (Google), and DeepSeek on saved contexts
- **MCP Resources:** Access recent contexts and active todos via MCP resources
- **Session Continuity:** Restore work from previous sessions seamlessly
- **Project Organization:** Contexts and todos automatically organized by project directory
- **Full-Text Search:** Find anything by content, tags, project, or session

## Installation

The server is available on PyPI and can be installed via pip:

```bash
pip install mcp-toolz
```

## Documentation

Full documentation available at: https://github.com/taylorleese/mcp-toolz#readme

## Checklist

- [x] Added server in alphabetical order
- [x] Server is published on PyPI
- [x] Server follows MCP protocol specifications
- [x] Repository includes README with usage instructions

---

**Part of [taylorleese/mcp-toolz#11](https://github.com/taylorleese/mcp-toolz/issues/11)** - Publishing MCP Toolz to official registries and community directories.

**Related PRs:**
- https://github.com/modelcontextprotocol/servers/pull/2900 - Official MCP third-party servers list
- https://github.com/docker/mcp-registry/pull/353 - Docker MCP registry  
- https://github.com/punkpeye/awesome-mcp-servers/pull/1444 - Awesome MCP Servers community list
