### PR TITLE
fix(filesystem): exclude test files from build (#2928)

### DIFF
--- a/src/filesystem/tsconfig.json
+++ b/src/filesystem/tsconfig.json
@@ -8,5 +8,10 @@
   },
   "include": [
     "./**/*.ts"
+  ],
+  "exclude": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
  Fixes test file compilation in Docker builds by excluding test directories from tsconfig.

  ## Description

  Test files were being compiled into dist/ during build, causing TypeScript errors in Docker environments. Added exclude pattern to skip test files.

  ## Server Details
  - Server: filesystem
  - Changes to: build configuration (tsconfig.json)

  ## Motivation and Context

  `npm install` triggers `prepare` script which runs `tsc`. TypeScript tried to compile test files that use vitest globals, causing:
  error TS2304: Cannot find name 'afterEach'

  ## How Has This Been Tested?

  - Local build and all tests pass
  - Docker build completes successfully
  - Verified dist/ no longer contains __tests__/

  ## Breaking Changes

  None

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Checklist
  - [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
  - [x] My changes follows MCP security best practices
  - [ ] I have updated the server's README accordingly
  - [ ] I have tested this with an LLM client
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [ ] I have added appropriate error handling
  - [ ] I have documented all environment variables and configuration options

  ## Additional context

  Added to tsconfig.json:
  ```json
  "exclude": [
    "**/__tests__/**",
    "**/*.test.ts",
    "**/*.spec.ts"
  ]
```
  Fixes #2928