### PR TITLE
Add Local RAG to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,6 +937,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[lldb-mcp](https://github.com/stass/lldb-mcp)** - A Model Context Protocol server for LLDB that provides LLM-driven debugging.
 - **[llm-context](https://github.com/cyberchitta/llm-context.py)** - Provides a repo-packing MCP tool with configurable profiles that specify file inclusion/exclusion patterns and optional prompts.
 - **[Local History](https://github.com/xxczaki/local-history-mcp)** – MCP server for accessing VS Code/Cursor's Local History.
+- **[Local RAG](https://github.com/shinpr/mcp-local-rag)** - Lightweight local document search with minimal setup. Search across PDF, DOCX, TXT, and Markdown files - no Docker, no external services required.
 - **[Locust](https://github.com/QAInsights/locust-mcp-server)** - Allows running and analyzing Locust tests using MCP compatible clients.
 - **[Loki](https://github.com/scottlepp/loki-mcp)** - Golang based MCP Server to query logs from [Grafana Loki](https://github.com/grafana/loki).
 - **[Loki MCP Server](https://github.com/mo-silent/loki-mcp-server)** - Python based MCP Server for querying and analyzing logs from Grafana Loki with advanced filtering and authentication support.


### PR DESCRIPTION
## Description

  This PR adds [Local RAG](https://github.com/shinpr/mcp-local-rag) to the community servers list.

  ## About Local RAG

  A lightweight, privacy-first document search server that runs entirely on your machine using Transformers.js and LanceDB.

  ### Key Features:
  - **Lightweight setup** - No Docker, Ollama, or external services required
  - **Document support** - PDF, DOCX, TXT, and Markdown files
  - **Local processing** - All embeddings generated on-device using Transformers.js
  - **Simple installation** - `npm install -g mcp-local-rag` and start searching

  ### Links:
  - **GitHub**: https://github.com/shinpr/mcp-local-rag
  - **npm**: https://www.npmjs.com/package/mcp-local-rag

  ### Testing:
Tested with Claude Code - document ingestion and semantic search working correctly for Japanese and English content.

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  - [x] Server link added in alphabetical order (between "Local History" and "Locust")
  - [x] Entry follows the existing format
  - [x] Server is published and publicly accessible
  - [x] Server has comprehensive documentation