### PR TITLE
Add git_push tool to Git MCP server

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -94,6 +94,16 @@ Please note that mcp-server-git is currently in early development. The functiona
      - `not_contains` (string, optional): The commit sha that branch should NOT contain. Do not pass anything to this param if no commit sha is specified
    - Returns: List of branches
 
+13. `git_push`
+   - Pushes changes to a remote repository
+   - Inputs:
+     - `repo_path` (string): Path to the Git repository
+     - `remote` (string, optional): The remote repository to push to (default: 'origin')
+     - `branch` (string, optional): The branch to push. If not specified, pushes the current branch
+     - `force` (boolean, optional): Force push the branch, overwriting remote history if necessary (default: false)
+     - `set_upstream` (boolean, optional): Set the upstream branch when pushing (git push -u) (default: false)
+   - Returns: Confirmation of push operation with output details
+
 ## Installation
 
 ### Using uv (recommended)

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 import git
-from mcp_server_git.server import git_checkout, git_branch, git_add
+from mcp_server_git.server import git_checkout, git_branch, git_add, git_push
 import shutil
 
 @pytest.fixture
@@ -91,3 +91,7 @@ def test_git_add_specific_files(test_repository):
     assert "file1.txt" in staged_files
     assert "file2.txt" not in staged_files
     assert result == "Files staged successfully"
+
+def test_git_push_no_remote(test_repository):
+    result = git_push(test_repository)
+    assert "Error pushing to origin" in result


### PR DESCRIPTION
- Implement git_push function with support for:
  - Pushing to custom remotes (default: origin)
  - Pushing specific branches
  - Force push capability
  - Setting upstream branch (-u flag)
- Add GitPush model with comprehensive field descriptions
- Register git_push as a new tool in the MCP server
- Add test coverage for push functionality
- Update README with git_push tool documentation
Resolves #618

## Description

This PR implements the `git_push` tool for the Git MCP server, enabling users to push branches to remote repositories. This addresses issue #618 where users need the ability to push branches remotely to support integration with other MCPs that create pull requests.

## Server Details

- Server: git
- Changes to: tools, README documentation

## Motivation and Context

Users working with multiple MCPs need the ability to push branches to remote repositories before creating pull requests through other tools. The Git MCP server previously lacked this functionality, limiting its utility in CI/CD and automation workflows. This feature enables seamless integration with other MCPs that depend on remote branch existence.

## How Has This Been Tested?

- Added `test_git_push_no_remote()` unit test to verify error handling when pushing to a non-existent remote
- Verified syntax and imports compile correctly with Python 3.10
- Tested with actual GitPython library to ensure proper argument composition

## Breaking Changes

No breaking changes. This is a new tool addition that does not affect existing functionality.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with unit tests
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all parameters and configuration options

## Additional context

The implementation uses GitPython's `repo.git.push()` method with dynamic argument construction to support:
- Optional branch specification (defaults to current branch)
- Custom remote targets (defaults to 'origin')
- Force push for overwriting remote history
- Upstream tracking with the `-u` flag

All parameters are optional with sensible defaults, making the tool flexible for various use cases.

---

**Built with [Zencoder](https://zencoder.ai)**
