### PR TITLE
Add comprehensive tests for git server functions

### DIFF
--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -1,7 +1,20 @@
 import pytest
 from pathlib import Path
 import git
-from mcp_server_git.server import git_checkout, git_branch, git_add, git_status
+from mcp_server_git.server import (
+    git_checkout,
+    git_branch,
+    git_add,
+    git_status,
+    git_diff_unstaged,
+    git_diff_staged,
+    git_diff,
+    git_commit,
+    git_reset,
+    git_log,
+    git_create_branch,
+    git_show
+)
 import shutil
 
 @pytest.fixture
@@ -35,8 +48,6 @@ def test_git_branch_local(test_repository):
     assert "new-branch-local" in result
 
 def test_git_branch_remote(test_repository):
-    # GitPython does not easily support creating remote branches without a remote.
-    # This test will check the behavior when 'remote' is specified without actual remotes.
     result = git_branch(test_repository, "remote")
     assert "" == result.strip()  # Should be empty if no remote branches
 
@@ -97,3 +108,137 @@ def test_git_status(test_repository):
 
     assert result is not None
     assert "On branch" in result or "branch" in result.lower()
+
+def test_git_diff_unstaged(test_repository):
+    file_path = Path(test_repository.working_dir) / "test.txt"
+    file_path.write_text("modified content")
+
+    result = git_diff_unstaged(test_repository)
+
+    assert "test.txt" in result
+    assert "modified content" in result
+
+def test_git_diff_unstaged_empty(test_repository):
+    result = git_diff_unstaged(test_repository)
+
+    assert result == ""
+
+def test_git_diff_staged(test_repository):
+    file_path = Path(test_repository.working_dir) / "staged_file.txt"
+    file_path.write_text("staged content")
+    test_repository.index.add(["staged_file.txt"])
+
+    result = git_diff_staged(test_repository)
+
+    assert "staged_file.txt" in result
+    assert "staged content" in result
+
+def test_git_diff_staged_empty(test_repository):
+    result = git_diff_staged(test_repository)
+
+    assert result == ""
+
+def test_git_diff(test_repository):
+    test_repository.git.checkout("-b", "feature-diff")
+    file_path = Path(test_repository.working_dir) / "test.txt"
+    file_path.write_text("feature changes")
+    test_repository.index.add(["test.txt"])
+    test_repository.index.commit("feature commit")
+
+    result = git_diff(test_repository, "master")
+
+    assert "test.txt" in result
+    assert "feature changes" in result
+
+def test_git_commit(test_repository):
+    file_path = Path(test_repository.working_dir) / "commit_test.txt"
+    file_path.write_text("content to commit")
+    test_repository.index.add(["commit_test.txt"])
+
+    result = git_commit(test_repository, "test commit message")
+
+    assert "Changes committed successfully with hash" in result
+
+    latest_commit = test_repository.head.commit
+    assert latest_commit.message.strip() == "test commit message"
+
+def test_git_reset(test_repository):
+    file_path = Path(test_repository.working_dir) / "reset_test.txt"
+    file_path.write_text("content to reset")
+    test_repository.index.add(["reset_test.txt"])
+
+    staged_before = [item.a_path for item in test_repository.index.diff("HEAD")]
+    assert "reset_test.txt" in staged_before
+
+    result = git_reset(test_repository)
+
+    assert result == "All staged changes reset"
+
+    staged_after = [item.a_path for item in test_repository.index.diff("HEAD")]
+    assert "reset_test.txt" not in staged_after
+
+def test_git_log(test_repository):
+    for i in range(3):
+        file_path = Path(test_repository.working_dir) / f"log_test_{i}.txt"
+        file_path.write_text(f"content {i}")
+        test_repository.index.add([f"log_test_{i}.txt"])
+        test_repository.index.commit(f"commit {i}")
+
+    result = git_log(test_repository, max_count=2)
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert "Commit:" in result[0]
+    assert "Author:" in result[0]
+    assert "Date:" in result[0]
+    assert "Message:" in result[0]
+
+def test_git_log_default(test_repository):
+    result = git_log(test_repository)
+
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert "initial commit" in result[0]
+
+def test_git_create_branch(test_repository):
+    result = git_create_branch(test_repository, "new-feature-branch")
+
+    assert "Created branch 'new-feature-branch'" in result
+
+    branches = [ref.name for ref in test_repository.references]
+    assert "new-feature-branch" in branches
+
+def test_git_create_branch_from_base(test_repository):
+    test_repository.git.checkout("-b", "base-branch")
+    file_path = Path(test_repository.working_dir) / "base.txt"
+    file_path.write_text("base content")
+    test_repository.index.add(["base.txt"])
+    test_repository.index.commit("base commit")
+
+    result = git_create_branch(test_repository, "derived-branch", "base-branch")
+
+    assert "Created branch 'derived-branch' from 'base-branch'" in result
+
+def test_git_show(test_repository):
+    file_path = Path(test_repository.working_dir) / "show_test.txt"
+    file_path.write_text("show content")
+    test_repository.index.add(["show_test.txt"])
+    test_repository.index.commit("show test commit")
+
+    commit_sha = test_repository.head.commit.hexsha
+
+    result = git_show(test_repository, commit_sha)
+
+    assert "Commit:" in result
+    assert "Author:" in result
+    assert "show test commit" in result
+    assert "show_test.txt" in result
+
+def test_git_show_initial_commit(test_repository):
+    initial_commit = list(test_repository.iter_commits())[-1]
+
+    result = git_show(test_repository, initial_commit.hexsha)
+
+    assert "Commit:" in result
+    assert "initial commit" in result
+    assert "test.txt" in result


### PR DESCRIPTION
## Summary
Adds comprehensive test coverage for 8 previously untested git server functions.

## Changes
- ✅ Added 13 new tests covering all untested functions
- ✅ Achieved 100% function coverage (12/12)
- ✅ Total: 23 tests, all passing
- ✅ Removed unnecessary comments

## Tests Added
- `git_diff_unstaged` (2 tests)
- `git_diff_staged` (2 tests)  
- `git_diff` (1 test)
- `git_commit` (1 test)
- `git_reset` (1 test)
- `git_log` (2 tests)
- `git_create_branch` (2 tests)
- `git_show` (2 tests)

## Testing
cd src/git
uv run pytest tests/ -v


Same pattern as PR #2959