### PR TITLE
Fix git_create_branch parameter documentation

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -70,7 +70,7 @@ Please note that mcp-server-git is currently in early development. The functiona
    - Inputs:
      - `repo_path` (string): Path to Git repository
      - `branch_name` (string): Name of the new branch
-     - `start_point` (string, optional): Starting point for the new branch
+     - `base_branch` (string, optional): Base branch to create from (defaults to current branch)
    - Returns: Confirmation of branch creation
 10. `git_checkout`
    - Switches branches


### PR DESCRIPTION
**Summary**
Fixed incorrect parameter name in `git_create_branch` documentation.

**Change**
- Line 73: `start_point` → `base_branch`

**Why**
The documented `start_point` parameter doesn't exist in the code.
The actual parameter is `base_branch` (verified in server.py lines 63, 172, 417).

**Impact**
Users can now use the correct parameter name that matches the implementation.