### PR TITLE
Add Runbear MCP client to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1455,7 +1455,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[MCP CLI Client](https://github.com/vincent-pli/mcp-cli-host)** - A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP).
 * **[OpenMCP Client](https://github.com/LSTM-Kirigaya/openmcp-client/)** - An all-in-one vscode/trae/cursor plugin for MCP server debugging. [Document](https://kirigaya.cn/openmcp/) & [OpenMCP SDK](https://kirigaya.cn/openmcp/sdk-tutorial/).
 * **[PHP MCP Client](https://github.com/php-mcp/client)** - Core PHP implementation for the Model Context Protocol (MCP) Client
-
+* **[Runbear](https://runbear.io/solutions/integrations/slack/mcp)** - No-code MCP client for team chat platforms, such as Slack, Microsoft Teams, and Discord.
 
 ## 📚 Resources
 


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Add Runbear MCP client that enables connecting MCP servers to team chat platforms like Slack, Teams, and HubSpot.

## Motivation and Context

Connecting MCP servers to everyday tools like Slack should be much easier. I'd love to guide the easiest way to introduce MCP servers to colleauges living in Slack.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
I've tested it by myself. I confirmed that it works with MCP servers across SSE, Streamable HTTP, OAuth, and API key.

## Breaking Changes

No breaking changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

