### PR TITLE
fix(sequential-thinking): Keep case of json params and description same

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -44,14 +44,14 @@ Parameters explained:
 * Changes in approach
 * Hypothesis generation
 * Hypothesis verification
-- next_thought_needed: True if you need more thinking, even if at what seemed like the end
-- thought_number: Current number in sequence (can go beyond initial total if needed)
-- total_thoughts: Current estimate of thoughts needed (can be adjusted up/down)
-- is_revision: A boolean indicating if this thought revises previous thinking
-- revises_thought: If is_revision is true, which thought number is being reconsidered
-- branch_from_thought: If branching, which thought number is the branching point
-- branch_id: Identifier for the current branch (if any)
-- needs_more_thoughts: If reaching end but realizing more thoughts needed
+- nextThoughtNeeded: True if you need more thinking, even if at what seemed like the end
+- thoughtNumber: Current number in sequence (can go beyond initial total if needed)
+- totalThoughts: Current estimate of thoughts needed (can be adjusted up/down)
+- isRevision: A boolean indicating if this thought revises previous thinking
+- revisesThought: If is_revision is true, which thought number is being reconsidered
+- branchFromThought: If branching, which thought number is the branching point
+- branchId: Identifier for the current branch (if any)
+- needsMoreThoughts: If reaching end but realizing more thoughts needed
 
 You should:
 1. Start with an initial estimate of needed thoughts, but be ready to adjust


### PR DESCRIPTION
Models are confused about the case of the variables, which results into random validation errors. Keeping them the same helps to remove back and forth.
## Description

## Server Details
- Server: sequential-thinking
- Changes to: prompts

## Motivation and Context
At random model may choose to pass either camel or snake_case names of keys in the request. Seems that model is confused, as required and 

## How Has This Been Tested?
I've reproduced this problem in Claude Code (Sonnet 4.5) and Copilot CLI (Sonnet 4.5, GPT-5).

## Breaking Changes
Don't think it is a breaking change. If some clients did not have issues, most probably they will be even better with it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options
