### PR TITLE
fix(ci): test failures should fail the build

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -41,21 +41,9 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: npm ci
 
-      - name: Check if tests exist
-        id: check-tests
-        working-directory: src/${{ matrix.package }}
-        run: |
-          if npm run test --silent 2>/dev/null; then
-            echo "has-tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "has-tests=false" >> $GITHUB_OUTPUT
-          fi
-        continue-on-error: true
-
       - name: Run tests
-        if: steps.check-tests.outputs.has-tests == 'true'
         working-directory: src/${{ matrix.package }}
-        run: npm test
+        run: npm test --if-present
 
   build:
     needs: [detect-packages, test]


### PR DESCRIPTION
## Problem

The CI was showing green even when tests were failing. This happened because the 'Check if tests exist' step was actually **running** the tests with `continue-on-error: true`. When tests failed, it would:

1. Set `has-tests=false` (because the test command failed)
2. Continue without error
3. Skip the "Run tests" step

### Example

In PR #3014, the sequentialthinking tests [were failing](https://github.com/modelcontextprotocol/servers/actions/runs/19435074060/job/55603696529) (10 failed, 14 passed), but:
- The "Check if tests exist" step showed ✅ green (due to `continue-on-error: true`)
- The actual "Run tests" step was skipped (because has-tests=false)
- The overall CI check passed ✅

This meant PRs with failing tests could be merged.

## Solution

Simplified to use `npm test --if-present` which:
- Runs tests if a test script exists (and **fails the build if tests fail**)
- Does nothing and exits 0 if no test script exists
- Removes the need for the complex check-then-run logic

The entire "Check if tests exist" step has been removed.

## Testing

Only one package (`everything`) doesn't have tests, and `npm test --if-present` handles it correctly. Test failures will now properly fail the CI build.