### PR TITLE
Add mcpName and repository fields for MCP registry

### DIFF
--- a/src/everything/package.json
+++ b/src/everything/package.json
@@ -3,9 +3,14 @@
   "version": "0.6.2",
   "description": "MCP server that exercises all the features of the MCP protocol",
   "license": "MIT",
+  "mcpName": "io.github.modelcontextprotocol/server-everything",
   "author": "Anthropic, PBC (https://anthropic.com)",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/servers.git"
+  },
   "type": "module",
   "bin": {
     "mcp-server-everything": "dist/index.js"

--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -1,5 +1,7 @@
 # Fetch MCP Server
 
+<!-- mcp-name: io.github.modelcontextprotocol/server-fetch -->
+
 A Model Context Protocol server that provides web content fetching capabilities. This server enables LLMs to retrieve and process content from web pages, converting HTML to markdown for easier consumption.
 
 > [!CAUTION]

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -3,9 +3,14 @@
   "version": "0.6.3",
   "description": "MCP server for filesystem access",
   "license": "MIT",
+  "mcpName": "io.github.modelcontextprotocol/server-filesystem",
   "author": "Anthropic, PBC (https://anthropic.com)",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/servers.git"
+  },
   "type": "module",
   "bin": {
     "mcp-server-filesystem": "dist/index.js"

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -1,5 +1,7 @@
 # mcp-server-git: A git MCP server
 
+<!-- mcp-name: io.github.modelcontextprotocol/server-git -->
+
 ## Overview
 
 A Model Context Protocol server for Git repository interaction and automation. This server provides tools to read, search, and manipulate Git repositories via Large Language Models.

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -3,9 +3,14 @@
   "version": "0.6.3",
   "description": "MCP server for enabling memory for Claude through a knowledge graph",
   "license": "MIT",
+  "mcpName": "io.github.modelcontextprotocol/server-memory",
   "author": "Anthropic, PBC (https://anthropic.com)",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/servers.git"
+  },
   "type": "module",
   "bin": {
     "mcp-server-memory": "dist/index.js"

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -3,9 +3,14 @@
   "version": "0.6.2",
   "description": "MCP server for sequential thinking and problem solving",
   "license": "MIT",
+  "mcpName": "io.github.modelcontextprotocol/server-sequential-thinking",
   "author": "Anthropic, PBC (https://anthropic.com)",
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modelcontextprotocol/servers.git"
+  },
   "type": "module",
   "bin": {
     "mcp-server-sequential-thinking": "dist/index.js"

--- a/src/time/README.md
+++ b/src/time/README.md
@@ -1,5 +1,7 @@
 # Time MCP Server
 
+<!-- mcp-name: io.github.modelcontextprotocol/server-time -->
+
 A Model Context Protocol server that provides time and timezone conversion capabilities. This server enables LLMs to get current time information and perform timezone conversions using IANA timezone names, with automatic system timezone detection.
 
 ### Available Tools


### PR DESCRIPTION
Adds metadata required for registering servers in the MCP registry:

- NPM servers (everything, filesystem, memory, sequentialthinking): Added `mcpName` and `repository` fields to package.json
- PyPI servers (fetch, git, time): Added `mcp-name` comment to README.md

Related to #3047