### PR TITLE
fix: add dependabot.yml to fix npm workspaces issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+updates:
+  # npm workspaces monorepo - manage from root only
+  # See: https://github.com/dependabot/dependabot-core/issues/6346
+  # Dependabot has issues updating package-lock.json when configured
+  # for individual workspace directories. Using root directory ensures
+  # consistent lockfile updates across all workspaces.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Use 'increase' strategy to ensure both package.json and package-lock.json
+    # are updated consistently
+    versioning-strategy: increase
+    groups:
+      # Group version updates (minor/patch only for safety)
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Explicitly configure security updates grouping
+      # This ensures security updates are handled from the root directory
+      # to avoid npm workspace hoisting issues when different workspaces
+      # need different major versions of the same package
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Python packages
+  - package-ecosystem: "pip"
+    directory: "/src/fetch"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/src/git"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/src/time"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds dependabot configuration to address npm workspace lockfile issues that caused PR #3021 to fail.

## Problem

PR #3021 (Dependabot security update for glob) failed with:
```
npm error Invalid: lock file's glob@11.1.0 does not satisfy glob@12.0.0
```

Root cause: Dependabot tried to update `glob` to different major versions across workspace directories (11.1.0 for transitive deps, 12.0.0 for filesystem's direct dep), creating an inconsistent `package-lock.json`.

This is a known Dependabot limitation with npm workspaces:
- https://github.com/dependabot/dependabot-core/issues/6346
- https://github.com/dependabot/dependabot-core/issues/7157

## Solution

Add `dependabot.yml` that:
- Manages npm from root directory only (workspaces handled as a unit)
- Uses `versioning-strategy: increase` for consistent lockfile updates
- Configures security update grouping via `applies-to: security-updates`

Also adds config for Python packages and GitHub Actions.