### PR TITLE
add streamable http transport support to memory and sequentialthinking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1865,7 +1865,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3459,7 +3458,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3568,7 +3566,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -3763,7 +3760,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -182,6 +182,31 @@ The server can be configured using the following environment variables:
 
 - `MEMORY_FILE_PATH`: Path to the memory storage JSONL file (default: `memory.jsonl` in the server directory)
 
+#### HTTP Transport
+
+To run the server with HTTP transport instead of stdio:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "http",
+        "PORT": "3000"
+      }
+    }
+  }
+}
+```
+
+- `MCP_TRANSPORT`: Set to `http` to use HTTP transport (default: stdio)
+- `PORT`: HTTP port number (default: 3000)
+
 # VS Code Installation Instructions
 
 For quick installation, use one of the one-click installation buttons below:

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -547,7 +547,8 @@ async function main() {
               } else if (!sessionId) {
                 transport = new StreamableHTTPServerTransport({
                   sessionIdGenerator: () => crypto.randomUUID(),
-                  onsessioninitialized: (sid) => {
+                  onsessioninitialized: async (sid) => {
+                    await server.connect(transport);
                     transports[sid] = transport;
                     resetSessionTimer(sid);
                     console.error('Session initialized:', sid);
@@ -556,7 +557,6 @@ async function main() {
                     cleanupSession(sid);
                   }
                 });
-                await server.connect(transport);
               } else {
                 res.writeHead(400);
                 res.end('Invalid session ID');

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -78,6 +78,32 @@ Add this to your `claude_desktop_config.json`:
 ```
 
 To disable logging of thought information set env var: `DISABLE_THOUGHT_LOGGING` to `true`.
+
+#### HTTP Transport
+
+To run the server with HTTP transport instead of stdio:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "http",
+        "PORT": "3000"
+      }
+    }
+  }
+}
+```
+
+- `MCP_TRANSPORT`: Set to `http` to use HTTP transport (default: stdio)
+- `PORT`: HTTP port number (default: 3000)
+
 Comment
 
 ### Usage with VS Code

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -2,6 +2,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 import { SequentialThinkingServer } from './lib.js';
 
@@ -107,9 +108,72 @@ You should:
 );
 
 async function runServer() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("Sequential Thinking MCP Server running on stdio");
+  if (process.env.MCP_TRANSPORT === 'http') {
+    const { createServer } = await import('http');
+    const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+    const httpServer = createServer(async (req, res) => {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      if (req.method === 'POST') {
+        let body = '';
+        req.on('data', chunk => body += chunk);
+        req.on('end', async () => {
+          const parsedBody = body.trim() ? JSON.parse(body) : undefined;
+
+          let transport: StreamableHTTPServerTransport;
+          if (sessionId && transports[sessionId]) {
+            transport = transports[sessionId];
+          } else if (!sessionId) {
+            transport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => crypto.randomUUID(),
+              onsessioninitialized: (sid) => {
+                transports[sid] = transport;
+                console.error('Session initialized:', sid);
+              },
+              onsessionclosed: (sid) => {
+                delete transports[sid];
+                console.error('Session closed:', sid);
+              }
+            });
+            await server.connect(transport);
+          } else {
+            res.writeHead(400);
+            res.end('Invalid session ID');
+            return;
+          }
+
+          await transport.handleRequest(req, res, parsedBody);
+        });
+      } else if (req.method === 'GET') {
+        if (!sessionId || !transports[sessionId]) {
+          res.writeHead(400);
+          res.end('Invalid or missing session ID');
+          return;
+        }
+        await transports[sessionId].handleRequest(req, res);
+      } else if (req.method === 'DELETE') {
+        if (!sessionId || !transports[sessionId]) {
+          res.writeHead(400);
+          res.end('Invalid or missing session ID');
+          return;
+        }
+        await transports[sessionId].handleRequest(req, res);
+      } else {
+        res.writeHead(405);
+        res.end('Method not allowed');
+      }
+    });
+
+    const port = parseInt(process.env.PORT || '3000');
+    httpServer.listen(port, () => {
+      console.error(`Sequential Thinking MCP Server running on HTTP port ${port}`);
+    });
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error("Sequential Thinking MCP Server running on stdio");
+  }
 }
 
 runServer().catch((error) => {


### PR DESCRIPTION
## Description

Add streamable HTTP transport support to memory and sequential thinking MCP servers, enabling them to run over HTTP in addition to the default stdio transport.

## Server Details

- Servers: memory, sequential-thinking
- Changes to: transport layer (added HTTP support alongside stdio)

## Motivation and Context

This change enables these servers to be used in environments where HTTP transport is preferred or required over stdio, such as web-based clients or containerized deployments. The implementation maintains backward compatibility by defaulting to stdio transport.

## How Has This Been Tested?

- Tested stdio transport (default behavior) remains unchanged
- Tested HTTP transport with `MCP_TRANSPORT=http` environment variable
- Verified session management (initialization, message handling, cleanup)
- Confirmed both POST/GET/DELETE request handling works correctly

## Breaking Changes

No breaking changes. This is fully backward compatible:
- Default behavior (stdio) is unchanged
- HTTP transport is opt-in via `MCP_TRANSPORT=http` environment variable

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

Implementation follows the pattern from the Immich MCP server PR. Key features:
- Uses `@modelcontextprotocol/sdk` v1.23.0 StreamableHTTPServerTransport
- Session management with UUID-based session IDs
- Supports POST (send), GET (receive), DELETE (close) HTTP methods
- Environment variables:
  - `MCP_TRANSPORT=http` - enables HTTP transport (default: stdio)
  - `PORT` - HTTP port number (default: 3000)
