### PR TITLE
Add Kolada MCP Server - Swedish municipality statistics

### DIFF
--- a/src/servers/io.github.isakskogstad/kolada-mcp.json
+++ b/src/servers/io.github.isakskogstad/kolada-mcp.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.isakskogstad/kolada-mcp",
+  "title": "Kolada MCP Server",
+  "description": "Swedish municipality statistics from Kolada API. 6000+ KPIs for all 290 municipalities.",
+  "version": "2.2.1",
+  "websiteUrl": "https://github.com/isakskogstad/kolada-mcp",
+  "repository": {
+    "url": "https://github.com/isakskogstad/kolada-mcp",
+    "source": "github"
+  },
+  "icons": [
+    {
+      "src": "https://github.com/user-attachments/assets/9dd18a33-0f97-4490-af45-5b5a32dc15d0",
+      "mimeType": "image/png"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "kolada-mcp-server",
+      "version": "2.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "node"
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://kolada-mcp-pafn.onrender.com/mcp"
+    },
+    {
+      "type": "sse",
+      "url": "https://kolada-mcp-pafn.onrender.com/sse"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the Kolada MCP Server to the official MCP Registry.

**Kolada MCP Server** provides LLMs and AI assistants access to comprehensive Swedish municipality and regional statistics from the Kolada API.

## Server Details

- **Name:** io.github.isakskogstad/kolada-mcp
- **Version:** 2.2.1
- **NPM Package:** kolada-mcp-server
- **Remote Server:** https://kolada-mcp-pafn.onrender.com/mcp
- **Repository:** https://github.com/isakskogstad/kolada-mcp

## Features

- **6000+ KPIs** covering 264 operating areas
- **290 municipalities + 21 regions** across Sweden
- **Dual transport:** stdio (NPM) and remote (HTTP/SSE)
- **Intelligent caching:** 24-hour TTL for metadata
- **Rate limiting:** Respects Kolada API limits
- **Swedish-first:** Optimized for Swedish AI assistants

## Operating Areas (sample)

- Municipality overview (553 KPIs)
- Primary school grades 0-9 (470 KPIs)
- Upper secondary school (215 KPIs)
- Healthcare (204 KPIs)
- Population statistics (199 KPIs)
- Preschool education (135 KPIs)

## Example Use Cases

- "How large is the population in Stockholm?" → 988,943 (2023)
- "Which municipalities have the largest population?"
- "Compare education costs in Gothenburg and Malmö"
- "Show trend for elderly care costs in Uppsala over the last 5 years"

## Validation

✅ All validations passed:
- Schema validation (MCP 2025-10-17)
- Version consistency (package.json ↔ server.json)
- NPM package published and accessible
- Remote endpoints healthy and operational

## Testing

The server has been tested with:
- Claude Desktop (stdio)
- Claude Web (remote HTTP)
- Claude Code CLI (SSE)

## Documentation

Complete documentation available at:
- README: https://github.com/isakskogstad/kolada-mcp#readme
- API Docs: https://api.kolada.se/v3/docs

## Source Attribution

Data source: [Kolada](https://www.kolada.se/) - managed by SKR (Swedish Association of Local Authorities and Regions). This is an independent project with no official affiliation.

## License

MIT License