### PR TITLE
Fix: Changed structuredContent output to match outputSchema

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -500,7 +500,7 @@ server.registerTool(
     const contentBlock = { type: "text" as const, text };
     return {
       content: [contentBlock],
-      structuredContent: { content: [contentBlock] }
+      structuredContent: { content: text }
     };
   }
 );
@@ -570,7 +570,7 @@ server.registerTool(
     const contentBlock = { type: "text" as const, text };
     return {
       content: [contentBlock],
-      structuredContent: { content: [contentBlock] }
+      structuredContent: { content: text }
     };
   }
 );
@@ -599,7 +599,7 @@ server.registerTool(
     const contentBlock = { type: "text" as const, text };
     return {
       content: [contentBlock],
-      structuredContent: { content: [contentBlock] }
+      structuredContent: { content: text }
     };
   }
 );


### PR DESCRIPTION
## Description
The tools "list_directory_with_sizes", "directory_tree" and "move_file" did not output content as specified by their output schema. This results in errors like:

```
MCP error -32602: Output validation error: Invalid structured content for tool directory_tree: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "array",
    "path": [
      "content"
    ],
    "message": "Expected string, received array"
  }
]
```

The output has been changed to match the output schema for these tools.

## Server Details
- Server: filesystem
- Changes to: tools

## Motivation and Context
See description.

## How Has This Been Tested?
This has been tested locally against the `@modelcontextprotocol/inspector`.

## Breaking Changes
N.a.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
N.a.
