### PR TITLE
Fix test_git_diff to use dynamic branch name

### DIFF
--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -143,13 +143,15 @@ def test_git_diff_staged_empty(test_repository):
     assert result == ""
 
 def test_git_diff(test_repository):
+    # Get the default branch name (could be "main" or "master")
+    default_branch = test_repository.active_branch.name
     test_repository.git.checkout("-b", "feature-diff")
     file_path = Path(test_repository.working_dir) / "test.txt"
     file_path.write_text("feature changes")
     test_repository.index.add(["test.txt"])
     test_repository.index.commit("feature commit")
 
-    result = git_diff(test_repository, "master")
+    result = git_diff(test_repository, default_branch)
 
     assert "test.txt" in result
     assert "feature changes" in result


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

Change `test_git_diff` to retrieve local default branch and using that as the checked-against branch name.

## Publishing Your Server

**Note: We are no longer accepting PRs to add servers to the README.** Instead, please publish your server to the [MCP Server Registry](https://github.com/modelcontextprotocol/registry) to make it discoverable to the MCP ecosystem.

To publish your server, follow the [quickstart guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx). You can browse published servers at [https://registry.modelcontextprotocol.io/](https://registry.modelcontextprotocol.io/).

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: git
- Changes to: tests

## Motivation and Context

When running tests locally, if the configured default branch name is anything other than `master`, such as the now common `main`, the `test_git_diff` will fail.

## How Has This Been Tested?

Local pytest ran and passed successfully.

## Breaking Changes

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
