### PR TITLE
Add Sub-Agents MCP to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,6 +1326,7 @@ search, and comprehensive file analysis.
 - **[Strava](https://github.com/r-huijts/strava-mcp)** - Connect to the Strava API to access activity data, athlete profiles, segments, and routes, enabling fitness tracking and analysis with Claude.
 - **[Strava API](https://github.com/tomekkorbak/strava-mcp-server)** - MCP server for Strava API to retrieve one's activities
 - **[Stripe](https://github.com/atharvagupta2003/mcp-stripe)** - This MCP allows integration with Stripe for handling payments, customers, and refunds.
+- **[Sub-Agents MCP](https://github.com/shinpr/sub-agents-mcp)** - Define focused AI agents in Markdown for specialized tasks.
 - **[Substack/Medium](https://github.com/jonathan-politzki/mcp-writer-substack)** - Connect Claude to your Substack/Medium writing, enabling semantic search and analysis of your published content.
 - **[System Health](https://github.com/thanhtung0201/mcp-remote-system-health)** - The MCP (Multi-Channel Protocol) System Health Monitoring is a robust, real-time monitoring solution designed to provide comprehensive health metrics and alerts for remote Linux servers.
 - **[SystemSage](https://github.com/Tarusharma1/SystemSage)** - A powerful, cross-platform system management and monitoring tool for Windows, Linux, and macOS.


### PR DESCRIPTION
## Description

This PR adds [Sub-Agents MCP](https://github.com/shinpr/sub-agents-mcp) to the Community Servers README.

## Motivation and Context

Sub-Agents MCP enables users to define focused AI agents in Markdown for specialized tasks. It addresses the growing need for multi-agent orchestration by providing context
isolation and lightweight agent definitions that can be reused across MCP-compatible tools.

## How Has This Been Tested?

Tested with:
- Claude Code
- Cursor CLI
- Gemini CLI

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options