### PR TITLE
Add Google Ads MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Golang Filesystem Server](https://github.com/mark3labs/mcp-filesystem-server)** - Secure file operations with configurable access controls built with Go!
 - **[Goodnews](https://github.com/VectorInstitute/mcp-goodnews)** - A simple MCP server that delivers curated positive and uplifting news stories.
 - **[Google Ads](https://github.com/gomarble-ai/google-ads-mcp-server)** - MCP server acting as an interface to the Google Ads, enabling programmatic access to Facebook Ads data and management features.
+- **[Google Ads](https://github.com/ameydabhade/google-ads-mcp)** - MCP server for Google Ads API with 18 tools for campaigns, ad groups, keywords, search terms, geographic/demographic analytics, and more. Supports HTTP and stdio modes.
 - **[Google Analytics](https://github.com/surendranb/google-analytics-mcp)** - Google Analytics MCP Server to bring data across 200+ dimensions & metrics for LLMs to analyse.
 - **[Google Analytics 4](https://github.com/gomakers-ai/mcp-google-analytics)** - MCP server for Google Analytics Data API and Measurement Protocol to read reports and send events.
 - **[Google Calendar](https://github.com/v-3/google-calendar)** - Integration with Google Calendar to check schedules, find time, and add/delete events


### PR DESCRIPTION
## Summary
Added MCP server for Google Ads API integration.

**Repository:** https://github.com/ameydabhade/google-ads-mcp

## Features
- 18 tools for Google Ads API access
- Campaign, ad group, keyword, and search term management
- Geographic and demographic performance analytics
- Account management and asset details
- Supports both HTTP and stdio transport modes
- Full documentation and Claude Desktop integration guide

## Tools Included
| Tool | Description |
|------|-------------|
| `get_accounts` | List all accessible Google Ads accounts |
| `get_campaigns` | Get campaigns with performance metrics |
| `get_ad_groups` | Get ad groups with metrics |
| `get_keywords` | Get keywords with quality scores |
| `get_search_terms` | Get search queries that triggered ads |
| `get_geographic_performance` | Performance by location |
| `get_audience_demographics` | Age and gender performance |
| `get_ad_schedule_performance` | Performance by day/hour |
| `get_account_summary` | Overall account metrics |
| `healthcheck` | Test API connectivity |
| And 8 more... |

## Checklist
- [x] Repository is public
- [x] Has comprehensive README with setup instructions
- [x] Includes MIT license
- [x] Tested and working