### PR TITLE
Add PraisonAI to Frameworks (For clients) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,6 +1501,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[MCP CLI Client](https://github.com/vincent-pli/mcp-cli-host)** - A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP).
 * **[OpenMCP Client](https://github.com/LSTM-Kirigaya/openmcp-client/)** - An all-in-one vscode/trae/cursor plugin for MCP server debugging. [Document](https://kirigaya.cn/openmcp/) & [OpenMCP SDK](https://kirigaya.cn/openmcp/sdk-tutorial/).
 * **[PHP MCP Client](https://github.com/php-mcp/client)** - Core PHP implementation for the Model Context Protocol (MCP) Client
+* **[PraisonAI](https://github.com/MervinPraison/PraisonAI)** (Python) - Production-ready AI Agents framework with native MCP client support. Consume any MCP server as agent tools with a simple `MCP()` class.
 * **[Runbear](https://runbear.io/solutions/integrations/slack/mcp)** - No-code MCP client for team chat platforms, such as Slack, Microsoft Teams, and Discord.
 
 ## 📚 Resources


### PR DESCRIPTION
## Summary
Add PraisonAI to the "📚 Frameworks → For clients" section as an AI Agents framework with native MCP client support.

## About PraisonAI
- **GitHub**: https://github.com/MervinPraison/PraisonAI
- **PyPI**: https://pypi.org/project/praisonai/ (2M+ downloads)
- **MCP Registry**: https://registry.modelcontextprotocol.io/servers/io.github.MervinPraison/praisonai
- **Documentation**: https://docs.praison.ai/mcp

## MCP Integration
PraisonAI provides a native `MCP` class that allows AI agents to consume any MCP server as tools:

```python
from praisonaiagents import Agent
from praisonaiagents.mcp import MCP

agent = Agent(
    instructions="You are a helpful assistant",
    tools=MCP("npx -y @modelcontextprotocol/server-filesystem /tmp")
)
agent.start("List files in /tmp")
```

### Supported MCP Features
- **All transports**: stdio, SSE, WebSocket, Streamable HTTP
- **Environment variables**: Pass API keys and config to MCP servers
- **Multiple servers**: Use multiple MCP servers simultaneously
- **Async support**: Full async/await compatibility

## Why This Belongs in Frameworks (For clients)
1. **Client-side MCP integration** - PraisonAI is an MCP client that consumes MCP servers
2. **Framework, not a server** - It's a framework for building AI agents, not an MCP server implementation
3. **Already in MCP Registry** - Published at `io.github.MervinPraison/praisonai`
4. **Active maintenance** - Regular releases, 10K+ GitHub stars, 2M+ PyPI downloads