### PR TITLE
Add Desearch X Twitter and Web Search MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1438,6 +1438,7 @@ search, and comprehensive file analysis.
 - **[Wren Engine](https://github.com/Canner/wren-engine)** - The Semantic Engine for Model Context Protocol(MCP) Clients and AI Agents
 - **[X (Twitter)](https://github.com/EnesCinr/twitter-mcp)** (by EnesCinr) - Interact with twitter API. Post tweets and search for tweets by query.
 - **[X (Twitter)](https://github.com/vidhupv/x-mcp)** (by vidhupv) - Create, manage and publish X/Twitter posts directly through Claude chat.
+- **[X (Twitter) & Web Search](https://github.com/Desearch-ai/mcp-desearch)** Decentralized X (Twitter) and Web Search with AI Search support for Model Context Protocol MCP clients and AI agents
 - **[Xcode](https://github.com/r-huijts/xcode-mcp-server)** - MCP server that brings AI to your Xcode projects, enabling intelligent code assistance, file operations, project management, and automated development tasks.
 - **[Xcode-mcp-server](https://github.com/drewster99/xcode-mcp-server)** (by drewster99) - Best Xcode integration - ClaudeCode and Cursor can build your project *with* Xcode and see the same errors you do. Fast easy setup.
 - **[xcodebuild](https://github.com/ShenghaiWang/xcodebuild)**  - 🍎 Build iOS Xcode workspace/project and feed back errors to llm.


### PR DESCRIPTION
## Add Desearch X Twitter and Web Search MCP Server

This PR adds Desearch to the MCP servers registry.

## Description

Desearch is a decentralized MCP server that provides real time X Twitter search, Web search, and AI powered search for MCP clients and AI agents.  
It is designed for agents that require fast, reliable, and structured access to external information.

## Key Features

• Real time X Twitter search with historical support  
• Decentralized Web Search SERP API  
• AI Search with summaries and structured results  
• High concurrency support for agents and tools  
• Simple API key based authentication  
• Clean and consistent response schema  
• Built for Model Context Protocol MCP clients  

## Links

• Repository  
https://github.com/Desearch-ai/mcp-desearch  

• Documentation  
https://desearch.ai/docs/guide/integrations/mcp

• Website  
https://desearch.ai  

• License  
MIT

## Installation

```bash
npm install desearch-mcp-server