### PR TITLE
fix(memory): add 'type' to schemas and use passthrough for Gemini CLI…

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -237,7 +237,7 @@ export class KnowledgeGraphManager {
 
 let knowledgeGraphManager: KnowledgeGraphManager;
 
-// Zod schemas for entities and relations - Patched for Gemini CLI compatibility
+// Zod schemas for entities and relations
 const EntitySchema = z.object({
   type: z.string().optional().describe("Internal type discriminator (entity)"),
   name: z.string().describe("The name of the entity"),

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -48,12 +48,14 @@ let MEMORY_FILE_PATH: string;
 
 // We are storing our memory using entities, relations, and observations in a graph structure
 export interface Entity {
+  type?: string;
   name: string;
   entityType: string;
   observations: string[];
 }
 
 export interface Relation {
+  type?: string;
   from: string;
   to: string;
   relationType: string;
@@ -235,18 +237,20 @@ export class KnowledgeGraphManager {
 
 let knowledgeGraphManager: KnowledgeGraphManager;
 
-// Zod schemas for entities and relations
+// Zod schemas for entities and relations - Patched for Gemini CLI compatibility
 const EntitySchema = z.object({
+  type: z.string().optional().describe("Internal type discriminator (entity)"),
   name: z.string().describe("The name of the entity"),
   entityType: z.string().describe("The type of the entity"),
   observations: z.array(z.string()).describe("An array of observation contents associated with the entity")
-});
+}).passthrough();
 
 const RelationSchema = z.object({
+  type: z.string().optional().describe("Internal type discriminator (relation)"),
   from: z.string().describe("The name of the entity where the relation starts"),
   to: z.string().describe("The name of the entity where the relation ends"),
   relationType: z.string().describe("The type of the relation")
-});
+}).passthrough();
 
 // The server instance and tools exposed to Claude
 const server = new McpServer({


### PR DESCRIPTION
Title
fix(memory): enhance schema compatibility for strict JSON validators (like Gemini CLI)

Description
This PR updates the memory server's Zod schemas to improve compatibility with MCP clients that enforce strict JSON schema validation, such as the Google Gemini CLI. 

The changes include:
 1. Formally declaring the optional type property in EntitySchema and RelationSchema.
 2. Enabling .passthrough() on these schemas to allow for internal or future properties without breaking strict validation.

Server Details
 - Server: memory
 - Changes to: tools (Output schemas for read_graph, search_nodes, and open_nodes)

Motivation and Context
Strict MCP clients like the Gemini CLI perform rigorous validation on tool outputs. The memory server includes a type field in its internal JSONL storage which is subsequently returned in tool outputs. Since this field was not declared in the tool's output schema, Gemini CLI rejected the response with an "additional properties not allowed" error (code -32602).

By declaring the type field and using .passthrough(), we ensure the server remains robust and compatible with both permissive and strict clients.

How Has This Been Tested?
Tested locally using google-gemini-cli:
 - Verified that read_graph no longer triggers validation errors and returns the full graph.
 - Verified that search_nodes and open_nodes successfully return structured content.
 - Confirmed that data remains intact in the memory.jsonl file.

Breaking Changes
 - No. This change is additive and increases tolerance for existing data structures.

Types of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Documentation update

Checklist
 - [x] I have read the [MCP Protocol Documentation (https://modelcontextprotocol.io)
 - [x] My changes follows MCP security best practices
 - [x] I have updated the server's README accordingly (N/A - no user-facing config changes)
 - [x] I have tested this with an LLM client
 - [x] My code follows the repository's style guidelines
 - [ ] New and existing tests pass locally (Need to run npm test)
 - [x] I have added appropriate error handling
 - [x] I have documented all environment variables and configuration options (N/A)

Additional context
The type discriminator is essential for the server's internal logic when parsing the JSONL file. Formalizing its presence in the communication schema resolves the "hidden property" conflict with strict validators.
