### PR TITLE
fix(git): use git CLI in git_add to avoid GitPython index corruption bug

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -129,10 +129,11 @@ def git_commit(repo: git.Repo, message: str) -> str:
     return f"Changes committed successfully with hash {commit.hexsha}"
 
 def git_add(repo: git.Repo, files: list[str]) -> str:
-    if files == ["."]:
-        repo.git.add(".")
-    else:
-        repo.index.add(files)
+    # Always use git CLI to avoid GitPython index.add() bugs with:
+    # - "." (stages .git/ directory, adds ./ prefix to paths)
+    # - paths with "./" prefix (preserved incorrectly in index)
+    # See: https://github.com/gitpython-developers/GitPython/issues/375
+    repo.git.add(files)
     return "Files staged successfully"
 
 def git_reset(repo: git.Repo) -> str:


### PR DESCRIPTION
## Description

GitPython's index.add() has a known bug that corrupts the git index when paths contain ./ prefixes or when . is included in the file list. The bug causes:
- Files appearing with ./ prefix (e.g., ./index.md)
- The .git directory itself being staged
- Corrupted commits requiring git filter-repo to fix

## Motivation and Context

The previous implementation only handled the exact case of ["."] but failed to handle [".", "other.md"] or ["./README.md"]. This fix uses repo.git.add() (CLI wrapper) for all cases, which is consistent with how other git operations are implemented in this file and correctly handles all edge cases.

## Testing

I have been using the `mcp-server-git` MCP to allow Claude to edit a private [otterwiki](https://otterwiki.com). Prior to making this change locally, I was seeing corruption of the Git repository every few commits. Since applying the change about a week ago,  I have been using the wiki with Claude every single day and have not seen a single error of any kind.

## Breaking Changes

None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## References

- https://github.com/gitpython-developers/GitPython/issues/375
- https://github.com/gitpython-developers/GitPython/issues/292

