### PR TITLE
fix(memory): allow additional properties in entity/relation schemas

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -390,5 +390,25 @@ describe('KnowledgeGraphManager', () => {
       expect(JSON.parse(lines[0])).toHaveProperty('type', 'entity');
       expect(JSON.parse(lines[1])).toHaveProperty('type', 'relation');
     });
+
+    it('should handle entities with additional properties in storage (issue #3144)', async () => {
+      // Manually write an entity with extra properties to the file
+      const entityWithExtra = JSON.stringify({
+        type: 'entity',
+        name: 'Test_Entity',
+        entityType: 'test',
+        observations: ['Has an extra field'],
+        custom_id: 'xyz-123',  // Extra property not in schema
+        metadata: { source: 'external' }  // Another extra property
+      });
+      await fs.writeFile(testFilePath, entityWithExtra);
+
+      // Reading the graph should not throw an error
+      const graph = await manager.readGraph();
+      expect(graph.entities).toHaveLength(1);
+      expect(graph.entities[0].name).toBe('Test_Entity');
+      expect(graph.entities[0].entityType).toBe('test');
+      expect(graph.entities[0].observations).toContain('Has an extra field');
+    });
   });
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -224,17 +224,19 @@ export class KnowledgeGraphManager {
 let knowledgeGraphManager: KnowledgeGraphManager;
 
 // Zod schemas for entities and relations
+// Using passthrough() to allow additional properties that may exist in stored data
+// This prevents schema validation errors when reading entities with extra fields
 const EntitySchema = z.object({
   name: z.string().describe("The name of the entity"),
   entityType: z.string().describe("The type of the entity"),
   observations: z.array(z.string()).describe("An array of observation contents associated with the entity")
-});
+}).passthrough();
 
 const RelationSchema = z.object({
   from: z.string().describe("The name of the entity where the relation starts"),
   to: z.string().describe("The name of the entity where the relation ends"),
   relationType: z.string().describe("The type of the relation")
-});
+}).passthrough();
 
 // The server instance and tools exposed to Claude
 const server = new McpServer({


### PR DESCRIPTION
## Summary
- Added `.passthrough()` to `EntitySchema` and `RelationSchema`
- Entities with extra properties in storage can now be read without validation errors
- Added test case for the exact scenario described in issue #3144

## Problem
When `memory.jsonl` contains entities with extra properties (e.g., `custom_id`), the `read_graph` tool fails with:
```
MCP error -32602: Structured content does not match the tool's output schema: 
data/entities/0 must NOT have additional properties
```

## Solution
Using Zod's `.passthrough()` allows the schema to accept additional properties while still validating required fields.

Fixes #3144