### PR TITLE
Add MCP Tool Factory to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1478,6 +1478,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[MCP Declarative Java SDK](https://github.com/codeboyzhou/mcp-declarative-java-sdk)** Annotation-driven MCP servers development with Java, no Spring Framework Required, minimize dependencies as much as possible.
 * **[MCP-Framework](https://mcp-framework.com)** Build MCP servers with elegance and speed in TypeScript. Comes with a CLI to create your project with `mcp create app`. Get started with your first server in under 5 minutes by **[Alex Andru](https://github.com/QuantGeekDev)**
 * **[MCP Plexus](https://github.com/Super-I-Tech/mcp_plexus)**: A secure, **multi-tenant** and Multi-user MCP python server framework built to integrate easily with external services via OAuth 2.1, offering scalable and robust solutions for managing complex AI applications.
+* **[MCP Tool Factory](https://github.com/heshamfs/mcp-tool-factory)** (Python) - Generate MCP servers from descriptions, OpenAPI specs, or databases using LLM. Multi-provider support. 
 * **[mcp_sse (Elixir)](https://github.com/kEND/mcp_sse)** An SSE implementation in Elixir for rapidly creating MCP servers.
 * **[mxcp](https://github.com/raw-labs/mxcp)** (Python) - Open-source framework for building enterprise-grade MCP servers using just YAML, SQL, and Python, with built-in auth, monitoring, ETL and policy enforcement.
 * **[Next.js MCP Server Template](https://github.com/vercel-labs/mcp-for-next.js)** (Typescript) - A starter Next.js project that uses the MCP Adapter to allow MCP clients to connect and access resources.
@@ -1491,7 +1492,6 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[AgentR Universal MCP SDK](https://github.com/universal-mcp/universal-mcp)** - A python SDK to build MCP Servers with inbuilt credential management by **[Agentr](https://agentr.dev/home)**
 * **[Vercel MCP Adapter](https://github.com/vercel/mcp-adapter)** (TypeScript) - A simple package to start serving an MCP server on most major JS meta-frameworks including Next, Nuxt, Svelte, and more.
 * **[PHP MCP Server](https://github.com/php-mcp/server)** (PHP) - Core PHP implementation for the Model Context Protocol (MCP) server
-
 ### For clients
 
 * **[codemirror-mcp](https://github.com/marimo-team/codemirror-mcp)** - CodeMirror extension that implements the Model Context Protocol (MCP) for resource mentions and prompt commands


### PR DESCRIPTION
Added MCP Tool Factory to the "For servers" section - an AI-powered Python framework that generates production-ready MCP servers from natural language descriptions, OpenAPI specifications, or database schemas.

  Server Details
  - Server: MCP Tool Factory (Python)
  - Category: Server Framework / Code Generator
  - Repository: https://github.com/HeshamFS/mcp-tool-factory

  Motivation and Context

  MCP Tool Factory fills a gap in the ecosystem by providing an AI-powered way to generate complete MCP server packages:

  - Natural Language → MCP Server: Describe tools in plain English, get working code
  - OpenAPI → MCP Server: Auto-convert REST APIs with full auth support (API Key, Bearer, OAuth2)  
  - Database → MCP Server: Generate CRUD tools from SQLite/PostgreSQL schemas
  - Multi-Provider: Works with Anthropic Claude, OpenAI GPT, and Google Gemini

  Generated servers work with all MCP-compatible frameworks: Claude Code, OpenAI Agents SDK, Google ADK, LangChain, CrewAI, and more.

  How Has This Been Tested?

  - ✅ Tested with Claude Code and Claude Desktop
  - ✅ 868 tests with 85%+ code coverage
  - ✅ CI/CD pipeline with GitHub Actions
  - ✅ Generated servers validated with multiple LLM clients

  Breaking Changes
  None - this is an addition to the server frameworks list.

  Checklist
  - I have read the https://modelcontextprotocol.io
  - My changes follows MCP security best practices
  - I have updated the server's README accordingly
  - I have tested this with an LLM client
  - My code follows the repository's style guidelines
  - New and existing tests pass locally
  - I have added appropriate error handling
  - I have documented all environment variables and configuration options