### PR TITLE
fix(filesystem): correct outputSchema for directory_tree and move_file

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -518,7 +518,12 @@ server.registerTool(
       path: z.string(),
       excludePatterns: z.array(z.string()).optional().default([])
     },
-    outputSchema: { content: z.string() },
+    outputSchema: {
+      content: z.array(z.object({
+        type: z.literal("text"),
+        text: z.string()
+      }))
+    },
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof DirectoryTreeArgsSchema>) => {
@@ -588,7 +593,12 @@ server.registerTool(
       source: z.string(),
       destination: z.string()
     },
-    outputSchema: { content: z.string() },
+    outputSchema: {
+      content: z.array(z.object({
+        type: z.literal("text"),
+        text: z.string()
+      }))
+    },
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: false }
   },
   async (args: z.infer<typeof MoveFileArgsSchema>) => {


### PR DESCRIPTION
## Summary

Fixes the `outputSchema` declarations for `directory_tree` and `move_file` tools to match their actual return types.

Both tools were declaring `outputSchema: { content: z.string() }` but returning `{ content: [{ type: "text", text: "..." }] }` - an array of content blocks. This mismatch caused MCP validation error `-32602` when clients used structured content validation.

## Changes

- Updated `directory_tree` outputSchema to declare content as array of text content blocks
- Updated `move_file` outputSchema with the same fix

## Test plan

- [ ] Build passes (`npm run build` in src/filesystem)
- [ ] Schema now matches the actual return type
- [ ] Clients using structured content validation should no longer receive -32602 errors

Fixes #3093
Fixes #3106