### PR TITLE
fix(memory): strip extra properties when loading entities from JSONL

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -74,8 +74,20 @@ export class KnowledgeGraphManager {
       const lines = data.split("\n").filter(line => line.trim() !== "");
       return lines.reduce((graph: KnowledgeGraph, line) => {
         const item = JSON.parse(line);
-        if (item.type === "entity") graph.entities.push(item as Entity);
-        if (item.type === "relation") graph.relations.push(item as Relation);
+        if (item.type === "entity") {
+          graph.entities.push({
+            name: item.name,
+            entityType: item.entityType,
+            observations: item.observations
+          });
+        }
+        if (item.type === "relation") {
+          graph.relations.push({
+            from: item.from,
+            to: item.to,
+            relationType: item.relationType
+          });
+        }
         return graph;
       }, { entities: [], relations: [] });
     } catch (error) {


### PR DESCRIPTION
## Summary

When loading entities and relations from JSONL files, the parsed JSON objects included extra properties like `type` (used for discriminating entity vs relation) and any other custom fields that may have been manually added or present in legacy data. These extra properties leaked into the Entity/Relation objects, causing MCP schema validation errors (-32602 Invalid params) when outputSchema validation is enabled.

**The fix:** Explicitly extract only the schema-defined properties (name, entityType, observations for entities; from, to, relationType for relations) instead of casting the entire parsed JSON object.

## Test plan

- [x] Added test case that writes JSONL with extra properties and verifies they are stripped when loading
- [x] All 40 existing tests continue to pass

Fixes #3144