### PR TITLE
fix(git): prevent path traversal in git_add and add hardening for git_create_branch

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -180,6 +180,13 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
         return log
 
 def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None = None) -> str:
+    # Defense in depth: reject branch names starting with '-' to prevent
+    # creating refs that could be interpreted as flags by other git commands
+    if branch_name.startswith("-"):
+        raise ValueError(f"Invalid branch name: '{branch_name}' - cannot start with '-'")
+    if base_branch and base_branch.startswith("-"):
+        raise ValueError(f"Invalid base branch: '{base_branch}' - cannot start with '-'")
+
     if base_branch:
         base = repo.references[base_branch]
     else:


### PR DESCRIPTION
## Description

Fix a critical path traversal vulnerability and add defense-in-depth hardening:

1. **Critical: Path traversal in `git_add`** - Allows staging files outside the repository
2. **Low (Defense-in-depth): `git_create_branch` hardening** - Adds input validation for consistency

cc @0dd 

## Server Details
- Server: git
- Changes to: tools (`git_add`, `git_create_branch`), security validation

## Motivation and Context

### Path Traversal in `git_add` (Critical)
The `git_add` function uses GitPython's `repo.index.add()` which does not validate that file paths are within the repository, unlike the Git CLI. This allows attackers to stage sensitive files:

```python
git_add(repo, ["../../../.ssh/id_rsa"])      # SSH keys
git_add(repo, ["../../../.kube/config"])     # K8s credentials
git_add(repo, ["../../../.aws/credentials"]) # AWS credentials
```

**Impact:** Complete credential exfiltration via git commit/push.

### `git_create_branch` Hardening (Low - Defense-in-depth)
The `git_create_branch` function allowed creating branch names starting with `-`. While not directly exploitable (other functions like `git_checkout` and `git_diff` already reject such refs), this fix adds consistency with the existing security pattern:

```python
git_create_branch(repo, "--help")           # Now rejected
git_create_branch(repo, "test", "--help")   # Now rejected
```

**Impact:** Prevents creating refs that could confuse other tools or future code.

## How Has This Been Tested?

- Added 14 new unit tests covering:
  - Path traversal with `../` sequences (rejected)
  - Absolute paths outside repo (rejected)
  - Specific attack vectors (`~/.kube/config`, `~/.ssh/id_rsa`)
  - Branch names starting with `-` (rejected)
  - Malicious base branch names (rejected)
  - Valid operations (still allowed)
- All existing tests pass
- Verified exploits work without fix, fail with fix

## Breaking Changes

None. Valid file paths continue to work. Only malicious paths outside the repository are now rejected with a `ValueError`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options
- [ ] 
## Additional context

These fixes follow existing security patterns in the codebase:
- `validate_repo_path()` for repository boundary validation
- Defense-in-depth checks in `git_diff()` and `git_checkout()` that reject inputs starting with `-`

The `git_create_branch` fix completes the defense-in-depth pattern across all branch-related functions.
