### PR TITLE
fix(filesystem): gracefully handle unavailable directories

### DIFF
--- a/src/filesystem/__tests__/startup-validation.test.ts
+++ b/src/filesystem/__tests__/startup-validation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+
+const SERVER_PATH = path.join(__dirname, '..', 'dist', 'index.js');
+
+/**
+ * Spawns the filesystem server with given arguments and returns exit info
+ */
+async function spawnServer(args: string[], timeoutMs = 2000): Promise<{ exitCode: number | null; stderr: string }> {
+  return new Promise((resolve) => {
+    const proc = spawn('node', [SERVER_PATH, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      proc.kill('SIGTERM');
+    }, timeoutMs);
+
+    proc.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ exitCode: code, stderr });
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      resolve({ exitCode: 1, stderr: err.message });
+    });
+  });
+}
+
+describe('Startup Directory Validation', () => {
+  let testDir: string;
+  let accessibleDir: string;
+  let accessibleDir2: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fs-startup-test-'));
+    accessibleDir = path.join(testDir, 'accessible');
+    accessibleDir2 = path.join(testDir, 'accessible2');
+    await fs.mkdir(accessibleDir, { recursive: true });
+    await fs.mkdir(accessibleDir2, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should start successfully with all accessible directories', async () => {
+    const result = await spawnServer([accessibleDir, accessibleDir2]);
+    // Server starts and runs (we kill it after timeout, so exit code is null or from SIGTERM)
+    expect(result.stderr).toContain('Secure MCP Filesystem Server running on stdio');
+    expect(result.stderr).not.toContain('Error:');
+  });
+
+  it('should skip inaccessible directory and continue with accessible one', async () => {
+    const nonExistentDir = path.join(testDir, 'non-existent-dir-12345');
+
+    const result = await spawnServer([nonExistentDir, accessibleDir]);
+
+    // Should warn about inaccessible directory
+    expect(result.stderr).toContain('Warning: Cannot access directory');
+    expect(result.stderr).toContain(nonExistentDir);
+
+    // Should still start successfully
+    expect(result.stderr).toContain('Secure MCP Filesystem Server running on stdio');
+  });
+
+  it('should exit with error when ALL directories are inaccessible', async () => {
+    const nonExistent1 = path.join(testDir, 'non-existent-1');
+    const nonExistent2 = path.join(testDir, 'non-existent-2');
+
+    const result = await spawnServer([nonExistent1, nonExistent2]);
+
+    // Should exit with error
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Error: None of the specified directories are accessible');
+  });
+
+  it('should warn when path is not a directory', async () => {
+    const filePath = path.join(testDir, 'not-a-directory.txt');
+    await fs.writeFile(filePath, 'content');
+
+    const result = await spawnServer([filePath, accessibleDir]);
+
+    // Should warn about non-directory
+    expect(result.stderr).toContain('Warning:');
+    expect(result.stderr).toContain('not a directory');
+
+    // Should still start with the valid directory
+    expect(result.stderr).toContain('Secure MCP Filesystem Server running on stdio');
+  });
+});


### PR DESCRIPTION
## Description
Previously, the server would crash if any configured directory was unavailable (e.g., unmounted external drive). Now it:
- Filters out inaccessible directories with a warning
- Continues operating with remaining accessible directories
- Only fails if NO directories are accessible

Fixes #2815

## Server Details
- Server: filesystem
- Changes to: startup validation logic in `index.ts`

## Motivation and Context
Users with external drives or network shares configured would lose ALL filesystem access when any single path was unavailable. This made the server unusable for laptop users who frequently connect/disconnect storage.

## How Has This Been Tested?
- Added 4 integration tests covering all scenarios
- Manually tested with mix of valid/invalid paths via CLI
- Build passes

## Breaking Changes
None. Server behavior is now more permissive (warns instead of crashing).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Note: 5 pre-existing test failures in `structured-content.test.ts` are unrelated to this change (verified by running tests on main branch before applying changes).