### PR TITLE
fix(filesystem): mark move_file as destructive operation

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -200,7 +200,7 @@ The mapping for filesystem tools is:
 | `create_directory`          | `false`      | `true`         | `false`         | Re‑creating the same dir is a no‑op             |
 | `write_file`                | `false`      | `true`         | `true`          | Overwrites existing files                       |
 | `edit_file`                 | `false`      | `false`        | `true`          | Re‑applying edits can fail or double‑apply      |
-| `move_file`                 | `false`      | `false`        | `false`         | Move/rename only; repeat usually errors         |
+| `move_file`                 | `false`      | `false`        | `true`          | Deletes source file                             |
 
 > Note: `idempotentHint` and `destructiveHint` are meaningful only when `readOnlyHint` is `false`, as defined by the MCP spec.
 

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -589,7 +589,7 @@ server.registerTool(
       destination: z.string()
     },
     outputSchema: { content: z.string() },
-    annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: false }
+    annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
     const validSourcePath = await validatePath(args.source);


### PR DESCRIPTION
## Description
`move_file` deletes the source file, which is a destructive operation. Updated annotations and README to reflect this.

## Server Details
- Server: filesystem
- Changes to: tool annotations, README

## Motivation and Context
MCP clients use `destructiveHint` to warn users. `move_file` deletes source file — should be marked destructive. For comparison: `write_file` has `destructiveHint: true`.

## How Has This Been Tested?
- Build passes
- 134 tests pass

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options