### PR TITLE
Everything server - Fix error when referring to roots

### DIFF
--- a/src/everything/server/roots.ts
+++ b/src/everything/server/roots.ts
@@ -41,7 +41,7 @@ export const syncRoots = async (server: McpServer, sessionId?: string) => {
         const response = await server.server.listRoots();
         if (response && "roots" in response) {
           // Store the roots list for this client
-          roots.set(sessionId, response?.roots);
+          roots.set(sessionId, response.roots);
 
           // Notify the client of roots received
           await server.sendLoggingMessage(


### PR DESCRIPTION
## Description
In src/everything/server/roots.ts
  - refer to `roots` as optional in `clientCapabilities`

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: everything
- Changes to: roots

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Referring to `clientCapabilities.roots` causes an error if the client doesn't support roots.
See #2818

## How Has This Been Tested?
As per the steps to reproduce in #2818 
<img width="1831" height="685" alt="Screenshot 2026-01-10 at 5 35 42 PM" src="https://github.com/user-attachments/assets/4f1057b0-58d6-472e-9054-9c6c43dfdb9c" />

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Fixes #2818
