### PR TITLE
Add che-apple-mail-mcp - Comprehensive Apple Mail MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[CFBD API](https://github.com/lenwood/cfbd-mcp-server)** - An MCP server for the [College Football Data API](https://collegefootballdata.com/).
 - **[ChatMCP](https://github.com/AI-QL/chat-mcp)** – An Open Source Cross-platform GUI Desktop application compatible with Linux, macOS, and Windows, enabling seamless interaction with MCP servers across dynamically selectable LLMs, by **[AIQL](https://github.com/AI-QL)**
 - **[ChatSum](https://github.com/mcpso/mcp-server-chatsum)** - Query and Summarize chat messages with LLM. by [mcpso](https://mcp.so)
+- **[che-apple-mail-mcp](https://github.com/kiki830621/che-apple-mail-mcp)** - The most comprehensive Apple Mail MCP with 42 tools covering accounts, mailboxes, emails, rules, signatures, VIP management and more. Built with Swift.
 - **[Chess.com](https://github.com/pab1it0/chess-mcp)** - Access Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 - **[Chessagine-mcp](https://github.com/jalpp/chessagine-mcp)** - A chess MCP server that integrates Stockfish engine evaluation, positional theme analysis, Lichess opening databases, and chess knowledgebase.
 - **[ChessPal Chess Engine (stockfish)](https://github.com/wilson-urdaneta/chesspal-mcp-engine)** - A Stockfish-powered chess engine exposed as an MCP server. Calculates best moves and supports both HTTP/SSE and stdio transports.


### PR DESCRIPTION
## New Community Server: che-apple-mail-mcp

**Repository**: https://github.com/kiki830621/che-apple-mail-mcp

### Description
The most comprehensive Apple Mail MCP server with 42 tools - more than double the tools of existing alternatives. Built natively in Swift using AppleScript for Mail.app automation.

### Features
- **42 tools** covering nearly all Mail.app scripting capabilities
- Full mailbox management (create/delete folders)
- 7 flag colors + background colors for emails
- VIP sender management
- Complete mail rule management (CRUD)
- Email signatures access
- SMTP server information
- Email redirect (preserves original sender)
- Raw email headers and source access
- Check for new mail / sync accounts

### Technical Details
- **Language**: Swift
- **Framework**: MCP Swift SDK v0.10.0
- **Platform**: macOS 13.0+ (Ventura and later)
- **Transport**: stdio

### Comparison with existing Apple Mail MCPs

| Feature | Other MCPs | che-apple-mail-mcp |
|---------|------------|-------------------|
| Total Tools | ~20 | **42** |
| Language | Python | Swift (native) |
| Mailbox CRUD | No | Yes |
| Flag colors | No | 7 colors |
| VIP/Rules/Signatures | Partial/No | Full support |

### Links
- Documentation: [README](https://github.com/kiki830621/che-apple-mail-mcp#readme)
- Chinese README: [README_zh-TW.md](https://github.com/kiki830621/che-apple-mail-mcp/blob/main/README_zh-TW.md)