### PR TITLE
remove type from loading

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -74,8 +74,20 @@ export class KnowledgeGraphManager {
       const lines = data.split("\n").filter(line => line.trim() !== "");
       return lines.reduce((graph: KnowledgeGraph, line) => {
         const item = JSON.parse(line);
-        if (item.type === "entity") graph.entities.push(item as Entity);
-        if (item.type === "relation") graph.relations.push(item as Relation);
+        if (item.type === "entity") {
+          graph.entities.push({
+            name: item.name,
+            entityType: item.entityType,
+            observations: item.observations
+          });
+        }
+        if (item.type === "relation") {
+          graph.relations.push({
+            from: item.from,
+            to: item.to,
+            relationType: item.relationType
+          });
+        }
         return graph;
       }, { entities: [], relations: [] });
     } catch (error) {


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
`loadGraph()` loads in type because `saveGraph` saves it as described in [3210](https://github.com/modelcontextprotocol/servers/issues/3210)

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: memory
- Changes to: index.ts, knowledge-graph.tst.ts

## Motivation and Context
Fixed a validation error where search_nodes (and other tools) returned entities/relations with a type field that wasn't in the schema.
## How Has This Been Tested?
Added 3 unit tests verifying entities/relations loaded from file

## Breaking Changes
None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
