### PR TITLE
fix(filesystem): handle negative values in formatSize()

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -65,8 +65,10 @@ describe('Lib Functions', () => {
       });
 
       it('handles negative numbers', () => {
-        // Negative numbers will result in NaN for the log calculation
-        expect(formatSize(-1024)).toContain('NaN');
+        // Negative numbers should return '0 B' as file sizes cannot be negative
+        expect(formatSize(-1)).toBe('0 B');
+        expect(formatSize(-1024)).toBe('0 B');
+        expect(formatSize(-1000000)).toBe('0 B');
         expect(formatSize(-0)).toBe('0 B');
       });
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -43,7 +43,7 @@ export interface SearchResult {
 // Pure Utility Functions
 export function formatSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-  if (bytes === 0) return '0 B';
+  if (bytes <= 0) return '0 B';
   
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   


### PR DESCRIPTION
## Description

`formatSize()` returned "NaN B" for negative byte values. Now returns "0 B" since file sizes cannot be negative.

> **Note:** Re-submission of #3197 (accidentally closed when I deleted my fork)

## Server Details

- Server: filesystem
- Changes to: lib.ts, lib.test.ts

## Motivation and Context

Invalid input should not produce "NaN B" in UI. File sizes cannot be negative, so returning "0 B" is a safe default.

## How Has This Been Tested?

- Build passes
- Updated existing test to verify new behavior

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options