### PR TITLE
fix(filesystem): resolve symlinked allowed directories to both forms

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -39,22 +39,32 @@ if (args.length === 0) {
 }
 
 // Store allowed directories in normalized and resolved form
-let allowedDirectories = await Promise.all(
+// We store BOTH the original path AND the resolved path to handle symlinks correctly
+// This fixes the macOS /tmp -> /private/tmp symlink issue where users specify /tmp
+// but the resolved path is /private/tmp
+let allowedDirectories = (await Promise.all(
   args.map(async (dir) => {
     const expanded = expandHome(dir);
     const absolute = path.resolve(expanded);
+    const normalizedOriginal = normalizePath(absolute);
     try {
       // Security: Resolve symlinks in allowed directories during startup
       // This ensures we know the real paths and can validate against them later
       const resolved = await fs.realpath(absolute);
-      return normalizePath(resolved);
+      const normalizedResolved = normalizePath(resolved);
+      // Return both original and resolved paths if they differ
+      // This allows matching against either /tmp or /private/tmp on macOS
+      if (normalizedOriginal !== normalizedResolved) {
+        return [normalizedOriginal, normalizedResolved];
+      }
+      return [normalizedResolved];
     } catch (error) {
       // If we can't resolve (doesn't exist), use the normalized absolute path
       // This allows configuring allowed dirs that will be created later
-      return normalizePath(absolute);
+      return [normalizedOriginal];
     }
   })
-);
+)).flat();
 
 // Validate that all directories exist and are accessible
 await Promise.all(allowedDirectories.map(async (dir) => {


### PR DESCRIPTION
## Summary

Fixes #3253

**Problem**
On macOS, `/tmp` is a symlink to `/private/tmp`. When users specify `/tmp` as an allowed directory:
1. Server startup resolves `/tmp` to `/private/tmp` and stores only `/private/tmp` in allowedDirectories
2. When user requests `/tmp/file.txt`, the initial validation check fails because `/tmp` doesn't match `/private/tmp`
3. User gets "Access denied - path outside allowed directories" error

**Solution**
Store both the original normalized path andthe resolved path in `allowedDirectories`. This allows users to access files through either form:
- `/tmp/file.txt` matches `/tmp` in allowedDirectories
- `/private/tmp/file.txt` matches `/private/tmp` in allowedDirectories

## Changes
- `src/filesystem/index.ts`: Modified allowed directory initialization to store both original and resolved paths when they differ
- `src/filesystem/__tests__/path-validation.test.ts`: Added test for the symlink behavior

## Tests
- [x] Added new test "allows paths through both original and resolved symlink directories"
- [x] Verified fix works on macOS by observing both paths in allowedDirectories output

## Reproduction
Before fix:
```bash
npx -y @modelcontextprotocol/server-filesystem /tmp
# Then request /tmp/test.txt -> REJECTED
```

After fix:
```bash
npx -y @modelcontextprotocol/server-filesystem /tmp
# Server logs: allowed directories: ['/tmp', '/private/tmp']
# Then request /tmp/test.txt -> ACCEPTED
```