### PR TITLE
added read_binary_file tool for file system MCP server

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -81,6 +81,16 @@ The server's directory access control follows this flow:
     - `path` (string)
   - Streams the file and returns base64 data with the corresponding MIME type
 
+- **read_binary_file**
+  - Read any binary file (Excel, PDF, images, etc.) as base64-encoded data
+  - Inputs:
+    - `path` (string)
+  - Returns file as an embedded resource with:
+    - Base64-encoded content in `blob` property
+    - Automatic MIME type detection
+    - Support for Excel (.xlsx, .xls), PDF, images, and other binary formats
+  - Use this for files that need to be processed as binary data
+
 - **read_multiple_files**
   - Read multiple files simultaneously
   - Input: `paths` (string[])
@@ -190,6 +200,7 @@ The mapping for filesystem tools is:
 |-----------------------------|--------------|----------------|-----------------|--------------------------------------------------|
 | `read_text_file`            | `true`       | –              | –               | Pure read                                       |
 | `read_media_file`           | `true`       | –              | –               | Pure read                                       |
+| `read_binary_file`          | `true`       | –              | –               | Pure read                                       |
 | `read_multiple_files`       | `true`       | –              | –               | Pure read                                       |
 | `list_directory`            | `true`       | –              | –               | Pure read                                       |
 | `list_directory_with_sizes` | `true`       | –              | –               | Pure read                                       |

--- a/src/filesystem/__tests__/read-binary-file.test.ts
+++ b/src/filesystem/__tests__/read-binary-file.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+/**
+ * Integration tests for read_binary_file tool.
+ * Tests that binary files (Excel, PDF, images, etc.) can be read and returned as embedded resources.
+ */
+describe('read_binary_file tool', () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let testDir: string;
+
+  beforeEach(async () => {
+    // Create a temp directory for testing
+    // Use realpath to resolve symlinks (e.g., /var -> /private/var on macOS)
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-fs-binary-test-'));
+    testDir = await fs.realpath(tempDir);
+
+    // Create a minimal valid .xlsx file (ZIP format with PK header)
+    const xlsxPath = path.join(testDir, 'test.xlsx');
+    const minimalXlsx = Buffer.from([
+      0x50, 0x4B, 0x03, 0x04, // ZIP local file header signature
+      0x14, 0x00, 0x00, 0x00, 0x08, 0x00, // version, flags, compression
+      0x00, 0x00, 0x00, 0x00, // time, date
+      0x00, 0x00, 0x00, 0x00, // CRC-32
+      0x00, 0x00, 0x00, 0x00, // compressed size
+      0x00, 0x00, 0x00, 0x00, // uncompressed size
+      0x00, 0x00, // filename length
+      0x00, 0x00, // extra field length
+    ]);
+    await fs.writeFile(xlsxPath, minimalXlsx);
+
+    // Create a minimal .xls file (OLE2 format)
+    const xlsPath = path.join(testDir, 'test.xls');
+    const minimalXls = Buffer.from([
+      0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1, // OLE2 signature
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    await fs.writeFile(xlsPath, minimalXls);
+
+    // Create a simple PNG file (1x1 red pixel)
+    const pngPath = path.join(testDir, 'test.png');
+    const pngData = Buffer.from([
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+      0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+      0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1 dimensions
+      0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+      0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+      0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+      0x00, 0x03, 0x01, 0x01, 0x00, 0x18, 0xDD, 0x8D,
+      0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+      0x44, 0xAE, 0x42, 0x60, 0x82
+    ]);
+    await fs.writeFile(pngPath, pngData);
+
+    // Create a PDF file
+    const pdfPath = path.join(testDir, 'test.pdf');
+    const minimalPdf = Buffer.from('%PDF-1.4\n%EOF\n');
+    await fs.writeFile(pdfPath, minimalPdf);
+
+    // Start the MCP server
+    const serverPath = path.resolve(__dirname, '../dist/index.js');
+    transport = new StdioClientTransport({
+      command: 'node',
+      args: [serverPath, testDir],
+    });
+
+    client = new Client({
+      name: 'test-client',
+      version: '1.0.0',
+    }, {
+      capabilities: {}
+    });
+
+    await client.connect(transport);
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should read .xlsx file and return as embedded resource', async () => {
+    const xlsxPath = path.join(testDir, 'test.xlsx');
+    
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: xlsxPath }
+    });
+
+    // Check that we got content back
+    expect(result.content).toBeDefined();
+    expect(Array.isArray(result.content)).toBe(true);
+    const content = result.content as Array<any>;
+    expect(content.length).toBeGreaterThan(0);
+
+    // Check the content structure - should be a resource
+    const contentItem = content[0];
+    expect(contentItem.type).toBe('resource');
+    expect(contentItem.resource).toBeDefined();
+    
+    // Check resource properties
+    const resource = contentItem.resource;
+    expect(resource.uri).toBeDefined();
+    expect(resource.uri).toContain(xlsxPath);
+    expect(resource.mimeType).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(resource.blob).toBeDefined();
+
+    // Blob should be valid base64
+    expect(typeof resource.blob).toBe('string');
+    expect(resource.blob.length).toBeGreaterThan(0);
+    expect(/^[A-Za-z0-9+/]*={0,2}$/.test(resource.blob)).toBe(true);
+
+    // Verify we can decode the base64 back to original
+    const decoded = Buffer.from(resource.blob, 'base64');
+    const original = await fs.readFile(xlsxPath);
+    expect(decoded.equals(original)).toBe(true);
+  });
+
+  it('should read .xls file and return as embedded resource', async () => {
+    const xlsPath = path.join(testDir, 'test.xls');
+    
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: xlsPath }
+    });
+
+    const content = result.content as Array<any>;
+    const contentItem = content[0];
+    
+    expect(contentItem.type).toBe('resource');
+    expect(contentItem.resource.mimeType).toBe('application/vnd.ms-excel');
+    expect(contentItem.resource.blob).toBeDefined();
+
+    // Verify data integrity
+    const decoded = Buffer.from(contentItem.resource.blob, 'base64');
+    const original = await fs.readFile(xlsPath);
+    expect(decoded.equals(original)).toBe(true);
+  });
+
+  it('should read PNG file and return as embedded resource', async () => {
+    const pngPath = path.join(testDir, 'test.png');
+    
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: pngPath }
+    });
+
+    const content = result.content as Array<any>;
+    const contentItem = content[0];
+    
+    expect(contentItem.type).toBe('resource');
+    expect(contentItem.resource.mimeType).toBe('image/png');
+    expect(contentItem.resource.blob).toBeDefined();
+
+    // Verify data integrity
+    const decoded = Buffer.from(contentItem.resource.blob, 'base64');
+    const original = await fs.readFile(pngPath);
+    expect(decoded.equals(original)).toBe(true);
+  });
+
+  it('should read PDF file and return as embedded resource', async () => {
+    const pdfPath = path.join(testDir, 'test.pdf');
+    
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: pdfPath }
+    });
+
+    const content = result.content as Array<any>;
+    const contentItem = content[0];
+    
+    expect(contentItem.type).toBe('resource');
+    expect(contentItem.resource.mimeType).toBe('application/pdf');
+    expect(contentItem.resource.blob).toBeDefined();
+
+    // Verify data integrity
+    const decoded = Buffer.from(contentItem.resource.blob, 'base64');
+    const original = await fs.readFile(pdfPath);
+    expect(decoded.equals(original)).toBe(true);
+  });
+
+  it('should handle large files efficiently', async () => {
+    // Create a larger file (100KB)
+    const largePath = path.join(testDir, 'large.xlsx');
+    const largeData = Buffer.alloc(100 * 1024);
+    // Add ZIP header to make it look like a valid xlsx
+    largeData.write('PK\x03\x04', 0);
+    await fs.writeFile(largePath, largeData);
+
+    const startTime = Date.now();
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: largePath }
+    });
+    const endTime = Date.now();
+
+    // Should complete in reasonable time
+    expect(endTime - startTime).toBeLessThan(2000);
+
+    // Verify the data
+    const content = result.content as Array<any>;
+    const contentItem = content[0];
+    expect(contentItem.type).toBe('resource');
+    
+    const decoded = Buffer.from(contentItem.resource.blob, 'base64');
+    expect(decoded.length).toBe(100 * 1024);
+  });
+
+  it('should handle unknown file extensions with generic MIME type', async () => {
+    const unknownPath = path.join(testDir, 'test.xyz');
+    await fs.writeFile(unknownPath, Buffer.from('test data'));
+
+    const result = await client.callTool({
+      name: 'read_binary_file',
+      arguments: { path: unknownPath }
+    });
+
+    const content = result.content as Array<any>;
+    const contentItem = content[0];
+    
+    expect(contentItem.type).toBe('resource');
+    expect(contentItem.resource.mimeType).toBe('application/octet-stream');
+    expect(contentItem.resource.blob).toBeDefined();
+  });
+});
+
+// Made with Bob


### PR DESCRIPTION
added a read_binary_file tool to the file system MCP Server

## Description

## Server Details
- Server: filesystem
- Changes to: added read_binary_file tool

## Motivation and Context
I was trying to use the existing server to fetch an excel file and it fails

## How Has This Been Tested?
I have a custom agent that this works in and also include a unit test

## Breaking Changes
pure additive, although read_file should likely now be removed vs. just being marked deprecated

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
