### PR TITLE
feat(time): add time_ prefix to tool names for consistency

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -6,11 +6,11 @@ A Model Context Protocol server that provides time and timezone conversion capab
 
 ### Available Tools
 
-- `get_current_time` - Get current time in a specific timezone or system timezone.
+- `time_get_current` - Get current time in a specific timezone or system timezone.
   - Required arguments:
     - `timezone` (string): IANA timezone name (e.g., 'America/New_York', 'Europe/London')
 
-- `convert_time` - Convert time between timezones.
+- `time_convert` - Convert time between timezones.
   - Required arguments:
     - `source_timezone` (string): Source IANA timezone name
     - `time` (string): Time in 24-hour format (HH:MM)
@@ -201,7 +201,7 @@ Example:
 1. Get current time:
 ```json
 {
-  "name": "get_current_time",
+  "name": "time_get_current",
   "arguments": {
     "timezone": "Europe/Warsaw"
   }
@@ -219,7 +219,7 @@ Response:
 2. Convert time between timezones:
 ```json
 {
-  "name": "convert_time",
+  "name": "time_convert",
   "arguments": {
     "source_timezone": "America/New_York",
     "time": "16:30",

--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -15,8 +15,8 @@ from pydantic import BaseModel
 
 
 class TimeTools(str, Enum):
-    GET_CURRENT_TIME = "get_current_time"
-    CONVERT_TIME = "convert_time"
+    GET_CURRENT_TIME = "time_get_current"
+    CONVERT_TIME = "time_convert"
 
 
 class TimeResult(BaseModel):


### PR DESCRIPTION
## Summary

Adds a `time_` prefix to the Time MCP server tool names for consistency with other MCP servers:

- `get_current_time` → `time_get_current`
- `convert_time` → `time_convert`

## Motivation

This follows the naming convention used by other MCP servers (e.g., `git_status`, `git_commit`, `git_diff`) and makes it easier to identify related tools when multiple MCP servers are registered with a client.

As noted in [issue #3201](https://github.com/modelcontextprotocol/servers/issues/3201), users integrating multiple MCP servers see tool names like:
- `MCP_DOCKER_convert_time`
- `MCP_DOCKER_get_current_time`

With this change, the tools become:
- `MCP_DOCKER_time_get_current`
- `MCP_DOCKER_time_convert`

This makes it immediately clear these tools belong to the Time server.

## Changes

- Updated tool name enum values in `server.py`
- Updated README documentation and examples

## Breaking Change Notice

⚠️ This is a breaking change for existing users of the Time MCP server. Any automation or configuration referencing the old tool names (`get_current_time`, `convert_time`) will need to be updated.

Closes #3201