### PR TITLE
fix(fetch): update to httpx 0.28+ proxy parameter

### DIFF
--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "httpx<0.28",
+    "httpx>=0.27",
     "markdownify>=0.13.1",
     "mcp>=1.1.3",
     "protego>=0.3.1",

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -72,7 +72,7 @@ async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url:
 
     robot_txt_url = get_robots_txt_url(url)
 
-    async with AsyncClient(proxies=proxy_url) as client:
+    async with AsyncClient(proxy=proxy_url) as client:
         try:
             response = await client.get(
                 robot_txt_url,
@@ -116,7 +116,7 @@ async def fetch_url(
     """
     from httpx import AsyncClient, HTTPError
 
-    async with AsyncClient(proxies=proxy_url) as client:
+    async with AsyncClient(proxy=proxy_url) as client:
         try:
             response = await client.get(
                 url,

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -323,4 +323,4 @@ class TestFetchUrl:
             )
 
             # Verify AsyncClient was called with proxy
-            mock_client_class.assert_called_once_with(proxies="http://proxy.example.com:8080")
+            mock_client_class.assert_called_once_with(proxy="http://proxy.example.com:8080")


### PR DESCRIPTION
The httpx library renamed `proxies` to `proxy` in version 0.28.0. This was causing a TypeError when using the --proxy-url argument.

Changes:
- Update `AsyncClient(proxies=...)` calls to use `proxy=` parameter
- Remove version cap on httpx dependency (was `<0.28`)
- Update test assertions to match new parameter name

Fixes #3287