### PR TITLE
Add mcp-safety-scanner CI (baseline)

### DIFF
--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@b37568ec70ebd233e0516e2263fe4fce58ad0969 # v0.4.6
+      - uses: TheodorNEngoy/mcp-safety-scanner@2e4512a3bc199a38b5c00e41daea8abdc1e39811 # v0.4.7
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@2e4512a3bc199a38b5c00e41daea8abdc1e39811 # v0.4.7
+      - uses: TheodorNEngoy/mcp-safety-scanner@5ecea148c56d0e38b297623f9eb6b467e2fccf71 # v0.4.8
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@7fd13fc55cb5c21cb1611f0eda4c9ac4da411b71 # v0.3.3
+      - uses: TheodorNEngoy/mcp-safety-scanner@dcf124b4f97aa893867ced9028264a298e2b4292 # v0.3.5
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@5ecea148c56d0e38b297623f9eb6b467e2fccf71 # v0.4.8
+      - uses: TheodorNEngoy/mcp-safety-scanner@5e09227cf63d559ec211ad3d99dfd3272c5a31c3 # v0.4.9
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -1,0 +1,33 @@
+name: MCP Safety Scan
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - ".github/workflows/mcp-safety-scan.yml"
+      - ".mcp-safety-baseline.json"
+  pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/mcp-safety-scan.yml"
+      - ".mcp-safety-baseline.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: TheodorNEngoy/mcp-safety-scanner@v0
+        with:
+          path: src
+          baseline: .mcp-safety-baseline.json
+          fail-on: high
+          format: github
+

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@a9f2724b4a8732e291146eb7569dc571ebf6f51b # v0.3.6
+      - uses: TheodorNEngoy/mcp-safety-scanner@1b38cabea5b6fe9c3c4baea13a3a209f862efb8b # v0.4.1
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@dcf124b4f97aa893867ced9028264a298e2b4292 # v0.3.5
+      - uses: TheodorNEngoy/mcp-safety-scanner@a9f2724b4a8732e291146eb7569dc571ebf6f51b # v0.3.6
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
 
       # Pin the action version for supply-chain safety.
-      - uses: TheodorNEngoy/mcp-safety-scanner@1b38cabea5b6fe9c3c4baea13a3a209f862efb8b # v0.4.1
+      - uses: TheodorNEngoy/mcp-safety-scanner@b37568ec70ebd233e0516e2263fe4fce58ad0969 # v0.4.6
         with:
           path: src
           baseline: .mcp-safety-baseline.json

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -21,9 +21,9 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/mcp-safety-scan.yml
+++ b/.github/workflows/mcp-safety-scan.yml
@@ -14,6 +14,9 @@ on:
       - ".github/workflows/mcp-safety-scan.yml"
       - ".mcp-safety-baseline.json"
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -24,10 +27,10 @@ jobs:
         with:
           node-version: 20
 
-      - uses: TheodorNEngoy/mcp-safety-scanner@v0
+      # Pin the action version for supply-chain safety.
+      - uses: TheodorNEngoy/mcp-safety-scanner@7fd13fc55cb5c21cb1611f0eda4c9ac4da411b71 # v0.3.3
         with:
           path: src
           baseline: .mcp-safety-baseline.json
           fail-on: high
           format: github
-

--- a/.mcp-safety-baseline.json
+++ b/.mcp-safety-baseline.json
@@ -1,33 +1,53 @@
 {
-  "version": 1,
+  "version": 2,
   "tool": "mcp-safety-scanner",
-  "generatedAt": "2026-02-08T01:11:19.241Z",
+  "generatedAt": "2026-02-08T18:53:00.598Z",
   "fingerprints": [
-    "5b247d1df57644d8c2fcf020c4a1bebb0df81a6206f3e28ca63a36f9ad8629ce",
-    "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
-    "8c6d459b9fe3fd08e618346ea8642343203edc21ba8e7d2aad85c3603aef3529"
+    "1080301ccc119b431825933246b66e42e8bb0e6aa4a286a27f6bf38639054e48",
+    "92abe3840e2e6c28655320eb095aefaaa3c766c73c9bb2e2a68b0255a3a8fcb6",
+    "b9bbbaf2acab0552d78b2e857daeb99e6d3f3ca0abfa1710540e97bb1998db97",
+    "e7805b7df03dde0ac35d234b54585a60d470e869e45d59b87f6d941757fc20a6"
   ],
   "entries": [
     {
-      "fingerprint": "5b247d1df57644d8c2fcf020c4a1bebb0df81a6206f3e28ca63a36f9ad8629ce",
-      "ruleId": "cors-wildcard-origin",
-      "severity": "high",
-      "file": "everything/transports/sse.ts",
-      "excerpt": "cors({"
-    },
-    {
-      "fingerprint": "8c6d459b9fe3fd08e618346ea8642343203edc21ba8e7d2aad85c3603aef3529",
-      "ruleId": "cors-wildcard-origin",
-      "severity": "high",
-      "file": "everything/transports/streamableHttp.ts",
-      "excerpt": "cors({"
-    },
-    {
-      "fingerprint": "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
+      "fingerprint": "1080301ccc119b431825933246b66e42e8bb0e6aa4a286a27f6bf38639054e48",
       "ruleId": "file-delete-apis",
       "severity": "medium",
       "file": "filesystem/lib.ts",
-      "excerpt": "await fs.unlink(tempPath);"
+      "excerpt": "await fs.unlink(tempPath);",
+      "context": "",
+      "line": 154,
+      "column": 20
+    },
+    {
+      "fingerprint": "92abe3840e2e6c28655320eb095aefaaa3c766c73c9bb2e2a68b0255a3a8fcb6",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/lib.ts",
+      "excerpt": "await fs.unlink(tempPath);",
+      "context": "",
+      "line": 252,
+      "column": 18
+    },
+    {
+      "fingerprint": "b9bbbaf2acab0552d78b2e857daeb99e6d3f3ca0abfa1710540e97bb1998db97",
+      "ruleId": "cors-wildcard-origin",
+      "severity": "high",
+      "file": "everything/transports/streamableHttp.ts",
+      "excerpt": "cors({",
+      "context": "cors({ origin: \"*\", // use \"*\" with caution in production methods: \"GET,POST,DELETE\", preflightContinue: false, optionsSuccessStatus: 204, exposedHeaders: [\"mcp-session-id\", \"last-event-id\", \"mcp-protocol-version\"], }) );",
+      "line": 44,
+      "column": 3
+    },
+    {
+      "fingerprint": "e7805b7df03dde0ac35d234b54585a60d470e869e45d59b87f6d941757fc20a6",
+      "ruleId": "cors-wildcard-origin",
+      "severity": "high",
+      "file": "everything/transports/sse.ts",
+      "excerpt": "cors({",
+      "context": "cors({ origin: \"*\", // use \"*\" with caution in production methods: \"GET,POST\", preflightContinue: false, optionsSuccessStatus: 204, }) ); const transports: Map<string, SSEServerTransport> = new Map<",
+      "line": 11,
+      "column": 3
     }
   ]
 }

--- a/.mcp-safety-baseline.json
+++ b/.mcp-safety-baseline.json
@@ -1,0 +1,133 @@
+{
+  "version": 1,
+  "tool": "mcp-safety-scanner",
+  "generatedAt": "2026-02-06T22:32:45.334Z",
+  "fingerprints": [
+    "02410ad395be4f98efe0dd7d4c3b55f637c6332ad612109194e40f73ddbdc58b",
+    "20ea9924fb8c695dd78758548be2ecb2933cb42ff959f3c554557345ac4b7980",
+    "22116cd74b04c873c1c1973258a48865663129bae24427bedd426f03750aa93f",
+    "5f062db381642e6b9911427afc31ec7badbdfad8a759ffe313afa65241630211",
+    "80481e00889801884b574675f1f4f53b33f46bc9be8af7f43b92c6e81d7193e0",
+    "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
+    "cae5e08ed72eb1188f4f3dea0bbe754864dd905b7fce3f626b453b904d401e7b",
+    "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
+    "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
+    "f6fd182ee3cca1e2535a1076c2001d0f71832e644eee80af342a226ecf0e74f3",
+    "f96122a88040d6f0ee21ae245e33196b51a9e3c38ea5aff7e9a5892426229b48",
+    "fd280dede9985170152ebf01cb12126178c34efab6f932636e19fab3971f58cf"
+  ],
+  "entries": [
+    {
+      "fingerprint": "cae5e08ed72eb1188f4f3dea0bbe754864dd905b7fce3f626b453b904d401e7b",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/directory-tree.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/path-validation.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/path-validation.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/path-validation.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/path-validation.test.ts",
+      "excerpt": "await fs.unlink(legitFile);"
+    },
+    {
+      "fingerprint": "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/path-validation.test.ts",
+      "excerpt": "await fs.unlink(legitFile);"
+    },
+    {
+      "fingerprint": "f6fd182ee3cca1e2535a1076c2001d0f71832e644eee80af342a226ecf0e74f3",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/roots-utils.test.ts",
+      "excerpt": "rmSync(testDir1, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "02410ad395be4f98efe0dd7d4c3b55f637c6332ad612109194e40f73ddbdc58b",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/roots-utils.test.ts",
+      "excerpt": "rmSync(testDir2, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "f96122a88040d6f0ee21ae245e33196b51a9e3c38ea5aff7e9a5892426229b48",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/roots-utils.test.ts",
+      "excerpt": "rmSync(testDir3, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "80481e00889801884b574675f1f4f53b33f46bc9be8af7f43b92c6e81d7193e0",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/startup-validation.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "fd280dede9985170152ebf01cb12126178c34efab6f932636e19fab3971f58cf",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/__tests__/structured-content.test.ts",
+      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+    },
+    {
+      "fingerprint": "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/lib.ts",
+      "excerpt": "await fs.unlink(tempPath);"
+    },
+    {
+      "fingerprint": "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "filesystem/lib.ts",
+      "excerpt": "await fs.unlink(tempPath);"
+    },
+    {
+      "fingerprint": "5f062db381642e6b9911427afc31ec7badbdfad8a759ffe313afa65241630211",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "memory/__tests__/file-path.test.ts",
+      "excerpt": "await fs.unlink(oldMemoryPath);"
+    },
+    {
+      "fingerprint": "20ea9924fb8c695dd78758548be2ecb2933cb42ff959f3c554557345ac4b7980",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "memory/__tests__/file-path.test.ts",
+      "excerpt": "await fs.unlink(newMemoryPath);"
+    },
+    {
+      "fingerprint": "22116cd74b04c873c1c1973258a48865663129bae24427bedd426f03750aa93f",
+      "ruleId": "file-delete-apis",
+      "severity": "medium",
+      "file": "memory/__tests__/knowledge-graph.test.ts",
+      "excerpt": "await fs.unlink(testFilePath);"
+    }
+  ]
+}

--- a/.mcp-safety-baseline.json
+++ b/.mcp-safety-baseline.json
@@ -1,98 +1,26 @@
 {
   "version": 1,
   "tool": "mcp-safety-scanner",
-  "generatedAt": "2026-02-06T22:32:45.334Z",
+  "generatedAt": "2026-02-08T01:11:19.241Z",
   "fingerprints": [
-    "02410ad395be4f98efe0dd7d4c3b55f637c6332ad612109194e40f73ddbdc58b",
-    "20ea9924fb8c695dd78758548be2ecb2933cb42ff959f3c554557345ac4b7980",
-    "22116cd74b04c873c1c1973258a48865663129bae24427bedd426f03750aa93f",
-    "5f062db381642e6b9911427afc31ec7badbdfad8a759ffe313afa65241630211",
-    "80481e00889801884b574675f1f4f53b33f46bc9be8af7f43b92c6e81d7193e0",
+    "5b247d1df57644d8c2fcf020c4a1bebb0df81a6206f3e28ca63a36f9ad8629ce",
     "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
-    "cae5e08ed72eb1188f4f3dea0bbe754864dd905b7fce3f626b453b904d401e7b",
-    "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
-    "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
-    "f6fd182ee3cca1e2535a1076c2001d0f71832e644eee80af342a226ecf0e74f3",
-    "f96122a88040d6f0ee21ae245e33196b51a9e3c38ea5aff7e9a5892426229b48",
-    "fd280dede9985170152ebf01cb12126178c34efab6f932636e19fab3971f58cf"
+    "8c6d459b9fe3fd08e618346ea8642343203edc21ba8e7d2aad85c3603aef3529"
   ],
   "entries": [
     {
-      "fingerprint": "cae5e08ed72eb1188f4f3dea0bbe754864dd905b7fce3f626b453b904d401e7b",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/directory-tree.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+      "fingerprint": "5b247d1df57644d8c2fcf020c4a1bebb0df81a6206f3e28ca63a36f9ad8629ce",
+      "ruleId": "cors-wildcard-origin",
+      "severity": "high",
+      "file": "everything/transports/sse.ts",
+      "excerpt": "cors({"
     },
     {
-      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/path-validation.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/path-validation.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "e719a3e7fd8bcfbcd83b1c415465724f1e9244850d6ff79cd5db22022025fd14",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/path-validation.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/path-validation.test.ts",
-      "excerpt": "await fs.unlink(legitFile);"
-    },
-    {
-      "fingerprint": "edc274e6867eb9ba856d66b6be112628fad9cf3e4fadae83a2f563bca94c47ae",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/path-validation.test.ts",
-      "excerpt": "await fs.unlink(legitFile);"
-    },
-    {
-      "fingerprint": "f6fd182ee3cca1e2535a1076c2001d0f71832e644eee80af342a226ecf0e74f3",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/roots-utils.test.ts",
-      "excerpt": "rmSync(testDir1, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "02410ad395be4f98efe0dd7d4c3b55f637c6332ad612109194e40f73ddbdc58b",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/roots-utils.test.ts",
-      "excerpt": "rmSync(testDir2, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "f96122a88040d6f0ee21ae245e33196b51a9e3c38ea5aff7e9a5892426229b48",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/roots-utils.test.ts",
-      "excerpt": "rmSync(testDir3, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "80481e00889801884b574675f1f4f53b33f46bc9be8af7f43b92c6e81d7193e0",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/startup-validation.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
-    },
-    {
-      "fingerprint": "fd280dede9985170152ebf01cb12126178c34efab6f932636e19fab3971f58cf",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/__tests__/structured-content.test.ts",
-      "excerpt": "await fs.rm(testDir, { recursive: true, force: true });"
+      "fingerprint": "8c6d459b9fe3fd08e618346ea8642343203edc21ba8e7d2aad85c3603aef3529",
+      "ruleId": "cors-wildcard-origin",
+      "severity": "high",
+      "file": "everything/transports/streamableHttp.ts",
+      "excerpt": "cors({"
     },
     {
       "fingerprint": "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
@@ -100,34 +28,6 @@
       "severity": "medium",
       "file": "filesystem/lib.ts",
       "excerpt": "await fs.unlink(tempPath);"
-    },
-    {
-      "fingerprint": "8963bde5a243de8f8bb4db469176e2348a070c9ce45f69327230b08e6e06afe8",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "filesystem/lib.ts",
-      "excerpt": "await fs.unlink(tempPath);"
-    },
-    {
-      "fingerprint": "5f062db381642e6b9911427afc31ec7badbdfad8a759ffe313afa65241630211",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "memory/__tests__/file-path.test.ts",
-      "excerpt": "await fs.unlink(oldMemoryPath);"
-    },
-    {
-      "fingerprint": "20ea9924fb8c695dd78758548be2ecb2933cb42ff959f3c554557345ac4b7980",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "memory/__tests__/file-path.test.ts",
-      "excerpt": "await fs.unlink(newMemoryPath);"
-    },
-    {
-      "fingerprint": "22116cd74b04c873c1c1973258a48865663129bae24427bedd426f03750aa93f",
-      "ruleId": "file-delete-apis",
-      "severity": "medium",
-      "file": "memory/__tests__/knowledge-graph.test.ts",
-      "excerpt": "await fs.unlink(testFilePath);"
     }
   ]
 }


### PR DESCRIPTION
Adds a lightweight MCP/tool-server safety scan in CI using TheodorNEngoy/mcp-safety-scanner@v0.

- Scans `src` for common footguns (CORS allow-all/reflect, eval/exec, etc.)
- Uses a committed baseline (`.mcp-safety-baseline.json`) to avoid noisy legacy findings
- CI fails only on `high`+ severity (medium/low show as annotations)

Refresh baseline (no Node required):
`docker run --rm -v "/tmp/mcp-servers.2eGvhp:/repo" ghcr.io/theodornengoy/mcp-safety-scanner:v0 /repo/src --write-baseline /repo/.mcp-safety-baseline.json --fail-on=none`