### PR TITLE
fix(filesystem): handle Windows EPERM when renaming over locked files

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -279,10 +279,65 @@ describe('Lib Functions', () => {
     describe('writeFileContent', () => {
       it('writes file content', async () => {
         mockFs.writeFile.mockResolvedValueOnce(undefined);
-        
+
         await writeFileContent('/test/file.txt', 'new content');
-        
+
         expect(mockFs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'new content', { encoding: "utf-8", flag: 'wx' });
+      });
+
+      it('falls back to fs.cp when fs.rename fails with EPERM (Windows locked file)', async () => {
+        // First write fails because file exists
+        const eexistError = new Error('EEXIST') as NodeJS.ErrnoException;
+        eexistError.code = 'EEXIST';
+
+        // Rename fails with EPERM (Windows file lock)
+        const epermError = new Error('EPERM') as NodeJS.ErrnoException;
+        epermError.code = 'EPERM';
+
+        mockFs.writeFile
+          .mockRejectedValueOnce(eexistError)  // First write fails (file exists)
+          .mockResolvedValueOnce(undefined);    // Temp file write succeeds
+        mockFs.rename.mockRejectedValueOnce(epermError);
+        mockFs.cp.mockResolvedValueOnce(undefined);
+        mockFs.unlink.mockResolvedValueOnce(undefined);
+
+        await writeFileContent('/test/file.txt', 'new content');
+
+        // Should have tried rename first, then fallen back to cp + unlink
+        expect(mockFs.rename).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          '/test/file.txt'
+        );
+        expect(mockFs.cp).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          '/test/file.txt',
+          { force: true }
+        );
+        expect(mockFs.unlink).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/)
+        );
+      });
+
+      it('propagates non-EPERM errors from fs.rename', async () => {
+        // First write fails because file exists
+        const eexistError = new Error('EEXIST') as NodeJS.ErrnoException;
+        eexistError.code = 'EEXIST';
+
+        // Rename fails with EACCES (not EPERM)
+        const eaccesError = new Error('EACCES') as NodeJS.ErrnoException;
+        eaccesError.code = 'EACCES';
+
+        mockFs.writeFile
+          .mockRejectedValueOnce(eexistError)
+          .mockResolvedValueOnce(undefined);
+        mockFs.rename.mockRejectedValueOnce(eaccesError);
+        mockFs.unlink.mockResolvedValueOnce(undefined); // Cleanup of temp file
+
+        await expect(writeFileContent('/test/file.txt', 'content'))
+          .rejects.toThrow('EACCES');
+
+        // Should not have tried cp fallback
+        expect(mockFs.cp).not.toHaveBeenCalled();
       });
     });
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -135,6 +135,27 @@ export async function readFileContent(filePath: string, encoding: string = 'utf-
   return await fs.readFile(filePath, encoding as BufferEncoding);
 }
 
+/**
+ * Atomically replaces a file by renaming a temporary file over it.
+ * On Windows, fs.rename() fails with EPERM when the target file is locked
+ * by another process (e.g., open in an editor). This function falls back
+ * to fs.cp() + fs.unlink() which can overwrite locked files.
+ */
+async function atomicReplaceFile(tempPath: string, targetPath: string): Promise<void> {
+  try {
+    await fs.rename(tempPath, targetPath);
+  } catch (error) {
+    // On Windows, rename fails with EPERM if target file is locked by another process
+    if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+      // Fallback: copy over the locked file, then remove temp file
+      await fs.cp(tempPath, targetPath, { force: true });
+      await fs.unlink(tempPath);
+    } else {
+      throw error;
+    }
+  }
+}
+
 export async function writeFileContent(filePath: string, content: string): Promise<void> {
   try {
     // Security: 'wx' flag ensures exclusive creation - fails if file/symlink exists,
@@ -148,12 +169,12 @@ export async function writeFileContent(filePath: string, content: string): Promi
       const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
       try {
         await fs.writeFile(tempPath, content, 'utf-8');
-        await fs.rename(tempPath, filePath);
-      } catch (renameError) {
+        await atomicReplaceFile(tempPath, filePath);
+      } catch (replaceError) {
         try {
           await fs.unlink(tempPath);
         } catch {}
-        throw renameError;
+        throw replaceError;
       }
     } else {
       throw error;
@@ -246,7 +267,7 @@ export async function applyFileEdits(
     const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
     try {
       await fs.writeFile(tempPath, modifiedContent, 'utf-8');
-      await fs.rename(tempPath, filePath);
+      await atomicReplaceFile(tempPath, filePath);
     } catch (error) {
       try {
         await fs.unlink(tempPath);


### PR DESCRIPTION
On Windows, fs.rename() fails with EPERM when the target file is locked by another process (e.g., open in an editor). This adds a fallback that uses fs.cp() + fs.unlink() when EPERM is encountered, allowing edits to succeed even when the file is open.

Fixes #3199

<!-- Provide a brief description of your changes -->

## Description
Adds atomicReplaceFile() helper that falls back to fs.cp() when fs.rename() fails with EPERM.

## Publishing Your Server

**Note: We are no longer accepting PRs to add servers to the README.** Instead, please publish your server to the [MCP Server Registry](https://github.com/modelcontextprotocol/registry) to make it discoverable to the MCP ecosystem.

To publish your server, follow the [quickstart guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx). You can browse published servers at [https://registry.modelcontextprotocol.io/](https://registry.modelcontextprotocol.io/).

## Server Details
  - Server: filesystem
  - Changes to: tools (edit_file, write_file)

## Motivation and Context
On Windows, files open in editors (VS Code, Notepad, etc.) are locked. The current fs.rename() approach fails with EPERM when trying to atomically replace these locked files. This prevents users from editing files they have open.

## How Has This Been Tested?
Unit tests added for EPERM fallback behavior. All 46 lib.test.ts tests pass.

## Breaking Changes
None - existing behavior unchanged on Linux/macOS. Windows users will now have edits succeed where they previously failed.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

