### PR TITLE
fix(memory): return relations connected to requested nodes in openNodes/searchNodes

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -197,9 +197,10 @@ export class KnowledgeGraphManager {
     // Create a Set of filtered entity names for quick lookup
     const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
   
-    // Filter relations to only include those between filtered entities
+    // Include relations where at least one endpoint matches the search results.
+    // This lets callers discover connections to nodes outside the result set.
     const filteredRelations = graph.relations.filter(r => 
-      filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
   
     const filteredGraph: KnowledgeGraph = {
@@ -219,9 +220,12 @@ export class KnowledgeGraphManager {
     // Create a Set of filtered entity names for quick lookup
     const filteredEntityNames = new Set(filteredEntities.map(e => e.name));
   
-    // Filter relations to only include those between filtered entities
+    // Include relations where at least one endpoint is in the requested set.
+    // Previously this required BOTH endpoints, which meant relations from a
+    // requested node to an unrequested node were silently dropped — making it
+    // impossible to discover a node's connections without reading the full graph.
     const filteredRelations = graph.relations.filter(r => 
-      filteredEntityNames.has(r.from) && filteredEntityNames.has(r.to)
+      filteredEntityNames.has(r.from) || filteredEntityNames.has(r.to)
     );
   
     const filteredGraph: KnowledgeGraph = {


### PR DESCRIPTION
## Human View

### Summary

Fixes #3137 — `open_nodes` returns empty relations array despite entity having relations in graph.

**Root cause:** Both `openNodes()` and `searchNodes()` filter relations using `&&` (require BOTH endpoints to be in the result set). This means if you call `open_nodes(["A"])` and there's a relation `A → B`, it gets silently dropped because `B` isn't in the filtered set.

**Fix:** Changed the relation filter from `&&` to `||` — include any relation where **at least one** endpoint is in the result set. This matches standard graph-query semantics: opening a node should reveal all its edges, not just edges to other opened nodes.

#### Before (broken)
```
open_nodes(["2025-12-17"])
→ entities: [2025-12-17], relations: []  // relations silently dropped!
```

#### After (fixed)
```
open_nodes(["2025-12-17"])
→ entities: [2025-12-17], relations: [{from: "2025-12-17", to: "incident/example", ...}]
```

### Changes

- `src/memory/index.ts`: Changed `&&` → `||` in relation filtering for both `openNodes()` and `searchNodes()`
- `src/memory/__tests__/knowledge-graph.test.ts`: Updated existing tests and added new cases:
  - Outgoing relations to nodes not in the open set
  - Incoming relations from nodes not in the open set
  - Relations connected to a single opened node (both directions)
  - `searchNodes` returning outgoing relations to unmatched entities

### Test plan

- [x] All 45 existing tests pass (`vitest run`)
- [x] New tests verify outgoing/incoming relations are returned for single-node queries
- [x] `read_graph` behavior unchanged (returns all relations)
- [x] Empty node list still returns empty graph
- [x] Non-existent nodes still return empty result

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix
4. Verified lint/formatting compliance

### Human Review Guidance
- Core changes are in: `src/memory/index.ts`, `src/memory/__tests__/knowledge-graph.test.ts`

Made with M7 [Cursor](https://cursor.com)
