### PR TITLE
everything: safer CORS + loopback bind for HTTP transports

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -70,12 +70,24 @@ npm install
 npm run start:sse
 ```
 
+Note: the SSE transport binds to `127.0.0.1` by default and only enables CORS for loopback origins (for Inspector direct connect). To intentionally expose it, set:
+
+```shell
+HOST=0.0.0.0 MCP_CORS_ORIGIN_REGEX='^https?://your-allowed-origin(:\\d+)?$' npm run start:sse
+```
+
 ## Run from source with [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
 
 ```shell
 cd src/everything
 npm install
 npm run start:streamableHttp
+```
+
+Note: the Streamable HTTP transport binds to `127.0.0.1` by default and only enables CORS for loopback origins (for Inspector direct connect). To intentionally expose it, set:
+
+```shell
+HOST=0.0.0.0 MCP_CORS_ORIGIN_REGEX='^https?://your-allowed-origin(:\\d+)?$' npm run start:streamableHttp
 ```
 
 ## Running as an installed package
@@ -103,4 +115,3 @@ npx @modelcontextprotocol/server-everything sse
 ```shell
 npx @modelcontextprotocol/server-everything streamableHttp
 ```
-

--- a/src/everything/transports/cors.ts
+++ b/src/everything/transports/cors.ts
@@ -1,0 +1,38 @@
+import type { CorsOptions } from "cors";
+
+const DEFAULT_LOOPBACK_ORIGIN_REGEX =
+  /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+function getCorsOriginRegex(): RegExp {
+  const raw = process.env.MCP_CORS_ORIGIN_REGEX;
+  if (!raw) return DEFAULT_LOOPBACK_ORIGIN_REGEX;
+
+  try {
+    return new RegExp(raw);
+  } catch (err) {
+    // Fail fast with a clear message instead of silently allowing all origins.
+    throw new Error(
+      `Invalid MCP_CORS_ORIGIN_REGEX=${JSON.stringify(raw)}: ${String(err)}`
+    );
+  }
+}
+
+export function createCorsOptions(opts: {
+  methods: string;
+  exposedHeaders?: string[];
+}): CorsOptions {
+  const originRegex = getCorsOriginRegex();
+
+  return {
+    // Only allow loopback origins by default (Inspector direct connect).
+    // Override via MCP_CORS_ORIGIN_REGEX if you intentionally need a wider allowlist.
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, false);
+      return callback(null, originRegex.test(origin));
+    },
+    methods: opts.methods,
+    preflightContinue: false,
+    optionsSuccessStatus: 204,
+    ...(opts.exposedHeaders ? { exposedHeaders: opts.exposedHeaders } : {}),
+  };
+}


### PR DESCRIPTION
The Everything server's HTTP transports currently:
- Bind to all interfaces by default (`app.listen(PORT)`)
- Use wildcard CORS (`origin: "*"`) for Inspector direct connect

This is a common local-dev footgun when running an MCP server that exposes powerful tools: any LAN host can connect, and any website can issue browser requests.

Changes:
- Bind SSE + Streamable HTTP transports to `127.0.0.1` by default (override with `HOST=0.0.0.0` when intentionally exposing)
- Replace wildcard CORS with a loopback-only allowlist by default (localhost/127.0.0.1/[::1])
- Add `MCP_CORS_ORIGIN_REGEX` to intentionally widen the browser allowlist
- Document the overrides in `src/everything/README.md`

No changes to the stdio transport.