### PR TITLE
docs(time): add explicit uvx command to installation section

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -23,6 +23,10 @@ A Model Context Protocol server that provides time and timezone conversion capab
 When using [`uv`](https://docs.astral.sh/uv/) no specific installation is needed. We will
 use [`uvx`](https://docs.astral.sh/uv/guides/tools/) to directly run *mcp-server-time*.
 
+```bash
+uvx mcp-server-time
+```
+
 ### Using PIP
 
 Alternatively you can install `mcp-server-time` via pip:


### PR DESCRIPTION
## Summary
- Added the missing `uvx mcp-server-time` command to the "Using uv (recommended)" installation section in the Time MCP server README
- The PIP section already showed explicit install/run commands, but the uv section only described using uvx without showing the actual command, making it harder for new users to get started

## Test plan
- [x] Verify the README renders correctly on GitHub
- [x] Confirm `uvx mcp-server-time` runs the server as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)