### PR TITLE
fix(sequentialthinking): prevent unbounded memory growth in thought history

### DIFF
--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -77,7 +77,12 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
-To disable logging of thought information set env var: `DISABLE_THOUGHT_LOGGING` to `true`.
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DISABLE_THOUGHT_LOGGING` | Set to `true` to disable logging thought output to stderr | `false` |
+| `SEQUENTIAL_THINKING_MAX_HISTORY` | Maximum number of thoughts retained in memory. Oldest thoughts are trimmed when exceeded. | `1000` |
 Comment
 
 ### Usage with VS Code

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -106,6 +106,21 @@ You should:
   }
 );
 
+server.registerTool(
+  "sequentialthinking_clear",
+  {
+    title: "Clear Thinking History",
+    description:
+      "Clears all stored thought history and branch data to free memory. " +
+      "Use this after completing a thinking session to prevent memory buildup " +
+      "in long-running server instances.",
+    inputSchema: {},
+  },
+  async () => {
+    return thinkingServer.clearHistory();
+  }
+);
+
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary

Fixes #2912 — The `SequentialThinkingServer` stores all thoughts in memory arrays (`thoughtHistory` and `branches`) that grow without bound across the server process lifetime. In long-running sessions (6-8+ hours of frequent use), this can lead to **10GB+ RAM consumption**.

## Root Cause

`thoughtHistory: ThoughtData[]` and `branches: Record<string, ThoughtData[]>` are append-only — thoughts are pushed but never removed or trimmed. Since the server is a long-lived stdio process, memory accumulates indefinitely.

## Changes

### 1. Configurable max history with auto-trimming (`lib.ts`)
- Added `SEQUENTIAL_THINKING_MAX_HISTORY` environment variable (default: `1000`)
- When thought count exceeds the limit, oldest thoughts are trimmed via `splice()`
- This bounds memory usage to a predictable maximum regardless of session length

### 2. Explicit `clearHistory()` method (`lib.ts`)
- New public method that resets both `thoughtHistory` and `branches` to empty
- Returns metadata about what was cleared (previous thought/branch counts)

### 3. New `sequentialthinking_clear` tool (`index.ts`)
- Registers a tool that clients can invoke to explicitly free memory
- Useful between distinct thinking sessions within the same server process

### 4. Documentation (`README.md`)
- Added environment variables table documenting both `DISABLE_THOUGHT_LOGGING` and the new `SEQUENTIAL_THINKING_MAX_HISTORY`

### 5. Tests (`lib.test.ts`)
- `clearHistory` — verifies thoughts and branches are fully reset
- Memory management — verifies history trimming at default limit
- Environment variable — verifies custom `SEQUENTIAL_THINKING_MAX_HISTORY` is respected

## Testing

All 17 tests pass:
```
✓ __tests__/lib.test.ts (17 tests) 4ms
Test Files  1 passed (1)
     Tests  17 passed (17)
```

## Design Decisions

- **Default limit of 1000**: Conservative — retains substantial context while preventing runaway growth. A single thought is typically a few hundred bytes of text, so 1000 thoughts ≈ a few hundred KB.
- **Trim oldest first**: Most recent thoughts are the most relevant for ongoing reasoning. Oldest thoughts are the least likely to be referenced.
- **Separate clear tool**: Allows explicit memory management without losing the auto-trim safety net.