### PR TITLE
Add Baozi.bet to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Azure Wiki Search](https://github.com/coder-linping/azure-wiki-search-server)** - An MCP that enables AI to query the wiki hosted on Azure Devops Wiki.
 - **[Baidu AI Search](https://github.com/baidubce/app-builder/tree/master/python/mcp_server/ai_search)** - Web search with Baidu Cloud's AI Search
 - **[BambooHR MCP](https://github.com/encoreshao/bamboohr-mcp)** - An MCP server that interfaces with the BambooHR APIs, providing access to employee data, time tracking, and HR management features.
+- **[Baozi.bet](https://github.com/bolivian-peru/baozi-mcp)** - Solana prediction markets with 68 tools for browsing markets, placing bets (pari-mutuel), claiming winnings, creating markets, and earning affiliate commissions. Builds unsigned transactions for wallet signing.
 - **[Base Free USDC Transfer](https://github.com/magnetai/mcp-free-usdc-transfer)** - Send USDC on [Base](https://base.org) for free using Claude AI! Built with [Coinbase CDP](https://docs.cdp.coinbase.com/mpc-wallet/docs/welcome).
 - **[Basic Memory](https://github.com/basicmachines-co/basic-memory)** - Local-first knowledge management system that builds a semantic graph from Markdown files, enabling persistent memory across conversations with LLMs.
 - **[BGG MCP](https://github.com/kkjdaniel/bgg-mcp)** (by kkjdaniel) - MCP to enable interaction with the BoardGameGeek API via AI tooling.


### PR DESCRIPTION
## Summary

Adds [Baozi.bet](https://github.com/bolivian-peru/baozi-mcp) to the community servers list.

**Baozi.bet** is a Solana prediction market MCP server with 68 tools covering:

- **Market discovery** — browse, search, and filter live prediction markets
- **Betting** — place YES/NO bets and pari-mutuel race bets (SOL)
- **Claims** — claim winnings from resolved markets
- **Market creation** — create boolean and race markets with customizable fees
- **Affiliate system** — earn 1% referral commissions
- **Creator profiles** — on-chain reputation and fee configuration

The server builds unsigned transactions that the user signs with their own wallet — no private keys are ever handled by the server.

- **npm:** [@baozi.bet/mcp-server](https://www.npmjs.com/package/@baozi.bet/mcp-server)
- **Install:** `npx @baozi.bet/mcp-server`
- **License:** MIT
- **Transport:** stdio

## Checklist

- [x] Server is open source (MIT license)
- [x] Published on npm
- [x] Uses official MCP SDK (`@modelcontextprotocol/sdk`)
- [x] Has comprehensive README with setup instructions
- [x] Entry is alphabetically placed in the Community Servers section
- [x] Entry follows the existing format (`**[Name](repo)** - Description`)