### PR TITLE
Add Spring Boot Swagger MCP to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,7 @@ search, and comprehensive file analysis.
 - **[Specbridge](https://github.com/TBosak/specbridge)** - Easily turn your OpenAPI specs into MCP Tools.
 - **[Splunk](https://github.com/jkosik/mcp-server-splunk)** - Golang MCP server for Splunk (lists saved searches, alerts, indexes, macros...). Supports SSE and STDIO.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify.
+- **[Spring Boot Swagger MCP](https://github.com/Neo1228/spring-boot-starter-swagger-mcp)** - Automatically turn any Spring Boot application into an MCP server by reusing existing Swagger/OpenAPI documentation.
 - **[Spring Initializr](https://github.com/hpalma/springinitializr-mcp)** - This MCP allows an LLM to create Spring Boot projects with custom configurations. Instead of manually visiting start.spring.io, you can now ask your AI assistant to generate projects with specific dependencies, Java versions, and project structures.
 - **[Squad AI](https://github.com/the-basilisk-ai/squad-mcp)** – Product‑discovery and strategy platform integration. Create, query and update opportunities, solutions, outcomes, requirements and feedback from any MCP‑aware LLM.
 - **[SSH](https://github.com/AiondaDotCom/mcp-ssh)** - Agent for managing and controlling SSH connections.


### PR DESCRIPTION
## Description
This PR adds [Spring Boot Swagger MCP](https://github.com/Neo1228/spring-boot-starter-swagger-mcp) to the Community Servers list.

## Motivation and Context
Spring Boot is the most popular framework for enterprise Java development. This library allows developers to instantly expose their existing APIs as MCP tools without writing any adapter code, bridging the gap between traditional backend services and AI agents.

## Key Features
- **Zero Boilerplate**: Uses existing \@RestController\ and \@Operation\ annotations.
- **Auto-Discovery**: Dynamically generates tool specifications from the running application.
- **Safe by Default**: Configurable human-in-the-loop confirmation for side-effect operations (POST/PUT/DELETE).
- **Advanced Context**: Built-in meta-tools to help LLMs explore and understand the API hierarchy.

## How Has This Been Tested?
Tested with:
- Claude Desktop
- MCP Inspector
- Various Spring Boot applications using \springdoc-openapi\.

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Links
- Repository: https://github.com/Neo1228/spring-boot-starter-swagger-mcp
- Documentation: https://github.com/Neo1228/spring-boot-starter-swagger-mcp#readme