### PR TITLE
fix(filesystem): fix quote style and add fileURLToPath regression test

### DIFF
--- a/src/filesystem/__tests__/roots-utils.test.ts
+++ b/src/filesystem/__tests__/roots-utils.test.ts
@@ -3,6 +3,7 @@ import { getValidRootDirectories } from '../roots-utils.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import type { Root } from '@modelcontextprotocol/sdk/types.js';
 
 describe('getValidRootDirectories', () => {
@@ -43,6 +44,21 @@ describe('getValidRootDirectories', () => {
       expect(result).toContain(testDir2);
       expect(result).toContain(testDir3);
       expect(result).toHaveLength(3);
+    });
+
+    it('should handle standard file URIs from pathToFileURL', async () => {
+      // pathToFileURL produces properly-encoded URIs (e.g. file:///C:/... on Windows)
+      // This is the format VS Code and other editors send via MCP roots
+      const roots: Root[] = [
+        { uri: pathToFileURL(testDir1).href, name: 'Standard File URI' },
+        { uri: pathToFileURL(testDir2).href, name: 'Standard File URI 2' },
+      ];
+
+      const result = await getValidRootDirectories(roots);
+
+      expect(result).toContain(testDir1);
+      expect(result).toContain(testDir2);
+      expect(result).toHaveLength(2);
     });
 
     it('should normalize complex paths', async () => {

--- a/src/filesystem/roots-utils.ts
+++ b/src/filesystem/roots-utils.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import os from 'os';
 import { normalizePath } from './path-utils.js';
 import type { Root } from '@modelcontextprotocol/sdk/types.js';
-import { fileURLToPath } from "url";
+import { fileURLToPath } from 'url';
 
 /**
  * Converts a root URI to a normalized directory path with basic security validation.


### PR DESCRIPTION
## Summary
Follow-up to #3205 with two small improvements:

- **Fix import quote style**: Changed `import { fileURLToPath } from "url"` to use single quotes, matching the rest of the file
- **Add regression test**: New test using `pathToFileURL()` to verify properly-encoded `file://` URIs (the format VS Code sends via MCP roots) are handled correctly on all platforms

## Test plan
- [x] `npx vitest run src/filesystem/__tests__/roots-utils.test.ts` — all 4 tests pass (3 existing + 1 new)

🦉 Generated with [Claude Code](https://claude.com/claude-code)