### PR TITLE
fix: add project URLs to Python package PyPI metadata

### DIFF
--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers"
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch"
+"Bug Tracker" = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-fetch = "mcp_server_fetch:main"
 

--- a/src/git/pyproject.toml
+++ b/src/git/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers"
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/git"
+"Bug Tracker" = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-git = "mcp_server_git:main"
 

--- a/src/time/pyproject.toml
+++ b/src/time/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "tzlocal>=5.3.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers"
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/time"
+"Bug Tracker" = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-time = "mcp_server_time:main"
 


### PR DESCRIPTION
## Summary

Adds `[project.urls]` sections to `pyproject.toml` for all three Python server packages (`mcp-server-git`, `mcp-server-fetch`, `mcp-server-time`).

This surfaces **Homepage**, **Repository**, and **Bug Tracker** links on each package's [PyPI page](https://pypi.org/project/mcp-server-git/), making it easy for users to navigate back to this repo and the specific subfolder for each package.

### Changes
- `src/git/pyproject.toml` — added `[project.urls]` pointing to `src/git`
- `src/fetch/pyproject.toml` — added `[project.urls]` pointing to `src/fetch`
- `src/time/pyproject.toml` — added `[project.urls]` pointing to `src/time`

Closes #3336

---

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*