### PR TITLE
fix: prevent server crash on malformed input in fetch and git servers

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -285,4 +285,4 @@ Although originally you did not have internet access, and were advised to refuse
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -493,4 +493,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)


### PR DESCRIPTION
## Summary

Change `raise_exceptions` from `True` to `False` in `mcp-server-fetch` and `mcp-server-git` to handle malformed JSON-RPC messages gracefully.

## Problem

With `raise_exceptions=True`, any invalid byte on stdin causes an unhandled `ExceptionGroup` that terminates the server process. As reported in #3359, fuzz testing showed `mcp-server-fetch` crashed on **61 out of 65** test cases, while servers using the default `raise_exceptions=False` survived all 65.

## Fix

Set `raise_exceptions=False` (the SDK default) in both affected servers, consistent with other reference server implementations.

## Files Changed

- `src/fetch/src/mcp_server_fetch/server.py` — line 288
- `src/git/src/mcp_server_git/server.py` — line 496

Fixes #3359