### PR TITLE
fix(filesystem): add symlink startup test and clarify catch block comment

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -59,8 +59,11 @@ let allowedDirectories = (await Promise.all(
       }
       return [normalizedResolved];
     } catch (error) {
-      // If we can't resolve (doesn't exist), use the normalized absolute path
-      // This allows configuring allowed dirs that will be created later
+      // Directory doesn't exist yet - store only the unresolved path.
+      // This allows configuring allowed dirs that will be created later.
+      // Note: if this path later appears as a symlink, only the unresolved
+      // form will be in allowedDirectories. Full symlink support requires
+      // the directory to exist at startup so both forms can be resolved.
       return [normalizedOriginal];
     }
   })


### PR DESCRIPTION
## Summary

Follow-up to #3254 (symlinked allowed directories fix), implementing the two suggestions from the review:

- **Integration test**: Add test in `startup-validation.test.ts` that spawns the server with a symlinked directory argument, verifying the startup code correctly produces both path forms. This closes the gap between the unit test in `path-validation.test.ts` (which manually constructs the allowedDirectories array) and the actual startup behavior.
- **Code comment**: Clarify the catch block comment in `index.ts` to document the design tradeoff: when a directory doesn't exist at startup, only the unresolved form is stored, so full symlink support requires the directory to exist at startup.

## Test plan

- [x] All 146 filesystem tests pass (7 test files)
- [x] New symlink startup test passes on Windows
- [x] Test gracefully skips on systems without symlink permissions (EPERM)
- [x] Build succeeds with no TypeScript errors

🦉 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>