### PR TITLE
Add Brain Protocol — verifiable AI memory MCP server

### DIFF
--- a/servers/io.github.seritalien/brain-protocol/server.json
+++ b/servers/io.github.seritalien/brain-protocol/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.seritalien/brain-protocol",
+  "description": "Verifiable Memory for AI Agents — 25 tools: knowledge graph, FTS, Starknet proofs, Giza zkML, decisions, curation. Local SQLite or cloud mode.",
+  "repository": {
+    "url": "https://github.com/seritalien/brain-protocol",
+    "source": "github",
+    "subfolder": "packages/brain-mcp"
+  },
+  "version": "0.5.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@brain-protocol/mcp",
+      "version": "0.5.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "BRAIN_API_URL",
+          "description": "Cloud mode API URL (e.g., https://brain.api.vauban.tech). When unset, uses local SQLite.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "BRAIN_API_KEY",
+          "description": "API key for cloud mode authentication (sent as X-API-Key header)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "BRAIN_DB_PATH",
+          "description": "Override path for the local SQLite database file",
+          "isRequired": false,
+          "format": "filepath",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/servers/io.github.seritalien/brain-protocol/server.json
+++ b/servers/io.github.seritalien/brain-protocol/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.seritalien/brain-protocol",
-  "description": "Verifiable Memory for AI Agents — 25 tools: knowledge graph, FTS, Starknet proofs, Giza zkML, decisions, curation. Local SQLite or cloud mode.",
+  "description": "Verifiable Memory for AI Agents — 25 tools: knowledge graph, FTS, semantic search, Starknet proofs, decisions, curation. Local SQLite (zero config) or cloud mode.",
   "repository": {
     "url": "https://github.com/seritalien/brain-protocol",
     "source": "github",
     "subfolder": "packages/brain-mcp"
   },
-  "version": "0.5.0",
+  "version": "0.7.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@brain-protocol/mcp",
-      "version": "0.5.0",
+      "version": "0.7.8",
       "transport": {
         "type": "stdio"
       },
@@ -39,6 +39,12 @@
           "isSecret": false
         }
       ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://brain.api.vauban.tech/mcp"
     }
   ]
 }

--- a/servers/io.github.seritalien/brain-protocol/server.json
+++ b/servers/io.github.seritalien/brain-protocol/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "packages/brain-mcp"
   },
-  "version": "0.7.8",
+  "version": "0.7.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@brain-protocol/mcp",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION

## Brain Protocol MCP Server

  **npm**: `@brain-protocol/mcp@0.5.0`
  **Source**: https://github.com/seritalien/brain-protocol
  **Category**: Memory / Knowledge Management

  Brain Protocol gives AI agents persistent, searchable, graph-connected memory
  with optional on-chain verification (Starknet). Works locally with SQLite
  (zero config) or in cloud mode with knowledge graph, FTS, semantic search,
  and blockchain proofs.

  ### Features
  - 25 MCP tools: query, archive, graph traversal, proofs, decisions
  - Local SQLite: `npx @brain-protocol/mcp` (zero config)
  - Compatible: Claude Desktop, Cursor, Windsurf, Claude Code, Continue

  ### Verification
  - MIT licensed | 12 versions published | Active maintenance
  - Full test suite, TypeScript

