### PR TITLE
fix(filesystem): sanitize error messages to prevent path info disclosure

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -241,7 +241,7 @@ Note: all directories must be mounted to `/projects` by default.
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-filesystem",
+        "@modelcontextprotocol/server-filesystem@0.6.3",
         "/Users/username/Desktop",
         "/path/to/other/allowed/dir"
       ]
@@ -300,7 +300,7 @@ Note: all directories must be mounted to `/projects` by default.
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-filesystem",
+        "@modelcontextprotocol/server-filesystem@0.6.3",
         "${workspaceFolder}"
       ]
     }

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -107,7 +107,7 @@ export async function validatePath(requestedPath: string): Promise<string> {
   // Security: Check if path is within allowed directories before any file operations
   const isAllowed = isPathWithinAllowedDirectories(normalizedRequested, allowedDirectories);
   if (!isAllowed) {
-    throw new Error(`Access denied - path outside allowed directories: ${absolute} not in ${allowedDirectories.join(', ')}`);
+    throw new Error(`Access denied - path outside allowed directories`);
   }
 
   // Security: Handle symlinks by checking their real path to prevent symlink attacks
@@ -116,7 +116,7 @@ export async function validatePath(requestedPath: string): Promise<string> {
     const realPath = await fs.realpath(absolute);
     const normalizedReal = normalizePath(realPath);
     if (!isPathWithinAllowedDirectories(normalizedReal, allowedDirectories)) {
-      throw new Error(`Access denied - symlink target outside allowed directories: ${realPath} not in ${allowedDirectories.join(', ')}`);
+      throw new Error(`Access denied - symlink target outside allowed directories`);
     }
     return realPath;
   } catch (error) {
@@ -128,11 +128,11 @@ export async function validatePath(requestedPath: string): Promise<string> {
         const realParentPath = await fs.realpath(parentDir);
         const normalizedParent = normalizePath(realParentPath);
         if (!isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
-          throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
+          throw new Error(`Access denied - parent directory outside allowed directories`);
         }
         return absolute;
       } catch {
-        throw new Error(`Parent directory does not exist: ${parentDir}`);
+        throw new Error(`Parent directory does not exist`);
       }
     }
     throw error;


### PR DESCRIPTION
## Summary
- Sanitize `validatePath()` error messages in `src/filesystem/lib.ts` to stop exposing absolute paths and allowed directory lists in error output
- Pin `npx` examples in `src/filesystem/README.md` to `@0.6.3` to mitigate supply chain risk from unpinned package resolution
- Add 3 tests that explicitly verify error messages don't contain filesystem paths

## Context
Addresses the 2 low-severity findings from the AgentAudit security report in #3317:

1. **Error messages expose internal path information** — `validatePath()` included the full requested path and the complete allowed directory list in thrown errors. In shared or multi-tenant environments, this could leak directory structure to unauthorized callers.

2. **NPX usage without version pinning** — Documentation examples used `npx -y @modelcontextprotocol/server-filesystem` without a version specifier, creating a supply chain risk if a malicious version were published.

## Changes

### `src/filesystem/lib.ts`
- Lines 110, 119, 131, 135: Removed interpolated paths from error messages while preserving the descriptive denial reason (e.g. "Access denied - path outside allowed directories")

### `src/filesystem/README.md`
- Pinned both NPX examples to `@modelcontextprotocol/server-filesystem@0.6.3`

### `src/filesystem/__tests__/lib.test.ts`
- `does not leak filesystem paths in access denied errors` — verifies error message contains no path or directory info
- `does not leak filesystem paths in parent directory errors` — verifies parent path is not leaked
- `does not leak filesystem paths in symlink denied errors` — verifies symlink target path is not leaked

## Test plan
- [x] All 48 lib tests pass (`npx vitest run __tests__/lib.test.ts`)
- [x] Full test suite: 144/145 pass (1 pre-existing Windows-specific failure unrelated to this change)
- [x] `tsc --noEmit` passes with no type errors
- [ ] Verify error messages are still useful for debugging in development

Closes #3317