### PR TITLE
Fix #3336: Link to this repo in PyPi packages.

### DIFF
--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch"
+Homepage = "https://github.com/modelcontextprotocol/servers"
+
 [project.scripts]
 mcp-server-fetch = "mcp_server_fetch:main"
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -339,6 +339,15 @@ cd src/git
 docker build -t mcp/git .
 ```
 
+## Contributing
+
+We encourage contributions to help expand and improve mcp-server-git. Whether you want to add new tools, enhance existing functionality, or improve documentation, your input is valuable.
+
+For examples of other MCP servers and implementation patterns, see:
+https://github.com/modelcontextprotocol/servers
+
+Pull requests are welcome! Feel free to contribute new ideas, bug fixes, or enhancements to make mcp-server-git even more powerful and useful.
+
 ## License
 
 This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/src/git/pyproject.toml
+++ b/src/git/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/git"
+Homepage = "https://github.com/modelcontextprotocol/servers"
+
 [project.scripts]
 mcp-server-git = "mcp_server_git:main"
 

--- a/src/time/pyproject.toml
+++ b/src/time/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "tzlocal>=5.3.1",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/time"
+Homepage = "https://github.com/modelcontextprotocol/servers"
+
 [project.scripts]
 mcp-server-time = "mcp_server_time:main"
 


### PR DESCRIPTION
Fixes #3336

## Summary
This PR fixes: Link to this repo in PyPi packages.

## Changes
```
src/fetch/pyproject.toml | 4 ++++
 src/git/README.md        | 9 +++++++++
 src/git/pyproject.toml   | 4 ++++
 src/time/pyproject.toml  | 4 ++++
 4 files changed, 21 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).