### PR TITLE
Fix #3122: The memory mcp error 32602 occurs in the cursor, but no erro

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -260,12 +260,12 @@ server.registerTool(
   {
     title: "Create Entities",
     description: "Create multiple new entities in the knowledge graph",
-    inputSchema: {
+    inputSchema: z.object({
       entities: z.array(EntitySchema)
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       entities: z.array(EntitySchema)
-    }
+    })
   },
   async ({ entities }) => {
     const result = await knowledgeGraphManager.createEntities(entities);
@@ -282,12 +282,12 @@ server.registerTool(
   {
     title: "Create Relations",
     description: "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
-    inputSchema: {
+    inputSchema: z.object({
       relations: z.array(RelationSchema)
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       relations: z.array(RelationSchema)
-    }
+    })
   },
   async ({ relations }) => {
     const result = await knowledgeGraphManager.createRelations(relations);
@@ -304,18 +304,18 @@ server.registerTool(
   {
     title: "Add Observations",
     description: "Add new observations to existing entities in the knowledge graph",
-    inputSchema: {
+    inputSchema: z.object({
       observations: z.array(z.object({
         entityName: z.string().describe("The name of the entity to add the observations to"),
         contents: z.array(z.string()).describe("An array of observation contents to add")
       }))
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       results: z.array(z.object({
         entityName: z.string(),
         addedObservations: z.array(z.string())
       }))
-    }
+    })
   },
   async ({ observations }) => {
     const result = await knowledgeGraphManager.addObservations(observations);
@@ -332,13 +332,13 @@ server.registerTool(
   {
     title: "Delete Entities",
     description: "Delete multiple entities and their associated relations from the knowledge graph",
-    inputSchema: {
+    inputSchema: z.object({
       entityNames: z.array(z.string()).describe("An array of entity names to delete")
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       success: z.boolean(),
       message: z.string()
-    }
+    })
   },
   async ({ entityNames }) => {
     await knowledgeGraphManager.deleteEntities(entityNames);
@@ -355,16 +355,16 @@ server.registerTool(
   {
     title: "Delete Observations",
     description: "Delete specific observations from entities in the knowledge graph",
-    inputSchema: {
+    inputSchema: z.object({
       deletions: z.array(z.object({
         entityName: z.string().describe("The name of the entity containing the observations"),
         observations: z.array(z.string()).describe("An array of observations to delete")
       }))
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       success: z.boolean(),
       message: z.string()
-    }
+    })
   },
   async ({ deletions }) => {
     await knowledgeGraphManager.deleteObservations(deletions);
@@ -381,13 +381,13 @@ server.registerTool(
   {
     title: "Delete Relations",
     description: "Delete multiple relations from the knowledge graph",
-    inputSchema: {
+    inputSchema: z.object({
       relations: z.array(RelationSchema).describe("An array of relations to delete")
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       success: z.boolean(),
       message: z.string()
-    }
+    })
   },
   async ({ relations }) => {
     await knowledgeGraphManager.deleteRelations(relations);
@@ -404,11 +404,11 @@ server.registerTool(
   {
     title: "Read Graph",
     description: "Read the entire knowledge graph",
-    inputSchema: {},
-    outputSchema: {
+    inputSchema: z.object({}),
+    outputSchema: z.object({
       entities: z.array(EntitySchema),
       relations: z.array(RelationSchema)
-    }
+    })
   },
   async () => {
     const graph = await knowledgeGraphManager.readGraph();
@@ -425,13 +425,13 @@ server.registerTool(
   {
     title: "Search Nodes",
     description: "Search for nodes in the knowledge graph based on a query",
-    inputSchema: {
+    inputSchema: z.object({
       query: z.string().describe("The search query to match against entity names, types, and observation content")
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       entities: z.array(EntitySchema),
       relations: z.array(RelationSchema)
-    }
+    })
   },
   async ({ query }) => {
     const graph = await knowledgeGraphManager.searchNodes(query);
@@ -448,13 +448,13 @@ server.registerTool(
   {
     title: "Open Nodes",
     description: "Open specific nodes in the knowledge graph by their names",
-    inputSchema: {
+    inputSchema: z.object({
       names: z.array(z.string()).describe("An array of entity names to retrieve")
-    },
-    outputSchema: {
+    }),
+    outputSchema: z.object({
       entities: z.array(EntitySchema),
       relations: z.array(RelationSchema)
-    }
+    })
   },
   async ({ names }) => {
     const graph = await knowledgeGraphManager.openNodes(names);


### PR DESCRIPTION
Fixes #3122

## Summary
This PR fixes: The memory mcp error 32602 occurs in the cursor, but no error occurs in claude code/roocode/cline, even though the same configuration is used.

## Changes
```
src/memory/index.ts | 70 ++++++++++++++++++++++++++---------------------------
 1 file changed, 35 insertions(+), 35 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).