### PR TITLE
Add node-red-contrib-mcp to clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[MCP-Agent](https://github.com/lastmile-ai/mcp-agent)** - A simple, composable framework to build agents using Model Context Protocol by **[LastMile AI](https://www.lastmileai.dev)**
 * **[Spring AI MCP Client](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html)** - Provides auto-configuration for MCP client functionality in Spring Boot applications.
 * **[MCP CLI Client](https://github.com/vincent-pli/mcp-cli-host)** - A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP).
+* **[node-red-contrib-mcp](https://github.com/BavarianAnalyst/node-red-contrib-mcp)** - MCP client nodes for [Node-RED](https://nodered.org). Includes tool calling, resource reading, LLM integration, and an autonomous AI agent node. Available on [npm](https://www.npmjs.com/package/node-red-contrib-mcp).
 * **[OpenMCP Client](https://github.com/LSTM-Kirigaya/openmcp-client/)** - An all-in-one vscode/trae/cursor plugin for MCP server debugging. [Document](https://kirigaya.cn/openmcp/) & [OpenMCP SDK](https://kirigaya.cn/openmcp/sdk-tutorial/).
 * **[PHP MCP Client](https://github.com/php-mcp/client)** - Core PHP implementation for the Model Context Protocol (MCP) Client
 * **[Runbear](https://runbear.io/solutions/integrations/slack/mcp)** - No-code MCP client for team chat platforms, such as Slack, Microsoft Teams, and Discord.


### PR DESCRIPTION
## What

Adds [node-red-contrib-mcp](https://github.com/BavarianAnalyst/node-red-contrib-mcp) to the "For clients" section in the frameworks list.

## About the package

MCP client nodes for [Node-RED](https://nodered.org) — the popular low-code platform for industrial automation, IoT, and event-driven workflows (4M+ installations worldwide).

**7 nodes:**
- `mcp-server-config` — Connect to any MCP server (Streamable HTTP / SSE)
- `llm-config` — Configure any OpenAI-compatible LLM
- `mcp-tool-call` — Call MCP tools with arguments
- `mcp-tool-list` — Discover available tools
- `mcp-resource-read` — Read MCP resources
- `llm-call` — LLM chat completion
- `ai-agent` — Autonomous agent loop (LLM reasons over MCP tools until it has an answer)

**Links:**
- GitHub: https://github.com/BavarianAnalyst/node-red-contrib-mcp
- npm: https://www.npmjs.com/package/node-red-contrib-mcp
- Node-RED Flow Library: https://flows.nodered.org/node/node-red-contrib-mcp

Apache-2.0 licensed. Published on npm. Works with any MCP server and any OpenAI-compatible LLM.