### PR TITLE
Add Launch Fast MCP - Amazon FBA research tools for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Language Server](https://github.com/isaacphi/mcp-language-server)** - MCP Language Server helps MCP enabled clients navigate codebases more easily by giving them access to semantic tools like get definition, references, rename, and diagnostics.
 - **[Large File MCP](https://github.com/willianpinho/large-file-mcp)** - Intelligent handling of large files with smart chunking, navigation, and streaming capabilities. Features LRU caching, regex
 search, and comprehensive file analysis.
+- **[Launch Fast MCP](https://github.com/BlockchainHB/launchfastmcp-skills)** - Amazon FBA research tools: multi-keyword product research with opportunity scoring, PPC keyword research with Sponsored Products bulk upload CSV, Alibaba supplier outreach automation, and IP/trademark checks. Skills for Claude Code via [Launch Fast](https://launchfastlegacyx.com).
 - **[Lark(Feishu)](https://github.com/kone-net/mcp_server_lark)** - A Model Context Protocol(MCP) server for Lark(Feishu) sheet, message, doc and etc.
 - **[Lazy Toggl MCP](https://github.com/movstox/lazy-toggl-mcp)** - Simple unofficial MCP server to track time via Toggl API
 - **[lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp)** - Interact with the [Lean theorem prover](https://lean-lang.org/) via the Language Server Protocol.


### PR DESCRIPTION
## Description

This PR adds [Launch Fast MCP](https://github.com/BlockchainHB/launchfastmcp-skills) to the Community Servers list.

Launch Fast MCP is a suite of Amazon FBA research tools packaged as Claude Code skills:

- **Product research** — multi-keyword parallel research loop with opportunity scoring (0–100, GO/INVESTIGATE/PASS verdicts)
- **PPC keyword research** — Amazon keyword research with Sponsored Products bulk upload CSV generation
- **Alibaba supplier outreach** — automated supplier research and outreach automation
- **IP/trademark checks** — product IP and trademark risk checks

## Links

- 🔗 GitHub: https://github.com/BlockchainHB/launchfastmcp-skills
- 🌐 Website: https://launchfastlegacyx.com
- 📖 Docs: https://docs.launchfastlegacyx.com/mcp

## Category

Community Servers — added alphabetically under the "L" section.