### PR TITLE
Add MolTrust community server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ search, and comprehensive file analysis.
 - **[MLflow](https://github.com/kkruglik/mlflow-mcp)** - MLflow MCP server for ML experiment tracking with advanced querying, run comparison, artifact access, and model registry.
 - **[Mobile MCP](https://github.com/mobile-next/mobile-mcp)** (by Mobile Next) - MCP server for Mobile(iOS/Android) automation, app scraping and development using physical devices or simulators/emulators.
 - **[Modao Proto MCP](https://github.com/modao-dev/modao-proto-mcp)** - AI-powered HTML prototype generation server that converts natural language descriptions into complete HTML code with modern design and responsive layouts. Supports design description expansion and seamless integration with Modao workspace.
+- **[MolTrust](https://github.com/MoltyCel/moltrust-mcp-server)** - Trust infrastructure for AI agents — register DIDs, verify identities, query reputation scores, rate agents, manage W3C Verifiable Credentials, and handle USDC credit deposits on Base.
 - **[Monday.com (unofficial)](https://github.com/sakce/mcp-server-monday)** - MCP Server to interact with Monday.com boards and items.
 - **[MongoDB](https://github.com/kiliczsh/mcp-mongo-server)** - A Model Context Protocol Server for MongoDB.
 - **[MongoDB & Mongoose](https://github.com/nabid-pf/mongo-mongoose-mcp)** - MongoDB MCP Server with Mongoose Schema and Validation.


### PR DESCRIPTION
## Summary

Adds **MolTrust** to the Community Servers section of README.md — W3C DID-based trust infrastructure for AI agents.

**v0.5.0** — 27 tools across 5 verticals:

| Vertical | Tools | Description |
|----------|-------|-------------|
| Core Trust | 11 | Agent registration, DID verification, reputation, W3C VCs, ERC-8004, credits |
| Agent Scoring | 7 | Wallet trust scores, Sybil detection, prediction market integrity |
| MT Shopping | 3 | BuyerAgentCredential issuance & verification for autonomous commerce |
| MT Travel | 3 | TravelAgentCredential with delegation chains for booking agents |
| MT Skills | 3 | Security audit + VerifiedSkillCredential for agent skills |

- Published on PyPI: `uvx moltrust-mcp-server`
- Repository: https://github.com/MoltyCel/moltrust-mcp-server
- Website: https://moltrust.ch

## Test plan
- [x] `uvx moltrust-mcp-server` installs and starts cleanly
- [x] 53 tests passing in CI
- [x] All 27 tools register correctly via MCP stdio transport