### PR TITLE
Add refcheck: academic reference verification server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,7 @@ search, and comprehensive file analysis.
 - **[Redis](https://github.com/prajwalnayak7/mcp-server-redis)** MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate
 - **[RedNote MCP](https://github.com/ifuryst/rednote-mcp)** - MCP server for accessing RedNote(XiaoHongShu, xhs) content
 - **[Reed Jobs](https://github.com/kld3v/reed_jobs_mcp)** - Search and retrieve job listings from Reed.co.uk.
+- **[refcheck](https://github.com/benchoi93/refcheck)** - Verify academic references against Crossref, Semantic Scholar, and arXiv. Catches hallucinated citations, finds real papers, and exports corrected BibTeX.
 - **[Rememberizer AI](https://github.com/skydeckai/mcp-server-rememberizer)** - An MCP server designed for interacting with the Rememberizer data source, facilitating enhanced knowledge retrieval.
 - **[Replicate](https://github.com/deepfates/mcp-replicate)** - Search, run and manage machine learning models on Replicate through a simple tool-based interface. Browse models, create predictions, track their status, and handle generated images.
 - **[Resend](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/resend)** - Send email using Resend services


### PR DESCRIPTION
## Summary

Adds **[refcheck](https://github.com/benchoi93/refcheck)** to the community servers list — an MCP server that verifies academic references against real publication databases.

### What it does

- **`verify_reference`** — Checks if a citation is real by fuzzy-matching against Crossref, Semantic Scholar, arXiv, Scopus, and IEEE Xplore. Returns `verified`, `partial_match`, or `not_found` with confidence score and corrected BibTeX.
- **`search_references`** — Finds real papers on a topic. Only returns database-backed results.
- **`get_bibtex`** — Exports publication-ready BibTeX by DOI, title, or Semantic Scholar ID. Supports batch export.

### Why it matters

LLMs frequently hallucinate academic citations — plausible-looking references with fabricated titles, authors, DOIs, or venues. This MCP server gives AI assistants direct access to real publication databases so every citation can be verified before use.

### Tech stack

Python, FastMCP, httpx (async), Pydantic v2, rapidfuzz. Works with zero API keys (Crossref + arXiv are free), with optional keys for Semantic Scholar, Scopus, and IEEE Xplore.