### PR TITLE
Assert deterministic tool registration order for capability exposure

### DIFF
--- a/src/everything/__tests__/registrations.test.ts
+++ b/src/everything/__tests__/registrations.test.ts
@@ -31,6 +31,20 @@ describe('Registration Index Files', () => {
       const registeredTools = (mockServer.registerTool as any).mock.calls.map(
         (call: any[]) => call[0]
       );
+      expect(registeredTools).toEqual([
+        'echo',
+        'get-annotated-message',
+        'get-env',
+        'get-resource-links',
+        'get-resource-reference',
+        'get-structured-content',
+        'get-sum',
+        'get-tiny-image',
+        'gzip-file-as-resource',
+        'toggle-simulated-logging',
+        'toggle-subscriber-updates',
+        'trigger-long-running-operation',
+      ]);
       expect(registeredTools).toContain('echo');
       expect(registeredTools).toContain('get-sum');
       expect(registeredTools).toContain('get-env');
@@ -73,6 +87,11 @@ describe('Registration Index Files', () => {
       const registeredTools = (
         mockServerWithCapabilities.registerTool as any
       ).mock.calls.map((call: any[]) => call[0]);
+      expect(registeredTools).toEqual([
+        'get-roots-list',
+        'trigger-elicitation-request',
+        'trigger-sampling-request',
+      ]);
       expect(registeredTools).toContain('get-roots-list');
       expect(registeredTools).toContain('trigger-elicitation-request');
       expect(registeredTools).toContain('trigger-sampling-request');


### PR DESCRIPTION
## Problem
Initialization capability exposure depends on the registered tool surfaces, and order drift can create avoidable snapshot churn and handshake instability in tests/clients.

## Why now
Issue #3410 calls for deterministic capability exposure ordering in initialization behavior.

## What changed
- Strengthened `src/everything/__tests__/registrations.test.ts` to assert exact deterministic registration order for:
  - standard tools
  - conditional capability-gated tools.

## Validation
- `cd src/everything && npx vitest run __tests__/registrations.test.ts`

Refs #3410
