### PR TITLE
Add OpenClaw Intel + Fortune community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,8 @@ search, and comprehensive file analysis.
 - **[OpenAPI Schema](https://github.com/hannesj/mcp-openapi-schema)** - Allow LLMs to explore large [OpenAPI](https://www.openapis.org/) schemas without bloating the context.
 - **[OpenAPI Schema Explorer](https://github.com/kadykov/mcp-openapi-schema-explorer)** - Token-efficient access to local or remote OpenAPI/Swagger specs via MCP Resources.
 - **[OpenCTI](https://github.com/Spathodea-Network/opencti-mcp)** - Interact with OpenCTI platform to retrieve threat intelligence data including reports, indicators, malware and threat actors.
+- **[OpenClaw Intel](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers)** - AI agent market intelligence. Real-time GitHub stars, releases, growth trends for Claude Code, Cursor, Devin, OpenHands, Windsurf. Updated every 6 hours.
+- **[OpenClaw Fortune](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers)** - Daily zodiac horoscope and tarot card readings MCP server for all 12 signs. Scores, lucky items, rankings. Japanese-localized.
 - **[OpenCV](https://github.com/GongRzhe/opencv-mcp-server)** - An MCP server providing OpenCV computer vision capabilities. This allows AI assistants and language models to access powerful computer vision tools.
 - **[OpenDigger MCP Server](https://github.com/X-lab2017/open-digger-mcp-server)** - Model Context Protocol (MCP) server for [OpenDigger](https://open-digger.cn/en/), enabling advanced repository analytics and insights through tools and prompts.
 - **[OpenDota](https://github.com/asusevski/opendota-mcp-server)** - Interact with OpenDota API to retrieve Dota 2 match data, player statistics, and more.


### PR DESCRIPTION
Adding two community MCP servers from OpenClaw Intelligence:

## OpenClaw Intel
- **Description**: AI agent market intelligence — GitHub stars, releases, growth trends for Claude Code, Cursor, Devin, OpenHands, Windsurf. Updated every 6 hours.
- **Endpoint**: `https://openclaw-intel-mcp.yagami8095.workers.dev/mcp`
- **Transport**: Streamable HTTP
- **Tools**: 6 tools (get_ai_market_report, get_report_by_id, list_reports, get_market_stats, purchase_api_key, validate_api_key)

## OpenClaw Fortune
- **Description**: Daily zodiac horoscope and tarot card readings for all 12 signs. Japanese-localized.
- **Endpoint**: `https://openclaw-fortune-mcp.yagami8095.workers.dev/mcp`
- **Transport**: Streamable HTTP
- **Tools**: 3 tools (get_daily_fortune, get_fortune_ranking, get_all_fortunes)

## Links
- GitHub: https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers
- Smithery: https://smithery.ai/servers/openclaw-ai/intel | https://smithery.ai/servers/openclaw-ai/fortune
