### PR TITLE
Add MoldSim MCP to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,6 +1099,7 @@ search, and comprehensive file analysis.
 - **[MLflow](https://github.com/kkruglik/mlflow-mcp)** - MLflow MCP server for ML experiment tracking with advanced querying, run comparison, artifact access, and model registry.
 - **[Mobile MCP](https://github.com/mobile-next/mobile-mcp)** (by Mobile Next) - MCP server for Mobile(iOS/Android) automation, app scraping and development using physical devices or simulators/emulators.
 - **[Modao Proto MCP](https://github.com/modao-dev/modao-proto-mcp)** - AI-powered HTML prototype generation server that converts natural language descriptions into complete HTML code with modern design and responsive layouts. Supports design description expansion and seamless integration with Modao workspace.
+- **[MoldSim MCP](https://github.com/kobzevvv/moldsim-mcp)** - Injection molding simulation knowledge for AI — material properties (Cross-WLF, PVT, thermal, mechanical for 21 materials), process validation, DFM checklist, troubleshooting (230+ knowledge chunks), and simulation spec generation.
 - **[Monday.com (unofficial)](https://github.com/sakce/mcp-server-monday)** - MCP Server to interact with Monday.com boards and items.
 - **[MongoDB](https://github.com/kiliczsh/mcp-mongo-server)** - A Model Context Protocol Server for MongoDB.
 - **[MongoDB & Mongoose](https://github.com/nabid-pf/mongo-mongoose-mcp)** - MongoDB MCP Server with Mongoose Schema and Validation.


### PR DESCRIPTION
## Summary

Adding [MoldSim MCP](https://github.com/kobzevvv/moldsim-mcp) to the Community Servers section.

MoldSim MCP provides injection molding simulation knowledge for AI assistants:

- **Material properties** — Cross-WLF viscosity, PVT, thermal, mechanical data for 21 engineering plastics
- **Process validation** — checks melt/mold temperature, shear rate, cooling time against material windows
- **DFM checklist** — design-for-manufacturability rules for injection molded parts
- **Troubleshooting** — 230+ knowledge chunks with semantic search covering defects, simulation issues, and best practices
- **Simulation spec generation** — structured specs from natural language descriptions

- **npm**: `npx moldsim-mcp`
- **Website**: https://moldsim.pages.dev