### PR TITLE
Add strict ACL startup mode for filesystem, fetch, and git servers

### DIFF
--- a/src/fetch/src/mcp_server_fetch/__init__.py
+++ b/src/fetch/src/mcp_server_fetch/__init__.py
@@ -1,4 +1,12 @@
-from .server import serve
+import os
+import sys
+
+from .server import ACLConfigError, serve
+
+
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
 
 
 def main():
@@ -16,9 +24,34 @@ def main():
         help="Ignore robots.txt restrictions",
     )
     parser.add_argument("--proxy-url", type=str, help="Proxy URL to use for requests")
+    parser.add_argument(
+        "--allow-host",
+        action="append",
+        default=[],
+        help="Allowed host (repeatable). Required when --strict-acl is enabled.",
+    )
+    parser.add_argument(
+        "--strict-acl",
+        action="store_true",
+        help="Fail startup unless explicit ACL configuration is provided.",
+    )
 
     args = parser.parse_args()
-    asyncio.run(serve(args.user_agent, args.ignore_robots_txt, args.proxy_url))
+    strict_acl = args.strict_acl or _env_flag("MCP_SERVER_STRICT_ACL")
+    allowed_hosts = tuple(args.allow_host or [])
+    try:
+        asyncio.run(
+            serve(
+                args.user_agent,
+                args.ignore_robots_txt,
+                args.proxy_url,
+                strict_acl=strict_acl,
+                allowed_hosts=allowed_hosts,
+            )
+        )
+    except ACLConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from exc
 
 
 if __name__ == "__main__":

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -5,10 +5,14 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from mcp.shared.exceptions import McpError
 
 from mcp_server_fetch.server import (
+    ACLConfigError,
     extract_content_from_html,
     get_robots_txt_url,
     check_may_autonomously_fetch_url,
     fetch_url,
+    is_url_allowed,
+    normalize_allowed_hosts,
+    validate_startup_acl,
     DEFAULT_USER_AGENT_AUTONOMOUS,
 )
 
@@ -100,13 +104,14 @@ class TestCheckMayAutonomouslyFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             # Should not raise
             await check_may_autonomously_fetch_url(
-                "https://example.com/page",
-                DEFAULT_USER_AGENT_AUTONOMOUS
+                "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
             )
 
     @pytest.mark.asyncio
@@ -118,13 +123,14 @@ class TestCheckMayAutonomouslyFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             with pytest.raises(McpError):
                 await check_may_autonomously_fetch_url(
-                    "https://example.com/page",
-                    DEFAULT_USER_AGENT_AUTONOMOUS
+                    "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
                 )
 
     @pytest.mark.asyncio
@@ -136,13 +142,14 @@ class TestCheckMayAutonomouslyFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             with pytest.raises(McpError):
                 await check_may_autonomously_fetch_url(
-                    "https://example.com/page",
-                    DEFAULT_USER_AGENT_AUTONOMOUS
+                    "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
                 )
 
     @pytest.mark.asyncio
@@ -155,13 +162,14 @@ class TestCheckMayAutonomouslyFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             # Should not raise
             await check_may_autonomously_fetch_url(
-                "https://example.com/page",
-                DEFAULT_USER_AGENT_AUTONOMOUS
+                "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
             )
 
     @pytest.mark.asyncio
@@ -174,13 +182,14 @@ class TestCheckMayAutonomouslyFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             with pytest.raises(McpError):
                 await check_may_autonomously_fetch_url(
-                    "https://example.com/page",
-                    DEFAULT_USER_AGENT_AUTONOMOUS
+                    "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
                 )
 
 
@@ -207,12 +216,13 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             content, prefix = await fetch_url(
-                "https://example.com/page",
-                DEFAULT_USER_AGENT_AUTONOMOUS
+                "https://example.com/page", DEFAULT_USER_AGENT_AUTONOMOUS
             )
 
             # HTML is processed, so we check it returns something
@@ -231,13 +241,15 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             content, prefix = await fetch_url(
                 "https://example.com/page",
                 DEFAULT_USER_AGENT_AUTONOMOUS,
-                force_raw=True
+                force_raw=True,
             )
 
             assert content == html_content
@@ -255,12 +267,13 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             content, prefix = await fetch_url(
-                "https://api.example.com/data",
-                DEFAULT_USER_AGENT_AUTONOMOUS
+                "https://api.example.com/data", DEFAULT_USER_AGENT_AUTONOMOUS
             )
 
             assert content == json_content
@@ -275,13 +288,14 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             with pytest.raises(McpError):
                 await fetch_url(
-                    "https://example.com/notfound",
-                    DEFAULT_USER_AGENT_AUTONOMOUS
+                    "https://example.com/notfound", DEFAULT_USER_AGENT_AUTONOMOUS
                 )
 
     @pytest.mark.asyncio
@@ -293,13 +307,14 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             with pytest.raises(McpError):
                 await fetch_url(
-                    "https://example.com/error",
-                    DEFAULT_USER_AGENT_AUTONOMOUS
+                    "https://example.com/error", DEFAULT_USER_AGENT_AUTONOMOUS
                 )
 
     @pytest.mark.asyncio
@@ -313,14 +328,42 @@ class TestFetchUrl:
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
-            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client
+            )
             mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
 
             await fetch_url(
                 "https://example.com/data",
                 DEFAULT_USER_AGENT_AUTONOMOUS,
-                proxy_url="http://proxy.example.com:8080"
+                proxy_url="http://proxy.example.com:8080",
             )
 
             # Verify AsyncClient was called with proxy
-            mock_client_class.assert_called_once_with(proxies="http://proxy.example.com:8080")
+            mock_client_class.assert_called_once_with(
+                proxies="http://proxy.example.com:8080"
+            )
+
+
+class TestStartupAcl:
+    def test_strict_acl_requires_allow_hosts(self):
+        with pytest.raises(ACLConfigError, match="ACL_CONFIG_MISSING"):
+            validate_startup_acl(strict_acl=True, allowed_hosts=())
+
+    def test_non_strict_acl_allows_missing_allow_hosts(self):
+        validate_startup_acl(strict_acl=False, allowed_hosts=())
+
+    def test_strict_acl_allows_explicit_hosts(self):
+        validate_startup_acl(strict_acl=True, allowed_hosts=("example.com",))
+
+    def test_normalize_allowed_hosts(self):
+        hosts = normalize_allowed_hosts(
+            [" Example.com ", "*.example.com", "api.example.com"]
+        )
+        assert hosts == ("example.com", "api.example.com")
+
+    def test_is_url_allowed_exact_and_subdomain(self):
+        allowed_hosts = ("example.com",)
+        assert is_url_allowed("https://example.com/path", allowed_hosts)
+        assert is_url_allowed("https://docs.example.com/path", allowed_hosts)
+        assert not is_url_allowed("https://other.com/path", allowed_hosts)

--- a/src/filesystem/__tests__/startup-validation.test.ts
+++ b/src/filesystem/__tests__/startup-validation.test.ts
@@ -97,4 +97,26 @@ describe('Startup Directory Validation', () => {
     // Should still start with the valid directory
     expect(result.stderr).toContain('Secure MCP Filesystem Server running on stdio');
   });
+
+  it('should fail in strict ACL mode when no directory is configured', async () => {
+    const result = await spawnServer(['--strict-acl']);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('ACL_CONFIG_MISSING');
+  });
+
+  it('should fail in strict ACL mode when any configured directory is invalid', async () => {
+    const nonExistentDir = path.join(testDir, 'missing-dir');
+    const result = await spawnServer(['--strict-acl', nonExistentDir, accessibleDir]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('ACL_CONFIG_INVALID');
+  });
+
+  it('should start in strict ACL mode when all configured directories are valid', async () => {
+    const result = await spawnServer(['--strict-acl', accessibleDir, accessibleDir2]);
+
+    expect(result.stderr).toContain('Secure MCP Filesystem Server running on stdio');
+    expect(result.stderr).not.toContain('ACL_CONFIG_');
+  });
 });

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import git
 from git.exc import BadName
 from mcp_server_git.server import (
+    ACLConfigError,
     git_checkout,
     git_branch,
     git_add,
@@ -16,8 +17,10 @@ from mcp_server_git.server import (
     git_create_branch,
     git_show,
     validate_repo_path,
+    validate_startup_acl,
 )
 import shutil
+
 
 @pytest.fixture
 def test_repository(tmp_path: Path):
@@ -32,6 +35,7 @@ def test_repository(tmp_path: Path):
 
     shutil.rmtree(repo_path)
 
+
 def test_git_checkout_existing_branch(test_repository):
     test_repository.git.branch("test-branch")
     result = git_checkout(test_repository, "test-branch")
@@ -39,31 +43,37 @@ def test_git_checkout_existing_branch(test_repository):
     assert "Switched to branch 'test-branch'" in result
     assert test_repository.active_branch.name == "test-branch"
 
-def test_git_checkout_nonexistent_branch(test_repository):
 
+def test_git_checkout_nonexistent_branch(test_repository):
     with pytest.raises(BadName):
         git_checkout(test_repository, "nonexistent-branch")
+
 
 def test_git_branch_local(test_repository):
     test_repository.git.branch("new-branch-local")
     result = git_branch(test_repository, "local")
     assert "new-branch-local" in result
 
+
 def test_git_branch_remote(test_repository):
     result = git_branch(test_repository, "remote")
     assert "" == result.strip()  # Should be empty if no remote branches
+
 
 def test_git_branch_all(test_repository):
     test_repository.git.branch("new-branch-all")
     result = git_branch(test_repository, "all")
     assert "new-branch-all" in result
 
+
 def test_git_branch_contains(test_repository):
     # Get the default branch name (could be "main" or "master")
     default_branch = test_repository.active_branch.name
     # Create a new branch and commit to it
     test_repository.git.checkout("-b", "feature-branch")
-    Path(test_repository.working_dir / Path("feature.txt")).write_text("feature content")
+    Path(test_repository.working_dir / Path("feature.txt")).write_text(
+        "feature content"
+    )
     test_repository.index.add(["feature.txt"])
     commit = test_repository.index.commit("feature commit")
     test_repository.git.checkout(default_branch)
@@ -72,12 +82,15 @@ def test_git_branch_contains(test_repository):
     assert "feature-branch" in result
     assert default_branch not in result
 
+
 def test_git_branch_not_contains(test_repository):
     # Get the default branch name (could be "main" or "master")
     default_branch = test_repository.active_branch.name
     # Create a new branch and commit to it
     test_repository.git.checkout("-b", "another-feature-branch")
-    Path(test_repository.working_dir / Path("another_feature.txt")).write_text("another feature content")
+    Path(test_repository.working_dir / Path("another_feature.txt")).write_text(
+        "another feature content"
+    )
     test_repository.index.add(["another_feature.txt"])
     commit = test_repository.index.commit("another feature commit")
     test_repository.git.checkout(default_branch)
@@ -85,6 +98,7 @@ def test_git_branch_not_contains(test_repository):
     result = git_branch(test_repository, "local", not_contains=commit.hexsha)
     assert "another-feature-branch" not in result
     assert default_branch in result
+
 
 def test_git_add_all_files(test_repository):
     file_path = Path(test_repository.working_dir) / "all_file.txt"
@@ -95,6 +109,7 @@ def test_git_add_all_files(test_repository):
     staged_files = [item.a_path for item in test_repository.index.diff("HEAD")]
     assert "all_file.txt" in staged_files
     assert result == "Files staged successfully"
+
 
 def test_git_add_specific_files(test_repository):
     file1 = Path(test_repository.working_dir) / "file1.txt"
@@ -109,11 +124,13 @@ def test_git_add_specific_files(test_repository):
     assert "file2.txt" not in staged_files
     assert result == "Files staged successfully"
 
+
 def test_git_status(test_repository):
     result = git_status(test_repository)
 
     assert result is not None
     assert "On branch" in result or "branch" in result.lower()
+
 
 def test_git_diff_unstaged(test_repository):
     file_path = Path(test_repository.working_dir) / "test.txt"
@@ -124,10 +141,12 @@ def test_git_diff_unstaged(test_repository):
     assert "test.txt" in result
     assert "modified content" in result
 
+
 def test_git_diff_unstaged_empty(test_repository):
     result = git_diff_unstaged(test_repository)
 
     assert result == ""
+
 
 def test_git_diff_staged(test_repository):
     file_path = Path(test_repository.working_dir) / "staged_file.txt"
@@ -139,10 +158,12 @@ def test_git_diff_staged(test_repository):
     assert "staged_file.txt" in result
     assert "staged content" in result
 
+
 def test_git_diff_staged_empty(test_repository):
     result = git_diff_staged(test_repository)
 
     assert result == ""
+
 
 def test_git_diff(test_repository):
     # Get the default branch name (could be "main" or "master")
@@ -158,6 +179,7 @@ def test_git_diff(test_repository):
     assert "test.txt" in result
     assert "feature changes" in result
 
+
 def test_git_commit(test_repository):
     file_path = Path(test_repository.working_dir) / "commit_test.txt"
     file_path.write_text("content to commit")
@@ -169,6 +191,7 @@ def test_git_commit(test_repository):
 
     latest_commit = test_repository.head.commit
     assert latest_commit.message.strip() == "test commit message"
+
 
 def test_git_reset(test_repository):
     file_path = Path(test_repository.working_dir) / "reset_test.txt"
@@ -184,6 +207,7 @@ def test_git_reset(test_repository):
 
     staged_after = [item.a_path for item in test_repository.index.diff("HEAD")]
     assert "reset_test.txt" not in staged_after
+
 
 def test_git_log(test_repository):
     for i in range(3):
@@ -201,12 +225,14 @@ def test_git_log(test_repository):
     assert "Date:" in result[0]
     assert "Message:" in result[0]
 
+
 def test_git_log_default(test_repository):
     result = git_log(test_repository)
 
     assert isinstance(result, list)
     assert len(result) >= 1
     assert "initial commit" in result[0]
+
 
 def test_git_create_branch(test_repository):
     result = git_create_branch(test_repository, "new-feature-branch")
@@ -215,6 +241,7 @@ def test_git_create_branch(test_repository):
 
     branches = [ref.name for ref in test_repository.references]
     assert "new-feature-branch" in branches
+
 
 def test_git_create_branch_from_base(test_repository):
     test_repository.git.checkout("-b", "base-branch")
@@ -226,6 +253,7 @@ def test_git_create_branch_from_base(test_repository):
     result = git_create_branch(test_repository, "derived-branch", "base-branch")
 
     assert "Created branch 'derived-branch' from 'base-branch'" in result
+
 
 def test_git_show(test_repository):
     file_path = Path(test_repository.working_dir) / "show_test.txt"
@@ -242,6 +270,7 @@ def test_git_show(test_repository):
     assert "show test commit" in result
     assert "show_test.txt" in result
 
+
 def test_git_show_initial_commit(test_repository):
     initial_commit = list(test_repository.iter_commits())[-1]
 
@@ -253,6 +282,7 @@ def test_git_show_initial_commit(test_repository):
 
 
 # Tests for validate_repo_path (repository scoping security fix)
+
 
 def test_validate_repo_path_no_restriction():
     """When no repository restriction is configured, any path should be allowed."""
@@ -313,7 +343,36 @@ def test_validate_repo_path_symlink_escape(tmp_path: Path):
     with pytest.raises(ValueError) as exc_info:
         validate_repo_path(symlink, allowed)
     assert "outside the allowed repository" in str(exc_info.value)
+
+
+def test_validate_startup_acl_non_strict_allows_missing_repository():
+    validate_startup_acl(None, strict_acl=False)
+
+
+def test_validate_startup_acl_strict_requires_repository():
+    with pytest.raises(ACLConfigError, match="ACL_CONFIG_MISSING"):
+        validate_startup_acl(None, strict_acl=True)
+
+
+def test_validate_startup_acl_strict_rejects_invalid_repository(tmp_path: Path):
+    not_repo = tmp_path / "not-a-repo"
+    not_repo.mkdir()
+    with pytest.raises(ACLConfigError, match="ACL_CONFIG_INVALID"):
+        validate_startup_acl(not_repo, strict_acl=True)
+
+
+def test_validate_startup_acl_non_strict_allows_invalid_repository(tmp_path: Path):
+    not_repo = tmp_path / "not-a-repo"
+    not_repo.mkdir()
+    validate_startup_acl(not_repo, strict_acl=False)
+
+
+def test_validate_startup_acl_strict_accepts_valid_repository(test_repository):
+    validate_startup_acl(Path(test_repository.working_dir), strict_acl=True)
+
+
 # Tests for argument injection protection
+
 
 def test_git_diff_rejects_flag_injection(test_repository):
     """git_diff should reject flags that could be used for argument injection."""


### PR DESCRIPTION
## Problem
Reference servers could start without explicit ACL guarantees, allowing permissive startup behavior when config was missing or invalid.

## Why now
These servers are security-conscious references; strict fail-closed startup should be available as an explicit contract.

## What changed
- Added strict ACL startup mode across three servers.

### Filesystem
- Added `--strict-acl` (and `MCP_SERVER_STRICT_ACL`) handling.
- In strict mode, startup fails when:
  - no allowed directories are configured
  - any configured ACL directory is invalid/inaccessible.
- Added startup validation tests in `startup-validation.test.ts`.

### Fetch
- Added `--strict-acl` + `--allow-host` (repeatable) and env support.
- Added ACL helpers for host allowlist normalization/validation.
- In strict mode, startup fails without explicit allow-host config.
- Enforced host allowlist at request time with deterministic ACL denial errors.
- Added targeted ACL unit coverage.

### Git
- Added `--strict-acl` and env support.
- Added startup ACL validation requiring `--repository` in strict mode and rejecting invalid repositories.
- Added targeted ACL validation tests.

## Validation
- `cd src/filesystem && npm run build && npm test -- --run __tests__/startup-validation.test.ts`
- `cd src/fetch && uv run ruff check src tests && uv run ruff format --check src tests && uv run pytest -q tests/test_server.py -k "StartupAcl or is_url_allowed or strict_acl"`
- `cd src/git && uv run ruff check src tests && uv run ruff format --check src tests && uv run pytest -q tests/test_server.py -k "validate_startup_acl"`

Refs #3439
