### PR TITLE
docs: add Windows `cmd /c npx` workaround to server READMEs

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -31,6 +31,23 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "everything": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-everything"
+>       ]
+>     }
+>   }
+> }
+> ```
+
 ## Usage with VS Code
 
 For quick installation, use of of the one-click install buttons below...
@@ -61,6 +78,23 @@ Alternatively, you can add the configuration to a file called `.vscode/mcp.json`
   }
 }
 ```
+
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "servers": {
+>     "everything": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-everything"
+>       ]
+>     }
+>   }
+> }
+> ```
 
 ## Running from source with [HTTP+SSE Transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) (deprecated as of [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports))
 

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -250,6 +250,25 @@ Note: all directories must be mounted to `/projects` by default.
 }
 ```
 
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "filesystem": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-filesystem",
+>         "C:\\Users\\username\\Desktop",
+>         "C:\\path\\to\\other\\allowed\\dir"
+>       ]
+>     }
+>   }
+> }
+> ```
+
 ## Usage with VS Code
 
 For quick installation, click the installation buttons below...
@@ -307,6 +326,24 @@ Note: all directories must be mounted to `/projects` by default.
   }
 }
 ```
+
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "servers": {
+>     "filesystem": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-filesystem",
+>         "${workspaceFolder}"
+>       ]
+>     }
+>   }
+> }
+> ```
 
 ## Build
 

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -159,6 +159,23 @@ Add this to your claude_desktop_config.json:
 }
 ```
 
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "memory": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-memory"
+>       ]
+>     }
+>   }
+> }
+> ```
+
 #### NPX with custom setting
 
 The server can be configured using the following environment variables:
@@ -179,6 +196,26 @@ The server can be configured using the following environment variables:
   }
 }
 ```
+
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "memory": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-memory"
+>       ],
+>       "env": {
+>         "MEMORY_FILE_PATH": "C:\\path\\to\\custom\\memory.jsonl"
+>       }
+>     }
+>   }
+> }
+> ```
 
 - `MEMORY_FILE_PATH`: Path to the memory storage JSONL file (default: `memory.jsonl` in the server directory)
 
@@ -215,6 +252,23 @@ Alternatively, you can add the configuration to a file called `.vscode/mcp.json`
   }
 }
 ```
+
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "servers": {
+>     "memory": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-memory"
+>       ]
+>     }
+>   }
+> }
+> ```
 
 #### Docker
 

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -59,6 +59,23 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "sequential-thinking": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-sequential-thinking"
+>       ]
+>     }
+>   }
+> }
+> ```
+
 #### docker
 
 ```json
@@ -113,6 +130,23 @@ For NPX installation:
   }
 }
 ```
+
+> **Windows users:** On Windows, `npx` is a `.cmd` batch file shim that cannot be executed directly by `child_process.spawn()`. Use `cmd /c` as the command instead:
+>
+> ```json
+> {
+>   "servers": {
+>     "sequential-thinking": {
+>       "command": "cmd",
+>       "args": [
+>         "/c", "npx",
+>         "-y",
+>         "@modelcontextprotocol/server-sequential-thinking"
+>       ]
+>     }
+>   }
+> }
+> ```
 
 For Docker installation:
 


### PR DESCRIPTION
## Problem

All official MCP server READMEs recommend NPX configs like:
```json
{ "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", ...] }
```

This silently fails on Windows because `npx` is installed as `npx.cmd` (a batch script shim), and `child_process.spawn()` — used by Claude Desktop and Claude Code — cannot execute `.cmd` files without `shell: true`, which MCP clients don't pass.

This is a well-known Node.js-on-Windows issue. Since MCP configs are copy-pasted from READMEs, Windows users hit this immediately with no clear error message.

Closes #3460

## Solution

Add a Windows-specific callout after each NPX config block showing the `cmd /c` wrapper:
```json
{ "command": "cmd", "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-filesystem", ...] }
```

## Affected servers

- `src/filesystem` — Claude Desktop + VS Code NPX sections
- `src/memory` — Claude Desktop + VS Code NPX sections  
- `src/sequentialthinking` — Claude Desktop + VS Code NPX sections
- `src/everything` — Claude Desktop NPX section

## Testing

Verified the diff is purely additive documentation — no code changes, no functional impact on macOS/Linux users.