### PR TITLE
Add ProofBets MCP Server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,7 @@ search, and comprehensive file analysis.
 - **[Prometheus](https://github.com/pab1it0/prometheus-mcp-server)** - Query and analyze Prometheus - open-source monitoring system.
 - **[Prometheus (Golang)](https://github.com/tjhop/prometheus-mcp-server/)** - A Prometheus MCP server with full API support for comprehensive management and deep interaction with Prometheus beyond basic query support. Written in go, it is a single binary install that is capable of STDIO, SSE, and HTTP transports for complex deployments. 
 - **[Prometheus (TypeScript)](https://github.com/yanmxa/prometheus-mcp-server)** - Enable AI assistants to query Prometheus using natural language with TypeScript implementation.
+- **[ProofBets](https://github.com/vjrmuc/proofbets/tree/main/mcp-server)** - Query verified crypto casino data, bonus codes, prediction market fees, and World Cup 2026 odds. 13 tools with on-chain verification via Etherscan. Supports SSE and stdio.
 - **[PubChem](https://github.com/sssjiang/pubchem_mcp_server)** - extract drug information from pubchem API.
 - **[PubMed](https://github.com/JackKuo666/PubMed-MCP-Server)** - Enable AI assistants to search, access, and analyze PubMed articles through a simple MCP interface.
 - **[Pulumi](https://github.com/dogukanakkaya/pulumi-mcp-server)** - MCP Server to Interact with Pulumi API, creates and lists Stacks


### PR DESCRIPTION
Adding ProofBets MCP Server to the community servers list.

ProofBets provides 13 tools for crypto casino intelligence:
- search_casinos, get_casino, search_bonuses, check_bonus_code, calculate_ev, compare_casinos
- search_p2p_platforms, compare_platforms, get_platform_fees
- get_world_cup_odds, search_glossary, get_guide, search_reviews

Data covers 50+ crypto casinos and 7 P2P prediction market platforms (Polymarket, Kalshi, Azuro, BetDEX, SX Bet, Overtime, Wager). All tools return source_url for AI citation.

- GitHub: https://github.com/proofbets/proofbets-mcp
- SSE transport: https://proofbets.com/api/mcp/
- Docs: https://proofbets.com/developers/
- Tech: TypeScript, @modelcontextprotocol/sdk

Placed alphabetically between Postman API and Powerdrill in the community servers section.