### PR TITLE
Add Novyx MCP to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,7 @@ search, and comprehensive file analysis.
 - **[Notion](https://github.com/suekou/mcp-notion-server)** (by suekou) - Interact with Notion API.
 - **[Notion](https://github.com/v-3/notion-server)** (by v-3) - Notion MCP integration. Search, Read, Update, and Create pages through Claude chat.
 - **[Notion](https://github.com/njbrake/notion-mcp-server)** (by njbrake) - Fork of official Notion MCP Server that returns markdown representation instead of raw json for efficient token usage
+- **[Novyx MCP](https://github.com/novyxlabs/novyx-core/tree/main/packages/novyx-mcp)** - Persistent memory for AI agents with local-first SQLite, semantic search, rollback, and cryptographic audit trails.
 - **[NPM Plus](https://github.com/shacharsol/js-package-manager-mcp)** - AI-powered JavaScript package management with security scanning, bundle analysis, and intelligent dependency management for MCP-compatible editors.
 - **[NS Travel Information](https://github.com/r-huijts/ns-mcp-server)** - Access Dutch Railways (NS) real-time train travel information and disruptions through the official NS API.
 - **[ntfy-mcp](https://github.com/teddyzxcv/ntfy-mcp)** (by teddyzxcv) - The MCP server that keeps you informed by sending the notification on phone using ntfy


### PR DESCRIPTION
Adds **Novyx MCP** to the community servers list.

Persistent memory for AI agents with local-first SQLite, semantic search, rollback, and cryptographic audit trails. 23 tools, 6 resources, 3 prompts.

- **GitHub:** https://github.com/novyxlabs/novyx-core/tree/main/packages/novyx-mcp
- **PyPI:** https://pypi.org/project/novyx-mcp/
- **Docs:** https://docs.novyxlabs.com