### PR TITLE
Add Sigil Notary — cryptographic audit trails for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ search, and comprehensive file analysis.
 - **[Sigil Notary](https://github.com/sly-the-fox/sigil)** - Tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures. Provides MCP tools for attesting actions, verifying receipts, and querying cryptographic audit chains.
 - **[Simple Loki MCP](https://github.com/ghrud92/simple-loki-mcp)** - A simple MCP server to query Loki logs using logcli.
 - **[Siri Shortcuts](https://github.com/dvcrn/mcp-server-siri-shortcuts)** - MCP to interact with Siri Shortcuts on macOS. Exposes all Shortcuts as MCP tools.
+- **[Sigil Notary](https://github.com/sly-the-fox/sigil)** - Tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures.
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP to let Claude / Windsurf / Cursor / your LLM control the browser
 - **[Slack](https://github.com/korotovsky/slack-mcp-server)** - The most powerful MCP server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins 😏.
 - **[Slack](https://github.com/zencoderai/slack-mcp-server)** - Slack MCP server which supports both stdio and Streamable HTTP transports. Extended from the original Anthropic's implementation which is now [archived](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/slack)

--- a/README.md
+++ b/README.md
@@ -1290,6 +1290,7 @@ search, and comprehensive file analysis.
 - **[Shodan MCP](https://github.com/Hexix23/shodan-mcp)** - MCP server to interact with [Shodan](https://www.shodan.io/)
 - **[Shopify](https://github.com/GeLi2001/shopify-mcp)** - MCP to interact with Shopify API including order, product, customers and so on.
 - **[Shopify Storefront](https://github.com/QuentinCody/shopify-storefront-mcp-server)** - Unofficial MCP server that allows AI agents to discover Shopify storefronts and interact with them to fetch products, collections, and other store data through the Storefront API.
+- **[Sigil Notary](https://github.com/sly-the-fox/sigil)** - Tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures. Provides MCP tools for attesting actions, verifying receipts, and querying cryptographic audit chains.
 - **[Simple Loki MCP](https://github.com/ghrud92/simple-loki-mcp)** - A simple MCP server to query Loki logs using logcli.
 - **[Siri Shortcuts](https://github.com/dvcrn/mcp-server-siri-shortcuts)** - MCP to interact with Siri Shortcuts on macOS. Exposes all Shortcuts as MCP tools.
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP to let Claude / Windsurf / Cursor / your LLM control the browser


### PR DESCRIPTION
## What

Adds [Sigil Notary](https://github.com/sly-the-fox/sigil) to the Community Servers section.

**Sigil Notary** provides tamper-evident, hash-chained audit trails for AI agents with Ed25519 signatures. Ships as an MCP server (`uvx sigil-notary`) and Python SDK (`pip install sigil-notary`).

### MCP Tools
- `attest_action` — Record an action and get a signed, hash-chained receipt
- `verify_receipt` — Verify a receipt's signature and chain integrity
- `get_chain` — Retrieve the full audit trail for the current agent

### Links
- **PyPI:** https://pypi.org/project/sigil-notary/
- **GitHub:** https://github.com/sly-the-fox/sigil
- **License:** MIT