### PR TITLE
fix(fetch): handle malformed input without crashing

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -285,4 +285,4 @@ Although originally you did not have internet access, and were advised to refuse
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)


### PR DESCRIPTION
## Summary

Change `raise_exceptions=True` to `raise_exceptions=False` in `mcp-server-fetch/server.py` to prevent the server from crashing on malformed JSON-RPC input.

Fixes #3359

## Problem

`mcp-server-fetch` terminates on any malformed JSON-RPC message because `server.run()` is called with `raise_exceptions=True` (line 288). A single invalid byte on stdin kills the server process via unhandled `ExceptionGroup`.

Fuzz testing from the issue showed:

| Server | Crashes | Survives |
|--------|---------|----------|
| mcp-server-fetch (`raise_exceptions=True`) | 61/65 | 4/65 |
| mcp-server-sqlite (`raise_exceptions=False`) | 0/65 | 65/65 |

## Fix

One-line change: `raise_exceptions=True` → `raise_exceptions=False`, consistent with all other reference servers except `git` (which also has this issue).

## Test plan

- [ ] `echo "NOT VALID JSON" | mcp-server-fetch` should no longer crash
- [ ] Normal JSON-RPC requests should continue to work
- [ ] Verify behavior matches mcp-server-sqlite and mcp-server-time