### PR TITLE
Add Intercept — open-source MCP policy enforcement proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[IMAP MCP](https://github.com/dominik1001/imap-mcp)** - 📧 An IMAP Model Context Protocol (MCP) server to expose IMAP operations as tools for AI assistants.
 - **[iMCP](https://github.com/loopwork-ai/iMCP)** - A macOS app that provides an MCP server for your iMessage, Reminders, and other Apple services.
 - **[InfluxDB](https://github.com/idoru/influxdb-mcp-server)** - Run queries against InfluxDB OSS API v2.
+- **[Intercept](https://github.com/PolicyLayer/Intercept)** - Open-source enforcement proxy that wraps any MCP server and evaluates every `tools/call` against YAML-defined policies. Block tools, rate limit, validate arguments, cap spending, and hide tools from agent context — all at the transport layer. Works with any stdio or SSE server.
 - **[Inner Monologue MCP](https://github.com/abhinav-mangla/inner-monologue-mcp)** - A cognitive reasoning tool that enables LLMs to engage in private, structured self-reflection and multi-step reasoning before generating responses, improving response quality and problem-solving capabilities.
 - **[Inoyu](https://github.com/sergehuber/inoyu-mcp-unomi-server)** - Interact with an Apache Unomi CDP customer data platform to retrieve and update customer profiles
 - **[Instagram DM](https://github.com/trypeggy/instagram_dm_mcp)** - Send DMs on Instagram via your LLM


### PR DESCRIPTION
## What is Intercept?

[Intercept](https://github.com/PolicyLayer/Intercept) is an open-source enforcement proxy that wraps any MCP server and evaluates every `tools/call` request against YAML-defined policies before forwarding to the upstream server.

## What it does

- **Block tools** — deny destructive operations like `delete_repository`
- **Rate limit** — cap tool calls per minute/hour/day
- **Validate arguments** — enforce conditions on tool call parameters
- **Spending caps** — stateful counters for financial operations
- **Hide tools** — remove tools from `tools/list` so the agent never sees them

## How it works

Intercept sits between the MCP client and server at the transport layer. The agent doesn't know it's there — it sees the same tools and schemas. Policy enforcement is deterministic (YAML rules, not prompt-based).

```
Agent → [Intercept] → MCP Server
             ↑
         policy.yaml
```

## Install

```bash
npx -y @policylayer/intercept -c policy.yaml -- npx -y @modelcontextprotocol/server-github
```

Also available as a Go binary: `go install github.com/policylayer/intercept@latest`

**License:** Apache 2.0
**npm:** [@policylayer/intercept](https://www.npmjs.com/package/@policylayer/intercept)
**Website:** [policylayer.com](https://policylayer.com)