### PR TITLE
docs: remove archived GitLab server reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The following reference servers are now archived and can be found at [servers-ar
 - **[Brave Search](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/brave-search)** - Web and local search using Brave's Search API.  Has been replaced by the [official server](https://github.com/brave/brave-search-mcp-server).
 - **[EverArt](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/everart)** - AI image generation using various models.
 - **[GitHub](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github)** - Repository management, file operations, and GitHub API integration.
-- **[GitLab](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gitlab)** - GitLab API, enabling project management.
 - **[Google Drive](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gdrive)** - File access and search capabilities for Google Drive.
 - **[Google Maps](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/google-maps)** - Location services, directions, and place details.
 - **[PostgreSQL](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/postgres)** - Read-only database access with schema inspection.


### PR DESCRIPTION
## Summary
Remove the outdated GitLab reference server entry from the Archived section of the README. The GitLab reference server was archived, and GitLab now maintains their own official MCP server which is already listed in the third-party servers section.

## Issue
Fixes #3347

## Changes
- Removed the archived GitLab server entry from the README's Archived section

## Testing
- Verified the official GitLab MCP server is still listed in the third-party servers section
- No other references to the archived GitLab server remain in the README