### PR TITLE
feat: add Pyth MCP

### DIFF
--- a/servers/pyth-mcp.json
+++ b/servers/pyth-mcp.json
@@ -1,17 +1,19 @@
 {
   "id": "pyth-mcp",
   "name": "Pyth MCP",
-  "description": "List all protocols with TVL data",
+  "description": "[Deprecated] **Deprecated: use /v2/updates/price/{publish_time} instead** — **Deprecated: use /v2/updates/price/{publish_time} instead**\n\nGet a price update for",
   "repository": "https://github.com/srimisra/pyth-mcp",
   "endpoint": "https://pyth.mcp.junct.dev/mcp",
   "transport": [
     "streamable-http"
   ],
   "tags": [
-    "read"
+    "read",
+    "rest",
+    "oracle"
   ],
   "version": "1.0.0",
   "author": "Junct",
   "llms_txt": "https://pyth.mcp.junct.dev/llms.txt",
-  "created_at": "2026-03-12T04:10:29.435Z"
+  "created_at": "2026-03-12T05:14:34.042Z"
 }


### PR DESCRIPTION
## Add Pyth MCP to the MCP Server Directory

**Server:** [Pyth MCP](https://github.com/srimisra/pyth-mcp)
**Endpoint:** `https://pyth.mcp.junct.dev/mcp`
**Transport:** Streamable HTTP (stateless)
**Auth:** None

### Description

# Pyth

> Pyth API — 3 operations.

MCP endpoint: https://pyth.mcp.junct.dev/mcp
Domain: unknown

### Tools

- **`get_protocols`** — List all protocols with TVL data
- **`get_protocol`** — Get protocol TVL history
- **`get_tvl`** — Get current TVL for a protocol

### Connection

```json
{
  "mcpServers": {
    "pyth-mcp": {
      "url": "https://pyth.mcp.junct.dev/mcp",
      "transport": "streamable-http"
    }
  }
}
```

### Registry entry (`servers.json`)

```json
{
  "id": "pyth-mcp",
  "name": "Pyth MCP",
  "description": "List all protocols with TVL data",
  "repository": "https://github.com/srimisra/pyth-mcp",
  "endpoint": "https://pyth.mcp.junct.dev/mcp",
  "transport": [
    "streamable-http"
  ],
  "tags": [
    "read"
  ],
  "version": "1.0.0",
  "author": "Junct",
  "llms_txt": "https://pyth.mcp.junct.dev/llms.txt",
  "created_at": "2026-03-12T04:00:41.978Z"
}
```

---
_Generated by [Junct](https://junct.dev) — agent-readiness infrastructure for crypto/DeFi._