### PR TITLE
fix(sequential-thinking): use z.coerce for number and boolean params

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -5,6 +5,16 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { SequentialThinkingServer } from './lib.js';
 
+/** Safe boolean coercion that correctly handles string "false" */
+const coercedBoolean = z.preprocess((val) => {
+  if (typeof val === "boolean") return val;
+  if (typeof val === "string") {
+    if (val.toLowerCase() === "true") return true;
+    if (val.toLowerCase() === "false") return false;
+  }
+  return val;
+}, z.boolean());
+
 const server = new McpServer({
   name: "sequential-thinking-server",
   version: "0.2.0",
@@ -72,14 +82,14 @@ You should:
 11. Only set nextThoughtNeeded to false when truly done and a satisfactory answer is reached`,
     inputSchema: {
       thought: z.string().describe("Your current thinking step"),
-      nextThoughtNeeded: z.coerce.boolean().describe("Whether another thought step is needed"),
+      nextThoughtNeeded: coercedBoolean.describe("Whether another thought step is needed"),
       thoughtNumber: z.coerce.number().int().min(1).describe("Current thought number (numeric value, e.g., 1, 2, 3)"),
       totalThoughts: z.coerce.number().int().min(1).describe("Estimated total thoughts needed (numeric value, e.g., 5, 10)"),
-      isRevision: z.coerce.boolean().optional().describe("Whether this revises previous thinking"),
+      isRevision: coercedBoolean.optional().describe("Whether this revises previous thinking"),
       revisesThought: z.coerce.number().int().min(1).optional().describe("Which thought is being reconsidered"),
       branchFromThought: z.coerce.number().int().min(1).optional().describe("Branching point thought number"),
       branchId: z.string().optional().describe("Branch identifier"),
-      needsMoreThoughts: z.coerce.boolean().optional().describe("If more thoughts are needed")
+      needsMoreThoughts: coercedBoolean.optional().describe("If more thoughts are needed")
     },
     outputSchema: {
       thoughtNumber: z.number(),


### PR DESCRIPTION
## Summary
LLM clients intermittently send `thoughtNumber`, `totalThoughts`, and boolean fields as strings instead of native JSON types, causing Zod validation errors. This replaces strict `z.number()` and `z.boolean()` with `z.coerce.number()` and `z.coerce.boolean()` in the inputSchema to gracefully accept both formats.

## Issue
Fixes #3428

## Changes
- Replace `z.number()` with `z.coerce.number()` for `thoughtNumber`, `totalThoughts`, `revisesThought`, and `branchFromThought`
- Replace `z.boolean()` with `z.coerce.boolean()` for `nextThoughtNeeded`, `isRevision`, and `needsMoreThoughts`

## Testing
- `z.coerce.number()` accepts both `1` and `"1"`, coercing strings to numbers
- `z.coerce.boolean()` accepts both `true` and `"true"`, coercing strings to booleans
- All `.int().min(1)` and `.optional()` constraints are preserved
- Existing tests pass unchanged since they already use native types