### PR TITLE
feat(sequential-thinking): add tool annotations

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -81,6 +81,12 @@ You should:
       branchId: z.string().optional().describe("Branch identifier"),
       needsMoreThoughts: z.boolean().optional().describe("If more thoughts are needed")
     },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     outputSchema: {
       thoughtNumber: z.number(),
       totalThoughts: z.number(),


### PR DESCRIPTION
## Summary
Adds tool annotations to the `sequentialthinking` tool, matching the pattern established by server-filesystem. This is the last unannotated reference server with a single tool.

## Issue
Fixes #3403

## Changes
- Added `readOnlyHint: true` — pure computation, no state persisted or files written
- Added `destructiveHint: false` — no data is modified or deleted
- Added `idempotentHint: true` — same input produces same reasoning structure
- Added `openWorldHint: false` — no external API calls or network access

## Testing
- Annotations are metadata-only and do not affect tool behavior
- Existing tests continue to pass
- Verified annotation format matches server-filesystem's pattern