### PR TITLE
feat(everything): add tool annotations to all 18 tools

### DIFF
--- a/src/everything/tools/echo.ts
+++ b/src/everything/tools/echo.ts
@@ -13,6 +13,7 @@ const config = {
   title: "Echo Tool",
   description: "Echoes back the input string",
   inputSchema: EchoSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-annotated-message.ts
+++ b/src/everything/tools/get-annotated-message.ts
@@ -21,6 +21,7 @@ const config = {
   description:
     "Demonstrates how annotations can be used to provide metadata about content.",
   inputSchema: GetAnnotatedMessageSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-env.ts
+++ b/src/everything/tools/get-env.ts
@@ -8,6 +8,7 @@ const config = {
   description:
     "Returns all environment variables, helpful for debugging MCP server configuration",
   inputSchema: {},
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-resource-links.ts
+++ b/src/everything/tools/get-resource-links.ts
@@ -25,6 +25,7 @@ const config = {
   description:
     "Returns up to ten resource links that reference different types of resources",
   inputSchema: GetResourceLinksSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-resource-reference.ts
+++ b/src/everything/tools/get-resource-reference.ts
@@ -28,6 +28,7 @@ const config = {
   title: "Get Resource Reference Tool",
   description: "Returns a resource reference that can be used by MCP clients",
   inputSchema: GetResourceReferenceSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-roots-list.ts
+++ b/src/everything/tools/get-roots-list.ts
@@ -9,6 +9,7 @@ const config = {
   description:
     "Lists the current MCP roots provided by the client. Demonstrates the roots protocol capability even though this server doesn't access files.",
   inputSchema: {},
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-structured-content.ts
+++ b/src/everything/tools/get-structured-content.ts
@@ -27,6 +27,7 @@ const config = {
     "Returns structured content along with an output schema for client data validation",
   inputSchema: GetStructuredContentInputSchema,
   outputSchema: GetStructuredContentOutputSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-sum.ts
+++ b/src/everything/tools/get-sum.ts
@@ -14,6 +14,7 @@ const config = {
   title: "Get Sum Tool",
   description: "Returns the sum of two numbers",
   inputSchema: GetSumSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/get-tiny-image.ts
+++ b/src/everything/tools/get-tiny-image.ts
@@ -11,6 +11,7 @@ const config = {
   title: "Get Tiny Image Tool",
   description: "Returns a tiny MCP logo image.",
   inputSchema: {},
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -48,6 +48,7 @@ const config = {
   description:
     "Compresses a single file using gzip compression. Depending upon the selected output type, returns either the compressed data as a gzipped resource or a resource link, allowing it to be downloaded in a subsequent request during the current session.",
   inputSchema: GZipFileAsResourceSchema,
+  annotations: { readOnlyHint: false, idempotentHint: true, openWorldHint: true },
 };
 
 /**

--- a/src/everything/tools/simulate-research-query.ts
+++ b/src/everything/tools/simulate-research-query.ts
@@ -254,6 +254,7 @@ export const registerSimulateResearchQueryTool = (server: McpServer) => {
         "Demonstrates MCP task-based operations with progress through multiple stages. " +
         "If 'ambiguous' is true and client supports elicitation, sends an elicitation request for clarification.",
       inputSchema: SimulateResearchQuerySchema,
+      annotations: { readOnlyHint: true },
       execution: { taskSupport: "required" },
     },
     {

--- a/src/everything/tools/toggle-simulated-logging.ts
+++ b/src/everything/tools/toggle-simulated-logging.ts
@@ -11,6 +11,7 @@ const config = {
   title: "Toggle Simulated Logging",
   description: "Toggles simulated, random-leveled logging on or off.",
   inputSchema: {},
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
 };
 
 // Track enabled clients by session id

--- a/src/everything/tools/toggle-subscriber-updates.ts
+++ b/src/everything/tools/toggle-subscriber-updates.ts
@@ -11,6 +11,7 @@ const config = {
   title: "Toggle Subscriber Updates",
   description: "Toggles simulated resource subscription updates on or off.",
   inputSchema: {},
+  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
 };
 
 // Track enabled clients by session id

--- a/src/everything/tools/trigger-elicitation-request-async.ts
+++ b/src/everything/tools/trigger-elicitation-request-async.ts
@@ -11,6 +11,7 @@ const config = {
     "Demonstrates bidirectional MCP tasks where the server sends an elicitation request and " +
     "the client handles user input asynchronously, allowing the server to poll for completion.",
   inputSchema: {},
+  annotations: { readOnlyHint: false, destructiveHint: false },
 };
 
 // Poll interval in milliseconds

--- a/src/everything/tools/trigger-elicitation-request.ts
+++ b/src/everything/tools/trigger-elicitation-request.ts
@@ -10,6 +10,7 @@ const config = {
   title: "Trigger Elicitation Request Tool",
   description: "Trigger a Request from the Server for User Elicitation",
   inputSchema: {},
+  annotations: { readOnlyHint: false, destructiveHint: false },
 };
 
 /**

--- a/src/everything/tools/trigger-long-running-operation.ts
+++ b/src/everything/tools/trigger-long-running-operation.ts
@@ -17,6 +17,7 @@ const config = {
   title: "Trigger Long Running Operation Tool",
   description: "Demonstrates a long running operation with progress updates.",
   inputSchema: TriggerLongRunningOperationSchema,
+  annotations: { readOnlyHint: true },
 };
 
 /**

--- a/src/everything/tools/trigger-sampling-request-async.ts
+++ b/src/everything/tools/trigger-sampling-request-async.ts
@@ -23,6 +23,7 @@ const config = {
     "Demonstrates bidirectional MCP tasks where the server sends a request and the client " +
     "executes it asynchronously, allowing the server to poll for progress and results.",
   inputSchema: TriggerSamplingRequestAsyncSchema,
+  annotations: { readOnlyHint: false, destructiveHint: false },
 };
 
 // Poll interval in milliseconds

--- a/src/everything/tools/trigger-sampling-request.ts
+++ b/src/everything/tools/trigger-sampling-request.ts
@@ -21,6 +21,7 @@ const config = {
   title: "Trigger Sampling Request Tool",
   description: "Trigger a Request from the Server for LLM Sampling",
   inputSchema: TriggerSamplingRequestSchema,
+  annotations: { readOnlyHint: false, destructiveHint: false },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds MCP tool annotations to all 18 tools in server-everything, the reference server developers use to learn the protocol
- Brings server-everything in line with server-filesystem, which already annotates all 14 of its tools

## Issue
Fixes #3401

## Changes
- Read-only tools (echo, get-env, get-sum, get-annotated-message, get-resource-links, get-resource-reference, get-structured-content, get-tiny-image, get-roots-list, trigger-long-running-operation, simulate-research-query): `readOnlyHint: true`
- Toggle tools (toggle-simulated-logging, toggle-subscriber-updates): `readOnlyHint: false, destructiveHint: false, idempotentHint: false`
- gzip-file-as-resource: `readOnlyHint: false, idempotentHint: true, openWorldHint: true` (fetches external URLs, creates session resources)
- Sampling/elicitation tools (trigger-sampling-request, trigger-elicitation-request, and their async variants): `readOnlyHint: false, destructiveHint: false`

## Testing
- `npm test --workspace=src/everything` — all 95 tests pass
- `npm run build --workspace=src/everything` — builds cleanly