### PR TITLE
feat: add NeuroStack to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ search, and comprehensive file analysis.
 - **[Netbird](https://github.com/aantti/mcp-netbird)** - List and analyze Netbird network peers, groups, policies, and more.
 - **[NetMind ParsePro](https://github.com/protagolabs/Netmind-Parse-PDF-MCP)** - The PDF Parser AI service, built and customized by the [NetMind](https://www.netmind.ai/) team.
 - **[NetSuite](https://github.com/dsvantien/netsuite-mcp-server)** - MCP server for NetSuite ERP integration with OAuth 2.0 authentication, enabling natural language access to NetSuite data through SuiteQL queries, reports, saved searches, and REST API operations.
+- **[NeuroStack](https://github.com/raphasouthall/neurostack)** - Local-first MCP server for Markdown knowledge graphs. Semantic search, prediction error tracking, and Leiden community detection — no cloud required.
 - **[Nikto MCP](https://github.com/weldpua2008/nikto-mcp)** (by weldpua2008) - A secure MCP server that enables AI agents to interact with Nikto web server scanner](- use with npx or docker).
 - **[NocoDB](https://github.com/edwinbernadus/nocodb-mcp-server)** - Read and write access to NocoDB database.
 - **[Node Code Sandbox](https://github.com/alfonsograziano/node-code-sandbox-mcp)** – A Node.js MCP server that spins up isolated Docker - based sandboxes for executing JavaScript snippets with on-the-fly npm dependency installation


### PR DESCRIPTION
NeuroStack is a local-first MCP server for Markdown knowledge graphs with semantic search, prediction error tracking, and Leiden community detection. PyPI: neurostack, repo: https://github.com/raphasouthall/neurostack

**What it is**: A local-first MCP server that indexes a Markdown vault (Obsidian-compatible) and exposes 9 tools to Claude Code, Cursor, or any MCP-compatible AI tool:
- `vault_search` — hybrid FTS5 + semantic search
- `vault_graph` — wiki-link neighbourhood with PageRank
- `vault_summary`, `vault_triples`, `vault_stats`, `vault_communities`
- `vault_prediction_errors` — surfaces notes that appeared in unexpected retrieval contexts
- `vault_record_usage`, `session_brief`

**Quick facts**:
- Install: `pip install neurostack`
- License: Apache-2.0
- Python 3.11+, SQLite/FTS5 — no GPU required in Lite mode
- 99 tests, CI passing, no telemetry, read-only vault access

**Links**:
- Repo: https://github.com/raphasouthall/neurostack
- PyPI: https://pypi.org/project/neurostack/