### PR TITLE
feat: add observe-instrument-mcp to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ search, and comprehensive file analysis.
 - **[ntfy-mcp](https://github.com/teddyzxcv/ntfy-mcp)** (by teddyzxcv) - The MCP server that keeps you informed by sending the notification on phone using ntfy
 - **[ntfy-me-mcp](https://github.com/gitmotion/ntfy-me-mcp)** (by gitmotion) - An ntfy MCP server for sending/fetching ntfy notifications to your self-hosted ntfy server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)
 - **[oatpp-mcp](https://github.com/oatpp/oatpp-mcp)** - C++ MCP integration for Oat++. Use [Oat++](https://oatpp.io) to build MCP servers.
+- **[Observe Instrument MCP](https://github.com/alanzha2/observe-instrument-mcp)** - Automatically instruments Python AI agents with OpenTelemetry-based tracing using the [ioa-observe-sdk](https://github.com/agntcy/observe). Supports LlamaIndex, LangGraph, CrewAI, and OpenAI SDK. Works with any LLM provider via LiteLLM.
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through your Obsidian vault or any directory containing Markdown notes
 - **[Obsidian Notes](https://github.com/Piotr1215/mcp-obsidian)** - Direct file system access to Obsidian vaults with security-first design, advanced search capabilities including MOC (Maps of Content) discovery, and support for obsidian.nvim - no Obsidian app required.
 - **[obsidian-mcp](https://github.com/StevenStavrakis/obsidian-mcp)** - (by Steven Stavrakis) An MCP server for Obsidian.md with tools for searching, reading, writing, and organizing notes.


### PR DESCRIPTION
## Summary

Adds [observe-instrument-mcp](https://github.com/alanzha2/observe-instrument-mcp) to the community servers list.

**What it does:** An MCP server that automatically instruments Python AI agents with OpenTelemetry-based tracing using the [ioa-observe-sdk](https://github.com/agntcy/observe). It adds `@agent`, `@tool`, `@graph`, and `@workflow` decorators plus `Observe.init()` and `session_start()` to existing agent code with zero manual effort.

**Supported frameworks:** LlamaIndex, LangGraph, CrewAI, raw OpenAI SDK (single-agent and multi-agent patterns)

**LLM providers:** Anthropic, OpenAI, Google Gemini, Groq, Ollama via LiteLLM

**Tools:**
- `instrument_agent` — reads a Python agent file, applies full instrumentation, writes it back with a `.bak` backup
- `check_instrumentation` — audits a file for missing instrumentation without modifying it

**PyPI:** https://pypi.org/project/observe-instrument-mcp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)