### PR TITLE
Add xpay MCP server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1449,6 +1449,7 @@ search, and comprehensive file analysis.
 - **[Xero-mcp-server](https://github.com/XeroAPI/xero-mcp-server)** - Enabling clients to interact with Xero system for streamlined accounting, invoicing, and business operations.
 - **[XiYan](https://github.com/XGenerationLab/xiyan_mcp_server)** - 🗄️ An MCP server that supports fetching data from a database using natural language queries, powered by XiyanSQL as the text-to-SQL LLM.
 - **[XMind](https://github.com/apeyroux/mcp-xmind)** - Read and search through your XMind directory containing XMind files.
+- **[xpay](https://github.com/xpaysh/mcp-server)** - 980+ AI tools as MCP servers — web scraping, lead gen, finance (253 tools), media generation, research, and dev tools from 30+ providers. Pay $0.01/call in USDC via x402 protocol.
 - **[Yahoo Finance](https://github.com/AgentX-ai/yahoo-finance-server)** - 📈 Lets your AI interact with Yahoo Finance to get comprehensive stock market data, news, financials, and more. Proxy supported.
 - **[YetiBrowser MCP](https://github.com/yetidevworks/yetibrowser-mcp)** - A fully open-source implementation of the Browser MCP workflow with standout features such as optimized screenshots, dom diffs, console access, multi-websocket support + more.
 - **[yfinance](https://github.com/Adity-star/mcp-yfinance-server)** -💹The MCP YFinance Stock Server provides real-time and historical stock data in a standard format, powering dashboards, AI agents,and research tools with seamless financial insights.


### PR DESCRIPTION
Adding xpay MCP server — 980+ AI tools available as MCP servers, pay-per-use via x402 protocol.

**Collections include:**
- Web Scraping (Firecrawl, Bright Data, Jina) — ~35 tools
- Lead Generation (Hunter, Apollo, Tomba) — ~50 tools
- Finance (FMP, Alpha Vantage, Polymarket) — 253 tools
- AI Media (FLUX, Ideogram, Recraft, MiniMax) — ~25 tools
- Developer Tools (Context7, code execution, npm scanning) — ~30 tools
- Academic Research (Semantic Scholar, arXiv, PubMed) — ~30 tools

**How it works:** $0.01/call in USDC on Base via x402 (HTTP 402). No API keys needed.

- Repo: https://github.com/xpaysh/mcp-server
- Hub: https://xpay.tools
- Docs: https://docs.xpay.sh