### PR TITLE
feat(time): add tool annotations

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -8,7 +8,7 @@ from tzlocal import get_localzone_name  # ← returns "Europe/Paris", etc.
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import Tool, TextContent, ImageContent, EmbeddedResource, ErrorData, INVALID_PARAMS
+from mcp.types import Tool, ToolAnnotations, TextContent, ImageContent, EmbeddedResource, ErrorData, INVALID_PARAMS
 from mcp.shared.exceptions import McpError
 
 from pydantic import BaseModel
@@ -142,6 +142,12 @@ async def serve(local_timezone: str | None = None) -> None:
                     },
                     "required": ["timezone"],
                 },
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
             ),
             Tool(
                 name=TimeTools.CONVERT_TIME.value,
@@ -164,6 +170,12 @@ async def serve(local_timezone: str | None = None) -> None:
                     },
                     "required": ["source_timezone", "time", "target_timezone"],
                 },
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=False,
+                ),
             ),
         ]
 


### PR DESCRIPTION
## Summary
Adds MCP ToolAnnotations to both tools in the time server (`get_current_time` and `convert_time`), marking them as read-only, non-destructive, idempotent, and closed-world — matching the annotation coverage already present in server-filesystem.

## Issue
Fixes #3574

## Changes
- Import `ToolAnnotations` from `mcp.types`
- Add `annotations` parameter to both `Tool()` declarations with `readOnlyHint=True`, `destructiveHint=False`, `idempotentHint=True`, `openWorldHint=False`

## Testing
- Metadata-only change; no behavioral impact
- Both tools are pure computations (system clock read and timezone conversion) with no side effects or external calls