### PR TITLE
Add rift zero-config dev runner to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,6 +1262,7 @@ search, and comprehensive file analysis.
 - **[Revit MCP](https://github.com/revit-mcp)** - A service implementing the MCP protocol for Autodesk Revit.
 - **[Rijksmuseum](https://github.com/r-huijts/rijksmuseum-mcp)** - Interface with the Rijksmuseum API to search artworks, retrieve artwork details, access image tiles, and explore user collections.
 - **[Riot Games](https://github.com/jifrozen0110/mcp-riot)** - MCP server for League of Legends – fetch player info, ranks, champion stats, and match history via Riot API.
+- **[Rift](https://github.com/ahmedEssyad/rift)** - Zero-config full-stack dev runner. Detects frameworks, starts all services in parallel, auto-restarts on crash, and diagnoses failures with AI. Tools: detect, start, stop, status, diagnose, fix.
 - **[Rohlik](https://github.com/tomaspavlin/rohlik-mcp)** - Shop groceries across the Rohlik Group platforms (Rohlik.cz, Knuspr.de, Gurkerl.at, Kifli.hu, Sezamo.ro)
 - **[Rquest](https://github.com/xxxbrian/mcp-rquest)** - An MCP server providing realistic browser-like HTTP request capabilities with accurate TLS/JA3/JA4 fingerprints for bypassing anti-bot measures.
 - **[Rust MCP Filesystem](https://github.com/rust-mcp-stack/rust-mcp-filesystem)** - Fast, asynchronous MCP server for efficient handling of various filesystem operations built with the power of Rust.


### PR DESCRIPTION
## Summary

- Adds [rift](https://github.com/ahmedEssyad/rift) to the community servers list
- Rift is a zero-config full-stack dev runner that detects frameworks, starts all services in parallel, auto-restarts on crash, and diagnoses failures with AI
- MCP server exposes 6 tools: detect, start, stop, status, diagnose, fix
- Published on npm as `rift-dev`

## Details

Rift replaces multi-terminal chaos with a single command. It scans a project, detects frameworks (15+ supported including Next.js, Django, FastAPI, Rails, Go, Rust), generates config, and runs all services with color-coded logs. The MCP server (`rift-mcp`) lets AI assistants manage the full dev environment lifecycle.