### PR TITLE
Add Signbee MCP server to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,7 @@ search, and comprehensive file analysis.
 - **[Shopify Storefront](https://github.com/QuentinCody/shopify-storefront-mcp-server)** - Unofficial MCP server that allows AI agents to discover Shopify storefronts and interact with them to fetch products, collections, and other store data through the Storefront API.
 - **[Simple Loki MCP](https://github.com/ghrud92/simple-loki-mcp)** - A simple MCP server to query Loki logs using logcli.
 - **[Siri Shortcuts](https://github.com/dvcrn/mcp-server-siri-shortcuts)** - MCP to interact with Siri Shortcuts on macOS. Exposes all Shortcuts as MCP tools.
+- **[Signbee](https://github.com/signbee/mcp)** - Document signing for AI agents. Send contracts for e-signature via a single API call with email OTP verification and SHA-256 signing certificates.
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP to let Claude / Windsurf / Cursor / your LLM control the browser
 - **[Slack](https://github.com/korotovsky/slack-mcp-server)** - The most powerful MCP server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins 😏.
 - **[Slack](https://github.com/zencoderai/slack-mcp-server)** - Slack MCP server which supports both stdio and Streamable HTTP transports. Extended from the original Anthropic's implementation which is now [archived](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/slack)


### PR DESCRIPTION
Adds [Signbee](https://signb.ee) to the Community Servers list.

Signbee is a document signing API that lets AI agents send contracts for e-signature via MCP, Agent Skill, or direct API call.

- **npm**: https://www.npmjs.com/package/signbee-mcp
- **GitHub**: https://github.com/signbee/mcp
- **Website**: https://signb.ee