### PR TITLE
fix(fetch): refresh uv lockfile for CI

### DIFF
--- a/src/fetch/uv.lock
+++ b/src/fetch/uv.lock
@@ -547,7 +547,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = "<0.28" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "markdownify", specifier = ">=0.13.1" },
     { name = "mcp", specifier = ">=1.1.3" },
     { name = "protego", specifier = ">=0.3.1" },


### PR DESCRIPTION
## Summary
- refresh src/fetch/uv.lock so uv sync --locked --all-extras --dev matches the current project metadata
- keep the scope limited to the Python fetch package

## Verification
- uv sync --locked --all-extras --dev in src/fetch
- uv sync --locked --all-extras --dev in src/git
- uv sync --locked --all-extras --dev in src/time

This is split out from #3434 to keep the filesystem fix focused.