### PR TITLE
fix(gitlab): handle undefined response in search_repositories

### DIFF
--- a/src/gitlab/Dockerfile
+++ b/src/gitlab/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22.12-alpine AS builder
+
+COPY src/gitlab /app
+COPY tsconfig.json /tsconfig.json
+
+WORKDIR /app
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+
+FROM node:22.12-alpine AS release
+
+WORKDIR /app
+
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/package.json
+COPY --from=builder /app/package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+RUN npm ci --ignore-scripts --omit-dev
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/src/gitlab/README.md
+++ b/src/gitlab/README.md
@@ -1,0 +1,260 @@
+# GitLab MCP Server
+
+MCP Server for the GitLab API, enabling project management, file operations, and more.
+
+### Features
+
+- **Automatic Branch Creation**: When creating/updating files or pushing changes, branches are automatically created if they don't exist
+- **Comprehensive Error Handling**: Clear error messages for common issues
+- **Git History Preservation**: Operations maintain proper Git history without force pushing
+- **Batch Operations**: Support for both single-file and multi-file operations
+
+
+## Tools
+
+1. `create_or_update_file`
+   - Create or update a single file in a project
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `file_path` (string): Path where to create/update the file
+     - `content` (string): Content of the file
+     - `commit_message` (string): Commit message
+     - `branch` (string): Branch to create/update the file in
+     - `previous_path` (optional string): Path of the file to move/rename
+   - Returns: File content and commit details
+
+2. `push_files`
+   - Push multiple files in a single commit
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `branch` (string): Branch to push to
+     - `files` (array): Files to push, each with `file_path` and `content`
+     - `commit_message` (string): Commit message
+   - Returns: Updated branch reference
+
+3. `search_repositories`
+   - Search for GitLab projects
+   - Inputs:
+     - `search` (string): Search query
+     - `page` (optional number): Page number for pagination
+     - `per_page` (optional number): Results per page (default 20)
+   - Returns: Project search results
+
+4. `create_repository`
+   - Create a new GitLab project
+   - Inputs:
+     - `name` (string): Project name
+     - `description` (optional string): Project description
+     - `visibility` (optional string): 'private', 'internal', or 'public'
+     - `initialize_with_readme` (optional boolean): Initialize with README
+   - Returns: Created project details
+
+5. `get_file_contents`
+   - Get contents of a file or directory
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `file_path` (string): Path to file/directory
+     - `ref` (optional string): Branch/tag/commit to get contents from
+   - Returns: File/directory contents
+
+6. `create_issue`
+   - Create a new issue
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `title` (string): Issue title
+     - `description` (optional string): Issue description
+     - `assignee_ids` (optional number[]): User IDs to assign
+     - `labels` (optional string[]): Labels to add
+     - `milestone_id` (optional number): Milestone ID
+   - Returns: Created issue details
+
+7. `create_merge_request`
+   - Create a new merge request
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `title` (string): MR title
+     - `description` (optional string): MR description
+     - `source_branch` (string): Branch containing changes
+     - `target_branch` (string): Branch to merge into
+     - `draft` (optional boolean): Create as draft MR
+     - `allow_collaboration` (optional boolean): Allow commits from upstream members
+   - Returns: Created merge request details
+
+8. `fork_repository`
+   - Fork a project
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `namespace` (optional string): Namespace to fork to
+   - Returns: Forked project details
+
+9. `create_branch`
+   - Create a new branch
+   - Inputs:
+     - `project_id` (string): Project ID or URL-encoded path
+     - `branch` (string): Name for new branch
+     - `ref` (optional string): Source branch/commit for new branch
+   - Returns: Created branch reference
+
+## Setup
+
+### Personal Access Token
+[Create a GitLab Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with appropriate permissions:
+   - Go to User Settings > Access Tokens in GitLab
+   - Select the required scopes:
+     - `api` for full API access
+     - `read_api` for read-only access
+     - `read_repository` and `write_repository` for repository operations
+   - Create the token and save it securely
+
+### Usage with Claude Desktop
+Add the following to your `claude_desktop_config.json`:
+
+#### Docker
+```json
+{
+  "mcpServers": { 
+    "gitlab": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "GITLAB_PERSONAL_ACCESS_TOKEN",
+        "-e",
+        "GITLAB_API_URL",
+        "mcp/gitlab"
+      ],
+      "env": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        "GITLAB_API_URL": "https://gitlab.com/api/v4" // Optional, for self-hosted instances
+      }
+    }
+  }
+}
+```
+
+#### NPX
+
+```json
+{
+  "mcpServers": {
+    "gitlab": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-gitlab"
+      ],
+      "env": {
+        "GITLAB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>",
+        "GITLAB_API_URL": "https://gitlab.com/api/v4" // Optional, for self-hosted instances
+      }
+    }
+  }
+}
+```
+
+### Usage with VS Code
+
+For quick installation, use one of the one-click installation buttons below...
+
+[![Install with NPX in VS Code](https://img.shields.io/badge/VS_Code-NPM-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gitlab&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_token%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_url%22%2C%22description%22%3A%22GitLab%20API%20URL%20(optional%2C%20default%3A%20https%3A%2F%2Fgitlab.com%2Fapi%2Fv4)%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%22%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40modelcontextprotocol%2Fserver-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agitlab_token%7D%22%2C%22GITLAB_API_URL%22%3A%22%24%7Binput%3Agitlab_url%7D%22%7D%7D) [![Install with NPX in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-NPM-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gitlab&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_token%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_url%22%2C%22description%22%3A%22GitLab%20API%20URL%20(optional%2C%20default%3A%20https%3A%2F%2Fgitlab.com%2Fapi%2Fv4)%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%22%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40modelcontextprotocol%2Fserver-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agitlab_token%7D%22%2C%22GITLAB_API_URL%22%3A%22%24%7Binput%3Agitlab_url%7D%22%7D%7D&quality=insiders)
+
+[![Install with Docker in VS Code](https://img.shields.io/badge/VS_Code-Docker-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gitlab&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_token%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_url%22%2C%22description%22%3A%22GitLab%20API%20URL%20(optional%2C%20default%3A%20https%3A%2F%2Fgitlab.com%2Fapi%2Fv4)%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%22%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22--rm%22%2C%22-i%22%2C%22mcp%2Fgitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agitlab_token%7D%22%2C%22GITLAB_API_URL%22%3A%22%24%7Binput%3Agitlab_url%7D%22%7D%7D) [![Install with Docker in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Docker-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=gitlab&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_token%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22gitlab_url%22%2C%22description%22%3A%22GitLab%20API%20URL%20(optional%2C%20default%3A%20https%3A%2F%2Fgitlab.com%2Fapi%2Fv4)%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%22%7D%5D&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22--rm%22%2C%22-i%22%2C%22mcp%2Fgitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_PERSONAL_ACCESS_TOKEN%22%3A%22%24%7Binput%3Agitlab_token%7D%22%2C%22GITLAB_API_URL%22%3A%22%24%7Binput%3Agitlab_url%7D%22%7D%7D&quality=insiders)
+
+For manual installation, add the following JSON block to your User Settings (JSON) file in VS Code. You can do this by pressing `Ctrl + Shift + P` and typing `Preferences: Open User Settings (JSON)`.
+
+Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace. This will allow you to share the configuration with others.
+
+> Note that the `mcp` key is not needed in the `.vscode/mcp.json` file.
+
+#### Docker
+
+```json
+{
+  "mcp": {
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "gitlab_token",
+        "description": "GitLab Personal Access Token",
+        "password": true
+      },
+      {
+        "type": "promptString",
+        "id": "gitlab_url",
+        "description": "GitLab API URL (optional)",
+        "default": "https://gitlab.com/api/v4"
+      }
+    ],
+    "servers": {
+      "gitlab": {
+        "command": "docker",
+        "args": [
+          "run",
+          "--rm",
+          "-i",
+          "mcp/gitlab"
+        ],
+        "env": {
+          "GITLAB_PERSONAL_ACCESS_TOKEN": "${input:gitlab_token}",
+          "GITLAB_API_URL": "${input:gitlab_url}"
+        }
+      }
+    }
+  }
+}
+```
+
+#### NPX
+
+```json
+{
+  "mcp": {
+    "inputs": [
+      {
+        "type": "promptString",
+        "id": "gitlab_token",
+        "description": "GitLab Personal Access Token",
+        "password": true
+      },
+      {
+        "type": "promptString",
+        "id": "gitlab_url",
+        "description": "GitLab API URL (optional)",
+        "default": "https://gitlab.com/api/v4"
+      }
+    ],
+    "servers": {
+      "gitlab": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@modelcontextprotocol/server-gitlab"
+        ],
+        "env": {
+          "GITLAB_PERSONAL_ACCESS_TOKEN": "${input:gitlab_token}",
+          "GITLAB_API_URL": "${input:gitlab_url}"
+        }
+      }
+    }
+  }
+}
+```
+
+## Build
+
+Docker build:
+
+```bash
+docker build -t vonwig/gitlab:mcp -f src/gitlab/Dockerfile .
+```
+
+## Environment Variables
+
+- `GITLAB_PERSONAL_ACCESS_TOKEN`: Your GitLab personal access token (required)
+- `GITLAB_API_URL`: Base URL for GitLab API (optional, defaults to `https://gitlab.com/api/v4`)
+
+## License
+
+This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/src/gitlab/index.ts
+++ b/src/gitlab/index.ts
@@ -1,0 +1,518 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  GitLabForkSchema,
+  GitLabReferenceSchema,
+  GitLabRepositorySchema,
+  GitLabIssueSchema,
+  GitLabMergeRequestSchema,
+  GitLabContentSchema,
+  GitLabCreateUpdateFileResponseSchema,
+  GitLabSearchResponseSchema,
+  GitLabTreeSchema,
+  GitLabCommitSchema,
+  CreateRepositoryOptionsSchema,
+  CreateIssueOptionsSchema,
+  CreateMergeRequestOptionsSchema,
+  CreateBranchOptionsSchema,
+  CreateOrUpdateFileSchema,
+  SearchRepositoriesSchema,
+  CreateRepositorySchema,
+  GetFileContentsSchema,
+  PushFilesSchema,
+  CreateIssueSchema,
+  CreateMergeRequestSchema,
+  ForkRepositorySchema,
+  CreateBranchSchema,
+  type GitLabFork,
+  type GitLabReference,
+  type GitLabRepository,
+  type GitLabIssue,
+  type GitLabMergeRequest,
+  type GitLabContent,
+  type GitLabCreateUpdateFileResponse,
+  type GitLabSearchResponse,
+  type GitLabTree,
+  type GitLabCommit,
+  type FileOperation,
+} from './schemas.js';
+
+const server = new Server({
+  name: "gitlab-mcp-server",
+  version: "0.5.1",
+}, {
+  capabilities: {
+    tools: {}
+  }
+});
+
+const GITLAB_PERSONAL_ACCESS_TOKEN = process.env.GITLAB_PERSONAL_ACCESS_TOKEN;
+const GITLAB_API_URL = process.env.GITLAB_API_URL || 'https://gitlab.com/api/v4';
+
+if (!GITLAB_PERSONAL_ACCESS_TOKEN) {
+  console.error("GITLAB_PERSONAL_ACCESS_TOKEN environment variable is not set");
+  process.exit(1);
+}
+
+async function forkProject(
+  projectId: string,
+  namespace?: string
+): Promise<GitLabFork> {
+  const url = `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/fork`;
+  const queryParams = namespace ? `?namespace=${encodeURIComponent(namespace)}` : '';
+
+  const response = await fetch(url + queryParams, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+      "Content-Type": "application/json"
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabForkSchema.parse(await response.json());
+}
+
+async function createBranch(
+  projectId: string,
+  options: z.infer<typeof CreateBranchOptionsSchema>
+): Promise<GitLabReference> {
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/branches`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        branch: options.name,
+        ref: options.ref
+      })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabReferenceSchema.parse(await response.json());
+}
+
+async function getFileContents(
+  projectId: string,
+  filePath: string,
+  ref?: string
+): Promise<GitLabContent> {
+  const encodedPath = encodeURIComponent(filePath);
+  let url = `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/files/${encodedPath}`;
+  if (ref) {
+    url += `?ref=${encodeURIComponent(ref)}`;
+  } else {
+    url += '?ref=HEAD';
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  const data = GitLabContentSchema.parse(await response.json());
+  
+  if (!Array.isArray(data) && data.content) {
+    data.content = Buffer.from(data.content, 'base64').toString('utf8');
+  }
+
+  return data;
+}
+
+async function createIssue(
+  projectId: string,
+  options: z.infer<typeof CreateIssueOptionsSchema>
+): Promise<GitLabIssue> {
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/issues`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        title: options.title,
+        description: options.description,
+        assignee_ids: options.assignee_ids,
+        milestone_id: options.milestone_id,
+        labels: options.labels?.join(',')
+      })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabIssueSchema.parse(await response.json());
+}
+
+async function createMergeRequest(
+  projectId: string,
+  options: z.infer<typeof CreateMergeRequestOptionsSchema>
+): Promise<GitLabMergeRequest> {
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/merge_requests`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        title: options.title,
+        description: options.description,
+        source_branch: options.source_branch,
+        target_branch: options.target_branch,
+        allow_collaboration: options.allow_collaboration,
+        draft: options.draft
+      })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabMergeRequestSchema.parse(await response.json());
+}
+
+async function createOrUpdateFile(
+  projectId: string,
+  filePath: string,
+  content: string,
+  commitMessage: string,
+  branch: string,
+  previousPath?: string
+): Promise<GitLabCreateUpdateFileResponse> {
+  const encodedPath = encodeURIComponent(filePath);
+  const url = `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/files/${encodedPath}`;
+
+  const body = {
+    branch,
+    content,
+    commit_message: commitMessage,
+    ...(previousPath ? { previous_path: previousPath } : {})
+  };
+
+  // Check if file exists
+  let method = "POST";
+  try {
+    await getFileContents(projectId, filePath, branch);
+    method = "PUT";
+  } catch (error) {
+    // File doesn't exist, use POST
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabCreateUpdateFileResponseSchema.parse(await response.json());
+}
+
+async function createTree(
+  projectId: string,
+  files: FileOperation[],
+  ref?: string
+): Promise<GitLabTree> {
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/tree`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        files: files.map(file => ({
+          file_path: file.path,
+          content: file.content
+        })),
+        ...(ref ? { ref } : {})
+      })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabTreeSchema.parse(await response.json());
+}
+
+async function createCommit(
+  projectId: string,
+  message: string,
+  branch: string,
+  actions: FileOperation[]
+): Promise<GitLabCommit> {
+  const response = await fetch(
+    `${GITLAB_API_URL}/projects/${encodeURIComponent(projectId)}/repository/commits`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        branch,
+        commit_message: message,
+        actions: actions.map(action => ({
+          action: "create",
+          file_path: action.path,
+          content: action.content
+        }))
+      })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabCommitSchema.parse(await response.json());
+}
+
+async function searchProjects(
+  query: string,
+  page: number = 1,
+  perPage: number = 20
+): Promise<GitLabSearchResponse> {
+  const url = new URL(`${GITLAB_API_URL}/projects`);
+  url.searchParams.append("search", query);
+  url.searchParams.append("page", page.toString());
+  url.searchParams.append("per_page", perPage.toString());
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  const projects = await response.json();
+  return GitLabSearchResponseSchema.parse({
+    count: parseInt(response.headers.get("X-Total") || "0"),
+    items: projects ?? []
+  });
+}
+
+async function createRepository(
+  options: z.infer<typeof CreateRepositoryOptionsSchema>
+): Promise<GitLabRepository> {
+  const response = await fetch(`${GITLAB_API_URL}/projects`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${GITLAB_PERSONAL_ACCESS_TOKEN}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      name: options.name,
+      description: options.description,
+      visibility: options.visibility,
+      initialize_with_readme: options.initialize_with_readme
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitLab API error: ${response.statusText}`);
+  }
+
+  return GitLabRepositorySchema.parse(await response.json());
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "create_or_update_file",
+        description: "Create or update a single file in a GitLab project",
+        inputSchema: zodToJsonSchema(CreateOrUpdateFileSchema)
+      },
+      {
+        name: "search_repositories",
+        description: "Search for GitLab projects",
+        inputSchema: zodToJsonSchema(SearchRepositoriesSchema)
+      },
+      {
+        name: "create_repository",
+        description: "Create a new GitLab project",
+        inputSchema: zodToJsonSchema(CreateRepositorySchema)
+      },
+      {
+        name: "get_file_contents",
+        description: "Get the contents of a file or directory from a GitLab project",
+        inputSchema: zodToJsonSchema(GetFileContentsSchema)
+      },
+      {
+        name: "push_files",
+        description: "Push multiple files to a GitLab project in a single commit",
+        inputSchema: zodToJsonSchema(PushFilesSchema)
+      },
+      {
+        name: "create_issue",
+        description: "Create a new issue in a GitLab project",
+        inputSchema: zodToJsonSchema(CreateIssueSchema)
+      },
+      {
+        name: "create_merge_request",
+        description: "Create a new merge request in a GitLab project",
+        inputSchema: zodToJsonSchema(CreateMergeRequestSchema)
+      },
+      {
+        name: "fork_repository",
+        description: "Fork a GitLab project to your account or specified namespace",
+        inputSchema: zodToJsonSchema(ForkRepositorySchema)
+      },
+      {
+        name: "create_branch",
+        description: "Create a new branch in a GitLab project",
+        inputSchema: zodToJsonSchema(CreateBranchSchema)
+      }
+    ]
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    if (!request.params.arguments) {
+      throw new Error("Arguments are required");
+    }
+
+    switch (request.params.name) {
+      case "fork_repository": {
+        const args = ForkRepositorySchema.parse(request.params.arguments);
+        const fork = await forkProject(args.project_id, args.namespace);
+        return { content: [{ type: "text", text: JSON.stringify(fork, null, 2) }] };
+      }
+
+      case "create_branch": {
+        const args = CreateBranchSchema.parse(request.params.arguments);
+        let ref = args.ref;
+        if (!ref) {
+          ref = "HEAD";
+        }
+
+        const branch = await createBranch(args.project_id, {
+          name: args.branch,
+          ref
+        });
+
+        return { content: [{ type: "text", text: JSON.stringify(branch, null, 2) }] };
+      }
+
+      case "search_repositories": {
+        const args = SearchRepositoriesSchema.parse(request.params.arguments);
+        const results = await searchProjects(args.search, args.page, args.per_page);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      }
+
+      case "create_repository": {
+        const args = CreateRepositorySchema.parse(request.params.arguments);
+        const repository = await createRepository(args);
+        return { content: [{ type: "text", text: JSON.stringify(repository, null, 2) }] };
+      }
+
+      case "get_file_contents": {
+        const args = GetFileContentsSchema.parse(request.params.arguments);
+        const contents = await getFileContents(args.project_id, args.file_path, args.ref);
+        return { content: [{ type: "text", text: JSON.stringify(contents, null, 2) }] };
+      }
+
+      case "create_or_update_file": {
+        const args = CreateOrUpdateFileSchema.parse(request.params.arguments);
+        const result = await createOrUpdateFile(
+          args.project_id,
+          args.file_path,
+          args.content,
+          args.commit_message,
+          args.branch,
+          args.previous_path
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "push_files": {
+        const args = PushFilesSchema.parse(request.params.arguments);
+        const result = await createCommit(
+          args.project_id,
+          args.commit_message,
+          args.branch,
+          args.files.map(f => ({ path: f.file_path, content: f.content }))
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case "create_issue": {
+        const args = CreateIssueSchema.parse(request.params.arguments);
+        const { project_id, ...options } = args;
+        const issue = await createIssue(project_id, options);
+        return { content: [{ type: "text", text: JSON.stringify(issue, null, 2) }] };
+      }
+
+      case "create_merge_request": {
+        const args = CreateMergeRequestSchema.parse(request.params.arguments);
+        const { project_id, ...options } = args;
+        const mergeRequest = await createMergeRequest(project_id, options);
+        return { content: [{ type: "text", text: JSON.stringify(mergeRequest, null, 2) }] };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(`Invalid arguments: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`);
+    }
+    throw error;
+  }
+});
+
+async function runServer() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("GitLab MCP Server running on stdio");
+}
+
+runServer().catch((error) => {
+  console.error("Fatal error in main():", error);
+  process.exit(1);
+});

--- a/src/gitlab/package.json
+++ b/src/gitlab/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@modelcontextprotocol/server-gitlab",
+  "version": "0.6.2",
+  "description": "MCP server for using the GitLab API",
+  "license": "MIT",
+  "author": "GitLab, PBC (https://gitlab.com)",
+  "homepage": "https://modelcontextprotocol.io",
+  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "type": "module",
+  "bin": {
+    "mcp-server-gitlab": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc && shx chmod +x dist/*.js",
+    "prepare": "npm run build",
+    "watch": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.0.1",
+    "@types/node-fetch": "^2.6.12",
+    "node-fetch": "^3.3.2",
+    "zod-to-json-schema": "^3.23.5"
+  },
+  "devDependencies": {
+    "shx": "^0.3.4",
+    "typescript": "^5.6.2"
+  }
+}

--- a/src/gitlab/schemas.ts
+++ b/src/gitlab/schemas.ts
@@ -1,0 +1,325 @@
+import { z } from 'zod';
+
+// Base schemas for common types
+export const GitLabAuthorSchema = z.object({
+  name: z.string(),
+  email: z.string(),
+  date: z.string()
+});
+
+// Repository related schemas
+export const GitLabOwnerSchema = z.object({
+  username: z.string(), // Changed from login to match GitLab API
+  id: z.number(),
+  avatar_url: z.string(),
+  web_url: z.string(), // Changed from html_url to match GitLab API
+  name: z.string(), // Added as GitLab includes full name
+  state: z.string() // Added as GitLab includes user state
+});
+
+export const GitLabRepositorySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  path_with_namespace: z.string(), // Changed from full_name to match GitLab API
+  visibility: z.string(), // Changed from private to match GitLab API
+  owner: GitLabOwnerSchema.optional(),
+  web_url: z.string(), // Changed from html_url to match GitLab API
+  description: z.string().nullable(),
+  fork: z.boolean().optional(),
+  ssh_url_to_repo: z.string(), // Changed from ssh_url to match GitLab API
+  http_url_to_repo: z.string(), // Changed from clone_url to match GitLab API
+  created_at: z.string(),
+  last_activity_at: z.string(), // Changed from updated_at to match GitLab API
+  default_branch: z.string()
+});
+
+// File content schemas
+export const GitLabFileContentSchema = z.object({
+  file_name: z.string(), // Changed from name to match GitLab API
+  file_path: z.string(), // Changed from path to match GitLab API
+  size: z.number(),
+  encoding: z.string(),
+  content: z.string(),
+  content_sha256: z.string(), // Changed from sha to match GitLab API
+  ref: z.string(), // Added as GitLab requires branch reference
+  blob_id: z.string(), // Added to match GitLab API
+  last_commit_id: z.string() // Added to match GitLab API
+});
+
+export const GitLabDirectoryContentSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  type: z.string(),
+  mode: z.string(),
+  id: z.string(), // Changed from sha to match GitLab API
+  web_url: z.string() // Changed from html_url to match GitLab API
+});
+
+export const GitLabContentSchema = z.union([
+  GitLabFileContentSchema,
+  z.array(GitLabDirectoryContentSchema)
+]);
+
+// Operation schemas
+export const FileOperationSchema = z.object({
+  path: z.string(),
+  content: z.string()
+});
+
+// Tree and commit schemas
+export const GitLabTreeEntrySchema = z.object({
+  id: z.string(), // Changed from sha to match GitLab API
+  name: z.string(),
+  type: z.enum(['blob', 'tree']),
+  path: z.string(),
+  mode: z.string()
+});
+
+export const GitLabTreeSchema = z.object({
+  id: z.string(), // Changed from sha to match GitLab API
+  tree: z.array(GitLabTreeEntrySchema)
+});
+
+export const GitLabCommitSchema = z.object({
+  id: z.string(), // Changed from sha to match GitLab API
+  short_id: z.string(), // Added to match GitLab API
+  title: z.string(), // Changed from message to match GitLab API
+  author_name: z.string(),
+  author_email: z.string(),
+  authored_date: z.string(),
+  committer_name: z.string(),
+  committer_email: z.string(),
+  committed_date: z.string(),
+  web_url: z.string(), // Changed from html_url to match GitLab API
+  parent_ids: z.array(z.string()) // Changed from parents to match GitLab API
+});
+
+// Reference schema
+export const GitLabReferenceSchema = z.object({
+  name: z.string(), // Changed from ref to match GitLab API
+  commit: z.object({
+    id: z.string(), // Changed from sha to match GitLab API
+    web_url: z.string() // Changed from url to match GitLab API
+  })
+});
+
+// Input schemas for operations
+export const CreateRepositoryOptionsSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  visibility: z.enum(['private', 'internal', 'public']).optional(), // Changed from private to match GitLab API
+  initialize_with_readme: z.boolean().optional() // Changed from auto_init to match GitLab API
+});
+
+export const CreateIssueOptionsSchema = z.object({
+  title: z.string(),
+  description: z.string().optional(), // Changed from body to match GitLab API
+  assignee_ids: z.array(z.number()).optional(), // Changed from assignees to match GitLab API
+  milestone_id: z.number().optional(), // Changed from milestone to match GitLab API
+  labels: z.array(z.string()).optional()
+});
+
+export const CreateMergeRequestOptionsSchema = z.object({ // Changed from CreatePullRequestOptionsSchema
+  title: z.string(),
+  description: z.string().optional(), // Changed from body to match GitLab API
+  source_branch: z.string(), // Changed from head to match GitLab API
+  target_branch: z.string(), // Changed from base to match GitLab API
+  allow_collaboration: z.boolean().optional(), // Changed from maintainer_can_modify to match GitLab API
+  draft: z.boolean().optional()
+});
+
+export const CreateBranchOptionsSchema = z.object({
+  name: z.string(), // Changed from ref to match GitLab API
+  ref: z.string() // The source branch/commit for the new branch
+});
+
+// Response schemas for operations
+export const GitLabCreateUpdateFileResponseSchema = z.object({
+  file_path: z.string(),
+  branch: z.string(),
+  commit_id: z.string(), // Changed from sha to match GitLab API
+  content: GitLabFileContentSchema.optional()
+});
+
+export const GitLabSearchResponseSchema = z.object({
+  count: z.number(), // Changed from total_count to match GitLab API
+  items: z.array(GitLabRepositorySchema)
+});
+
+// Fork related schemas
+export const GitLabForkParentSchema = z.object({
+  name: z.string(),
+  path_with_namespace: z.string(), // Changed from full_name to match GitLab API
+  owner: z.object({
+    username: z.string(), // Changed from login to match GitLab API
+    id: z.number(),
+    avatar_url: z.string()
+  }),
+  web_url: z.string() // Changed from html_url to match GitLab API
+});
+
+export const GitLabForkSchema = GitLabRepositorySchema.extend({
+  forked_from_project: GitLabForkParentSchema // Changed from parent to match GitLab API
+});
+
+// Issue related schemas
+export const GitLabLabelSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  color: z.string(),
+  description: z.string().optional()
+});
+
+export const GitLabUserSchema = z.object({
+  username: z.string(), // Changed from login to match GitLab API
+  id: z.number(),
+  name: z.string(),
+  avatar_url: z.string(),
+  web_url: z.string() // Changed from html_url to match GitLab API
+});
+
+export const GitLabMilestoneSchema = z.object({
+  id: z.number(),
+  iid: z.number(), // Added to match GitLab API
+  title: z.string(),
+  description: z.string(),
+  state: z.string(),
+  web_url: z.string() // Changed from html_url to match GitLab API
+});
+
+export const GitLabIssueSchema = z.object({
+  id: z.number(),
+  iid: z.number(), // Added to match GitLab API
+  project_id: z.number(), // Added to match GitLab API
+  title: z.string(),
+  description: z.string(), // Changed from body to match GitLab API
+  state: z.string(),
+  author: GitLabUserSchema,
+  assignees: z.array(GitLabUserSchema),
+  labels: z.array(GitLabLabelSchema),
+  milestone: GitLabMilestoneSchema.nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  closed_at: z.string().nullable(),
+  web_url: z.string() // Changed from html_url to match GitLab API
+});
+
+// Merge Request related schemas (equivalent to Pull Request)
+export const GitLabMergeRequestDiffRefSchema = z.object({
+  base_sha: z.string(),
+  head_sha: z.string(),
+  start_sha: z.string()
+});
+
+export const GitLabMergeRequestSchema = z.object({
+  id: z.number(),
+  iid: z.number(), // Added to match GitLab API
+  project_id: z.number(), // Added to match GitLab API
+  title: z.string(),
+  description: z.string(), // Changed from body to match GitLab API
+  state: z.string(),
+  merged: z.boolean().optional(),
+  author: GitLabUserSchema,
+  assignees: z.array(GitLabUserSchema),
+  source_branch: z.string(), // Changed from head to match GitLab API
+  target_branch: z.string(), // Changed from base to match GitLab API
+  diff_refs: GitLabMergeRequestDiffRefSchema.nullable(),
+  web_url: z.string(), // Changed from html_url to match GitLab API
+  created_at: z.string(),
+  updated_at: z.string(),
+  merged_at: z.string().nullable(),
+  closed_at: z.string().nullable(),
+  merge_commit_sha: z.string().nullable()
+});
+
+// API Operation Parameter Schemas
+const ProjectParamsSchema = z.object({
+  project_id: z.string().describe("Project ID or URL-encoded path") // Changed from owner/repo to match GitLab API
+});
+
+export const CreateOrUpdateFileSchema = ProjectParamsSchema.extend({
+  file_path: z.string().describe("Path where to create/update the file"),
+  content: z.string().describe("Content of the file"),
+  commit_message: z.string().describe("Commit message"),
+  branch: z.string().describe("Branch to create/update the file in"),
+  previous_path: z.string().optional()
+    .describe("Path of the file to move/rename")
+});
+
+export const SearchRepositoriesSchema = z.object({
+  search: z.string().describe("Search query"), // Changed from query to match GitLab API
+  page: z.number().optional().describe("Page number for pagination (default: 1)"),
+  per_page: z.number().optional().describe("Number of results per page (default: 20)")
+});
+
+export const CreateRepositorySchema = z.object({
+  name: z.string().describe("Repository name"),
+  description: z.string().optional().describe("Repository description"),
+  visibility: z.enum(['private', 'internal', 'public']).optional()
+    .describe("Repository visibility level"),
+  initialize_with_readme: z.boolean().optional()
+    .describe("Initialize with README.md")
+});
+
+export const GetFileContentsSchema = ProjectParamsSchema.extend({
+  file_path: z.string().describe("Path to the file or directory"),
+  ref: z.string().optional().describe("Branch/tag/commit to get contents from")
+});
+
+export const PushFilesSchema = ProjectParamsSchema.extend({
+  branch: z.string().describe("Branch to push to"),
+  files: z.array(z.object({
+    file_path: z.string().describe("Path where to create the file"),
+    content: z.string().describe("Content of the file")
+  })).describe("Array of files to push"),
+  commit_message: z.string().describe("Commit message")
+});
+
+export const CreateIssueSchema = ProjectParamsSchema.extend({
+  title: z.string().describe("Issue title"),
+  description: z.string().optional().describe("Issue description"),
+  assignee_ids: z.array(z.number()).optional().describe("Array of user IDs to assign"),
+  labels: z.array(z.string()).optional().describe("Array of label names"),
+  milestone_id: z.number().optional().describe("Milestone ID to assign")
+});
+
+export const CreateMergeRequestSchema = ProjectParamsSchema.extend({
+  title: z.string().describe("Merge request title"),
+  description: z.string().optional().describe("Merge request description"),
+  source_branch: z.string().describe("Branch containing changes"),
+  target_branch: z.string().describe("Branch to merge into"),
+  draft: z.boolean().optional().describe("Create as draft merge request"),
+  allow_collaboration: z.boolean().optional()
+    .describe("Allow commits from upstream members")
+});
+
+export const ForkRepositorySchema = ProjectParamsSchema.extend({
+  namespace: z.string().optional()
+    .describe("Namespace to fork to (full path)")
+});
+
+export const CreateBranchSchema = ProjectParamsSchema.extend({
+  branch: z.string().describe("Name for the new branch"),
+  ref: z.string().optional()
+    .describe("Source branch/commit for new branch")
+});
+
+// Export types
+export type GitLabAuthor = z.infer<typeof GitLabAuthorSchema>;
+export type GitLabFork = z.infer<typeof GitLabForkSchema>;
+export type GitLabIssue = z.infer<typeof GitLabIssueSchema>;
+export type GitLabMergeRequest = z.infer<typeof GitLabMergeRequestSchema>;
+export type GitLabRepository = z.infer<typeof GitLabRepositorySchema>;
+export type GitLabFileContent = z.infer<typeof GitLabFileContentSchema>;
+export type GitLabDirectoryContent = z.infer<typeof GitLabDirectoryContentSchema>;
+export type GitLabContent = z.infer<typeof GitLabContentSchema>;
+export type FileOperation = z.infer<typeof FileOperationSchema>;
+export type GitLabTree = z.infer<typeof GitLabTreeSchema>;
+export type GitLabCommit = z.infer<typeof GitLabCommitSchema>;
+export type GitLabReference = z.infer<typeof GitLabReferenceSchema>;
+export type CreateRepositoryOptions = z.infer<typeof CreateRepositoryOptionsSchema>;
+export type CreateIssueOptions = z.infer<typeof CreateIssueOptionsSchema>;
+export type CreateMergeRequestOptions = z.infer<typeof CreateMergeRequestOptionsSchema>;
+export type CreateBranchOptions = z.infer<typeof CreateBranchOptionsSchema>;
+export type GitLabCreateUpdateFileResponse = z.infer<typeof GitLabCreateUpdateFileResponseSchema>;
+export type GitLabSearchResponse = z.infer<typeof GitLabSearchResponseSchema>;

--- a/src/gitlab/tsconfig.json
+++ b/src/gitlab/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./dist",
+      "rootDir": "."
+    },
+    "include": [
+      "./**/*.ts"
+    ]
+  }
+  


### PR DESCRIPTION
## Summary

Fixes #3454

The `search_repositories` tool in `server-gitlab` crashes with `McpError: Cannot read properties of undefined (reading 'map')` when used against Enterprise self-hosted GitLab (v18.4).

**Root cause**: The `/projects` API endpoint on some Enterprise GitLab instances may return a non-array response body. When this `undefined` value is passed to Zod's `z.array()` validator, it internally calls `.map()` on `undefined`, causing the crash.

**Fix**: Add nullish coalescing (`?? []`) to default `projects` to an empty array when the API response is `undefined` or `null`.

```diff
-    items: projects
+    items: projects ?? []
```

**Note**: The `src/gitlab/` directory was previously archived. This PR restores it to apply the fix. The actual code change is a single line in `src/gitlab/index.ts`.