### PR TITLE
fix(filesystem): normalize UNC paths in access check

### DIFF
--- a/src/filesystem/path-validation.ts
+++ b/src/filesystem/path-validation.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { normalizePath } from './path-utils.js';
 
 /**
  * Checks if an absolute path is within any of the allowed directories.
@@ -24,10 +25,10 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
     return false;
   }
 
-  // Normalize the input path
+  // Normalize the input path using normalizePath to correctly handle UNC paths
   let normalizedPath: string;
   try {
-    normalizedPath = path.resolve(path.normalize(absolutePath));
+    normalizedPath = normalizePath(path.resolve(normalizePath(absolutePath)));
   } catch {
     return false;
   }
@@ -48,10 +49,10 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
       return false;
     }
 
-    // Normalize the allowed directory
+    // Normalize the allowed directory using normalizePath to correctly handle UNC paths
     let normalizedDir: string;
     try {
-      normalizedDir = path.resolve(path.normalize(dir));
+      normalizedDir = normalizePath(path.resolve(normalizePath(dir)));
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary

UNC/network share paths (`\\server\share\subdir`) fail the access check in `isPathWithinAllowedDirectories()` despite the parent share being in the allowed directories list. The root listing works but any subdirectory access fails.

**Root cause**: `path-validation.ts` used `path.resolve(path.normalize(...))` to normalize paths, which can mangle the `\\` prefix on UNC paths on Windows. Meanwhile, `path-utils.ts` already has a `normalizePath()` function with explicit UNC path handling that preserves the prefix correctly.

**Fix**: Use `normalizePath()` from `path-utils.ts` in `isPathWithinAllowedDirectories()` instead of raw `path.resolve(path.normalize(...))`, ensuring both the requested path and allowed directories are normalized consistently for UNC paths.

All 145 existing tests pass.

Fixes #3527