### PR TITLE
Add Google Sheets MCP Server (Python, 32 tools, OAuth2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[Google Maps](https://github.com/Mastan1301/google_maps_mcp)** - Provides location results using Google Places API.
 - **[Google Sheets](https://github.com/xing5/mcp-google-sheets)** - Access and editing data to your Google Sheets.
 - **[Google Sheets](https://github.com/rohans2/mcp-google-sheets)** - An MCP Server written in TypeScript to access and edit data in your Google Sheets.
+- **[Google Sheets MCP](https://github.com/geosta-engineer/mcp-google-sheets)** - Python MCP server with 32 tools for creating, reading, writing and formatting Google Sheets. Supports OAuth2, Service Account and ADC. Compatible with Claude Desktop & Claude Code.
 - **[Google Tasks](https://github.com/zcaceres/gtasks-mcp)** - Google Tasks API Model Context Protocol Server.
 - **[Google Vertex AI Search](https://github.com/ubie-oss/mcp-vertexai-search)** - Provides Google Vertex AI Search results by grounding a Gemini model with your own private data
 - **[Google Workspace](https://github.com/taylorwilsdon/google_workspace_mcp)** - Comprehensive Google Workspace MCP with full support for Calendar, Drive, Gmail, and Docs using Streamable HTTP or SSE transport.


### PR DESCRIPTION
## New Community Server: Google Sheets MCP

**Repository:** https://github.com/geosta-engineer/mcp-google-sheets

### What it does
A Python MCP server that connects Claude directly to a user's Google Sheets account. Exposes **32 tools** across 5 modules:

| Module | Tools |
|---|---|
| Spreadsheets | create, get, list, delete, share |
| Sheet tabs | list, add, delete, rename, duplicate, copy_to |
| Values | read, read_multiple, write, write_multiple, append, clear, clear_multiple, find_replace |
| Formatting | format_cells, merge, unmerge, freeze, clear_formatting |
| Rows & Columns | insert_rows, insert_columns, delete_rows, delete_columns, resize_rows, resize_columns, auto_resize_columns, add_chart |

### Technical details
- **Language:** Python 3.10+
- **Framework:** FastMCP
- **Auth:** OAuth2 interactive → Service Account file → Base64 env var → Application Default Credentials (4-layer fallback)
- **Transport:** stdio (Claude Desktop & Claude Code compatible)
- **Install:** `uvx --from git+https://github.com/geosta-engineer/mcp-google-sheets mcp-google-sheets`
- **License:** MIT

### Why it belongs in the list
Google Sheets is one of the most universally used productivity tools. This server fills a real gap — users can now ask Claude to create reports, log data, format spreadsheets, and automate workflows directly, without leaving the conversation.

---
*If the registry submission process is preferred over README additions, I'm happy to follow that path — just let me know.*