### PR TITLE
Add LetsFG flight search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ search, and comprehensive file analysis.
 - **[Lark(Feishu)](https://github.com/kone-net/mcp_server_lark)** - A Model Context Protocol(MCP) server for Lark(Feishu) sheet, message, doc and etc.
 - **[Lazy Toggl MCP](https://github.com/movstox/lazy-toggl-mcp)** - Simple unofficial MCP server to track time via Toggl API
 - **[lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp)** - Interact with the [Lean theorem prover](https://lean-lang.org/) via the Language Server Protocol.
+- **[LetsFG](https://github.com/LetsFG/LetsFG)** - Search and compare flights at real airline prices. 400+ airlines via GDS/NDC plus 73 direct airline connectors. No price bias, no tracking.
 - **[librenms-mcp](https://github.com/mhajder/librenms-mcp)** - MCP server for [LibreNMS](https://www.librenms.org/) management
 - **[libvirt-mcp](https://github.com/MatiasVara/libvirt-mcp)** - Allows LLM to interact with libvirt thus enabling to create, destroy or list the Virtual Machines in a system.
 - **[Lightdash](https://github.com/syucream/lightdash-mcp-server)** - Interact with [Lightdash](https://www.lightdash.com/), a BI tool.

--- a/README.md
+++ b/README.md
@@ -982,7 +982,7 @@ search, and comprehensive file analysis.
 - **[Lark(Feishu)](https://github.com/kone-net/mcp_server_lark)** - A Model Context Protocol(MCP) server for Lark(Feishu) sheet, message, doc and etc.
 - **[Lazy Toggl MCP](https://github.com/movstox/lazy-toggl-mcp)** - Simple unofficial MCP server to track time via Toggl API
 - **[lean-lsp-mcp](https://github.com/oOo0oOo/lean-lsp-mcp)** - Interact with the [Lean theorem prover](https://lean-lang.org/) via the Language Server Protocol.
-- **[LetsFG](https://github.com/LetsFG/LetsFG)** - Search and compare flights at real airline prices. 400+ airlines via GDS/NDC plus 73 direct airline connectors. No price bias, no tracking.
+- **[LetsFG](https://github.com/LetsFG/LetsFG)** - Search and compare flights at real airline prices. 400+ airlines via GDS/NDC plus 102 direct airline connectors. No price bias, no tracking.
 - **[librenms-mcp](https://github.com/mhajder/librenms-mcp)** - MCP server for [LibreNMS](https://www.librenms.org/) management
 - **[libvirt-mcp](https://github.com/MatiasVara/libvirt-mcp)** - Allows LLM to interact with libvirt thus enabling to create, destroy or list the Virtual Machines in a system.
 - **[Lightdash](https://github.com/syucream/lightdash-mcp-server)** - Interact with [Lightdash](https://www.lightdash.com/), a BI tool.

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,22 @@
+Adds [LetsFG](https://github.com/LetsFG/LetsFG) to the Community Servers section.
+
+**What it does:** LetsFG is an MCP server for flight search and comparison. It connects AI assistants to real airline pricing data from 400+ airlines via GDS/NDC aggregators plus 102 direct airline API connectors. No price bias, no tracking.
+
+**Install:**
+```json
+{
+  "mcpServers": {
+    "letsfg": {
+      "command": "npx",
+      "args": ["-y", "letsfg-mcp"],
+      "env": {
+        "LETSFG_API_KEY": "your_api_key"
+      }
+    }
+  }
+}
+```
+
+**npm:** [letsfg-mcp](https://www.npmjs.com/package/letsfg-mcp)
+**PyPI:** [letsfg](https://pypi.org/project/letsfg/)
+**GitHub:** [LetsFG/LetsFG](https://github.com/LetsFG/LetsFG)


### PR DESCRIPTION
Adds [LetsFG](https://github.com/LetsFG/LetsFG) to the Community Servers section.

**What it does:** LetsFG is an MCP server for flight search and comparison. It connects AI assistants to real airline pricing data from 400+ airlines via GDS/NDC aggregators plus 73 direct airline API connectors. No price bias, no tracking.

**Install:**
```json
{
  "mcpServers": {
    "letsfg": {
      "command": "npx",
      "args": ["-y", "letsfg-mcp"],
      "env": {
        "LETSFG_API_KEY": "your_api_key"
      }
    }
  }
}
```

**npm:** [letsfg-mcp](https://www.npmjs.com/package/letsfg-mcp)
**PyPI:** [letsfg](https://pypi.org/project/letsfg/)
**GitHub:** [LetsFG/LetsFG](https://github.com/LetsFG/LetsFG)
