### PR TITLE
fix(filesystem): preserve CLI directories when merging with MCP roots

### DIFF
--- a/src/filesystem/__tests__/roots-utils.test.ts
+++ b/src/filesystem/__tests__/roots-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { getValidRootDirectories } from '../roots-utils.js';
+import { getValidRootDirectories, mergeAllowedDirectories } from '../roots-utils.js';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -80,5 +80,34 @@ describe('getValidRootDirectories', () => {
       expect(result).not.toContain(invalidPath);
       expect(result).toHaveLength(1);
     });
+  });
+});
+
+describe('mergeAllowedDirectories', () => {
+  it('preserves CLI directories while adding current client roots', () => {
+    const result = mergeAllowedDirectories(
+      ['/cli/one', '/cli/two'],
+      ['/roots/current']
+    );
+
+    expect(result).toEqual(['/cli/one', '/cli/two', '/roots/current']);
+  });
+
+  it('deduplicates directories shared by CLI args and client roots', () => {
+    const result = mergeAllowedDirectories(
+      ['/shared', '/cli/only'],
+      ['/shared', '/roots/only']
+    );
+
+    expect(result).toEqual(['/shared', '/cli/only', '/roots/only']);
+  });
+
+  it('falls back to the CLI baseline when the client provides no valid roots', () => {
+    const result = mergeAllowedDirectories(
+      ['/cli/one', '/cli/two'],
+      []
+    );
+
+    expect(result).toEqual(['/cli/one', '/cli/two']);
   });
 });

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -13,7 +13,7 @@ import path from "path";
 import { z } from "zod";
 import { minimatch } from "minimatch";
 import { normalizePath, expandHome } from './path-utils.js';
-import { getValidRootDirectories } from './roots-utils.js';
+import { getValidRootDirectories, mergeAllowedDirectories } from './roots-utils.js';
 import {
   // Function imports
   formatSize,
@@ -88,6 +88,11 @@ if (accessibleDirectories.length === 0 && allowedDirectories.length > 0) {
 }
 
 allowedDirectories = accessibleDirectories;
+
+// Preserve CLI-provided directories for merging with MCP roots later.
+// CLI directories are explicitly set by the administrator and must not be
+// discarded when the client provides roots via the MCP roots protocol.
+const cliAllowedDirectories = [...allowedDirectories];
 
 // Initialize the global allowedDirectories in lib.ts
 setAllowedDirectories(allowedDirectories);
@@ -702,15 +707,17 @@ server.registerTool(
   }
 );
 
-// Updates allowed directories based on MCP client roots
+// Updates allowed directories by merging CLI-provided directories with MCP client roots.
+// CLI directories are always preserved; client roots are added on top of them.
 async function updateAllowedDirectoriesFromRoots(requestedRoots: Root[]) {
   const validatedRootDirs = await getValidRootDirectories(requestedRoots);
+  allowedDirectories = mergeAllowedDirectories(cliAllowedDirectories, validatedRootDirs);
+  setAllowedDirectories(allowedDirectories);
+
   if (validatedRootDirs.length > 0) {
-    allowedDirectories = [...validatedRootDirs];
-    setAllowedDirectories(allowedDirectories); // Update the global state in lib.ts
-    console.error(`Updated allowed directories from MCP roots: ${validatedRootDirs.length} valid directories`);
+    console.error(`Allowed directories: ${cliAllowedDirectories.length} from CLI + ${validatedRootDirs.length} from MCP roots (${allowedDirectories.length} total after dedup)`);
   } else {
-    console.error("No valid root directories provided by client");
+    console.error(`No valid root directories provided by client, using ${cliAllowedDirectories.length} CLI directory${cliAllowedDirectories.length === 1 ? '' : 'ies'}`);
   }
 }
 

--- a/src/filesystem/roots-utils.ts
+++ b/src/filesystem/roots-utils.ts
@@ -75,3 +75,16 @@ export async function getValidRootDirectories(
   
   return validatedDirectories;
 }
+
+/**
+ * Merges the fixed CLI directory baseline with the current client-provided roots.
+ *
+ * The merge is recalculated from scratch each time so outdated roots do not linger
+ * after a roots/list_changed update.
+ */
+export function mergeAllowedDirectories(
+  cliAllowedDirectories: readonly string[],
+  rootDirectories: readonly string[]
+): string[] {
+  return [...new Set([...cliAllowedDirectories, ...rootDirectories])];
+}


### PR DESCRIPTION
## Summary

Fixes #3602

When the MCP client supports the roots protocol, the `oninitialized` and `roots/list_changed` handlers unconditionally **replaced** all CLI-provided `allowedDirectories` with client roots. This caused any extra directories passed via command-line arguments to be silently discarded.

**Before:** `npx @modelcontextprotocol/server-filesystem /home/user /mnt/Storage /mnt/Games` + client root `/home/user` → only `/home/user` accessible.

**After:** CLI directories are preserved as an immutable baseline and merged with client roots. All four directories remain accessible.

## Changes

- **`src/filesystem/index.ts`**: Save CLI directories as `cliAllowedDirectories` baseline. Change `updateAllowedDirectoriesFromRoots` to merge CLI baseline + current client roots instead of replacing. When roots become empty/invalid, fall back to CLI baseline only (no stale roots).
- **`src/filesystem/roots-utils.ts`**: Add `mergeAllowedDirectories()` helper — uses `Set` to deduplicate CLI dirs + root dirs.
- **`src/filesystem/__tests__/roots-utils.test.ts`**: Add 3 regression tests:
  - Preserves CLI directories while adding current client roots
  - Deduplicates directories shared by CLI args and client roots
  - Falls back to CLI baseline when client provides no valid roots

## Test plan

- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run --config src/filesystem/vitest.config.ts src/filesystem/__tests__/roots-utils.test.ts` — all 6 tests pass (3 existing + 3 new)
- [x] Full filesystem test suite — no new failures introduced