### PR TITLE
fix: correct 6 bugs across multiple servers

### DIFF
--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -139,8 +139,8 @@ export const blobResourceUri = (resourceId: number) =>
 const parseResourceId = (uri: URL, variables: Record<string, unknown>) => {
   const uriError = `Unknown resource: ${uri.toString()}`;
   if (
-    uri.toString().startsWith(textUriBase) &&
-    uri.toString().startsWith(blobUriBase)
+    !uri.toString().startsWith(textUriBase) &&
+    !uri.toString().startsWith(blobUriBase)
   ) {
     throw new Error(uriError);
   } else {

--- a/src/everything/tools/trigger-elicitation-request.ts
+++ b/src/everything/tools/trigger-elicitation-request.ts
@@ -189,7 +189,8 @@ export const registerTriggerElicitationRequestTool = (server: McpServer) => {
           if (userData.name) lines.push(`- Name: ${userData.name}`);
           if (userData.check !== undefined)
             lines.push(`- Agreed to terms: ${userData.check}`);
-          if (userData.color) lines.push(`- Favorite Color: ${userData.color}`);
+          if (userData.firstLine)
+            lines.push(`- Favorite First Line: ${userData.firstLine}`);
           if (userData.email) lines.push(`- Email: ${userData.email}`);
           if (userData.homepage) lines.push(`- Homepage: ${userData.homepage}`);
           if (userData.birthdate)
@@ -198,7 +199,16 @@ export const registerTriggerElicitationRequestTool = (server: McpServer) => {
             lines.push(`- Favorite Integer: ${userData.integer}`);
           if (userData.number !== undefined)
             lines.push(`- Favorite Number: ${userData.number}`);
-          if (userData.petType) lines.push(`- Pet Type: ${userData.petType}`);
+          if (userData.untitledSingleSelectEnum)
+            lines.push(`- Favorite Friend: ${userData.untitledSingleSelectEnum}`);
+          if (userData.untitledMultipleSelectEnum)
+            lines.push(`- Favorite Instruments: ${userData.untitledMultipleSelectEnum}`);
+          if (userData.titledSingleSelectEnum)
+            lines.push(`- Favorite Hero: ${userData.titledSingleSelectEnum}`);
+          if (userData.titledMultipleSelectEnum)
+            lines.push(`- Favorite Fish: ${userData.titledMultipleSelectEnum}`);
+          if (userData.legacyTitledEnum)
+            lines.push(`- Favorite Pet: ${userData.legacyTitledEnum}`);
 
           content.push({
             type: "text",

--- a/src/everything/transports/streamableHttp.ts
+++ b/src/everything/transports/streamableHttp.ts
@@ -225,10 +225,10 @@ process.on("SIGINT", async () => {
   console.log("Shutting down server...");
 
   // Close all active transports to properly clean up resources
-  for (const sessionId in transports) {
+  for (const [sessionId, transport] of transports) {
     try {
       console.log(`Closing transport for session ${sessionId}`);
-      await transports.get(sessionId)!.close();
+      await transport.close();
       transports.delete(sessionId);
     } catch (error) {
       console.log(`Error closing transport for session ${sessionId}:`, error);

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -131,7 +131,10 @@ export async function validatePath(requestedPath: string): Promise<string> {
           throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
         }
         return absolute;
-      } catch {
+      } catch (innerError) {
+        if (innerError instanceof Error && innerError.message.startsWith('Access denied')) {
+          throw innerError;
+        }
         throw new Error(`Parent directory does not exist: ${parentDir}`);
       }
     }

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -24,21 +24,22 @@ export async function ensureMemoryFilePath(): Promise<string> {
   const newMemoryPath = defaultMemoryPath;
   
   try {
-    // Check if old file exists and new file doesn't
     await fs.access(oldMemoryPath);
-    try {
-      await fs.access(newMemoryPath);
-      // Both files exist, use new one (no migration needed)
-      return newMemoryPath;
-    } catch {
-      // Old file exists, new file doesn't - migrate
-      console.error('DETECTED: Found legacy memory.json file, migrating to memory.jsonl for JSONL format compatibility');
-      await fs.rename(oldMemoryPath, newMemoryPath);
-      console.error('COMPLETED: Successfully migrated memory.json to memory.jsonl');
-      return newMemoryPath;
-    }
   } catch {
     // Old file doesn't exist, use new path
+    return newMemoryPath;
+  }
+
+  try {
+    await fs.access(newMemoryPath);
+    // Both files exist, use new one (no migration needed)
+    return newMemoryPath;
+  } catch {
+    // Old file exists, new file doesn't - migrate
+    // Let rename errors propagate so migration failures are not silently ignored
+    console.error('DETECTED: Found legacy memory.json file, migrating to memory.jsonl for JSONL format compatibility');
+    await fs.rename(oldMemoryPath, newMemoryPath);
+    console.error('COMPLETED: Successfully migrated memory.json to memory.jsonl');
     return newMemoryPath;
   }
 }

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -94,7 +94,7 @@ You should:
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     outputSchema: {


### PR DESCRIPTION
## Description

This PR fixes 6 confirmed bugs found across multiple server implementations via systematic code audit. Each fix is a separate commit for ease of review.

## Bug Fixes

### 1. CRITICAL: `for...in` on Map never iterates entries (streamableHttp.ts)
The SIGINT shutdown handler used `for...in` to iterate a `Map<string, StreamableHTTPServerTransport>`. Since `Map` entries are not enumerable own properties, the loop body never executed, meaning active transports were never closed on shutdown — causing resource leaks.

**Fix:** Changed to `for...of` which correctly iterates Map entries.

### 2. HIGH: Inner catch swallows access-denied security error (filesystem/lib.ts)
In `validatePath`, when a new file's parent directory exists but is outside allowed directories, the "Access denied" error thrown on line 131 was immediately caught by the bare `catch` on line 134 and replaced with a misleading "Parent directory does not exist" message.

**Fix:** The inner catch now re-throws errors that start with "Access denied".

### 3. MEDIUM: Always-false guard condition in parseResourceId (templates.ts)
The guard `uri.startsWith(textUriBase) && uri.startsWith(blobUriBase)` is always false since a URI cannot start with both `"demo://resource/dynamic/text"` and `"demo://resource/dynamic/blob"`. The intended check was to reject URIs matching *neither* prefix.

**Fix:** Added `!` negation to both `startsWith` checks.

### 4. MEDIUM: Incorrect idempotentHint on sequential thinking tool (index.ts)
The tool was marked `idempotentHint: true`, but it appends to `thoughtHistory` on every call, making repeated identical calls produce different `thoughtHistoryLength` values and duplicate entries. Clients relying on this hint for auto-retry could corrupt the thinking chain.

**Fix:** Changed `idempotentHint` to `false`.

### 5. MEDIUM: Memory migration rename error silently swallowed (memory/index.ts)
The nested try/catch structure meant that if `fs.rename()` failed during `memory.json → memory.jsonl` migration (e.g. permission error), the exception would bubble into the outer catch which silently returned the new path. The server would start with a non-existent file and overwrite the user's data on the first write.

**Fix:** Restructured to flat try/catch blocks so rename errors propagate to the caller.

### 6. MEDIUM: Elicitation response handler references non-existent schema fields (trigger-elicitation-request.ts)
The response handler referenced `color` and `petType` fields that were not defined in the elicitation request schema (thus always undefined), while omitting fields that are actually in the schema: `firstLine`, `untitledSingleSelectEnum`, `untitledMultipleSelectEnum`, `titledSingleSelectEnum`, `titledMultipleSelectEnum`, and `legacyTitledEnum`.

**Fix:** Removed dead field references and added handlers for all schema-defined fields.

## Server Details
- Server: everything, filesystem, memory, sequential-thinking
- Changes to: tools, resources, transports, core logic

## Motivation and Context
These bugs were found through systematic code audit. Each is a clear, unambiguous defect with a deterministic fix that doesn't alter intended semantics.

## How Has This Been Tested?
Each fix was verified by reading the original code, confirming the bug exists, applying the minimal correct fix, and re-reading the modified code. The changes are minimal and localized.

## Breaking Changes
None. All fixes correct existing behavior to match documented intent.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] My code follows the repository's style guidelines
- [x] I have added appropriate error handling

## Additional context
All 6 commits are independent and can be cherry-picked individually if needed.