### PR TITLE
feat(fetch): add tool annotations

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -14,6 +14,7 @@ from mcp.types import (
     PromptMessage,
     TextContent,
     Tool,
+    ToolAnnotations,
     INVALID_PARAMS,
     INTERNAL_ERROR,
 )
@@ -203,6 +204,12 @@ async def serve(
 
 Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.""",
                 inputSchema=Fetch.model_json_schema(),
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
             )
         ]
 


### PR DESCRIPTION
## Summary

Adds tool annotations to the fetch server's single tool, implementing the request in #3572.

## Changes

Added `ToolAnnotations` to the `fetch` tool with:

| Annotation | Value | Rationale |
|------------|-------|-----------|
| `readOnlyHint` | `true` | Uses HTTP GET only, doesn't modify data |
| `destructiveHint` | `false` | Read-only operation |
| `idempotentHint` | `true` | Same URL returns same content (modulo server changes) |
| `openWorldHint` | `true` | Makes outbound HTTP requests to arbitrary URLs |

The `openWorldHint: true` is particularly important — the fetch tool can reach any URL on the internet, making it a key vector for data exfiltration in multi-server setups. Accurate annotations help clients enforce "allow reads, gate sends" policies.

## Testing

- Verified syntax with `python -m py_compile`
- Pattern follows existing servers (time, git) that use `ToolAnnotations`

Closes #3572