### PR TITLE
feat(fetch): add tool annotations to server-fetch

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -14,6 +14,7 @@ from mcp.types import (
     PromptMessage,
     TextContent,
     Tool,
+    ToolAnnotations,
     INVALID_PARAMS,
     INTERNAL_ERROR,
 )
@@ -178,6 +179,22 @@ class Fetch(BaseModel):
     ]
 
 
+def _make_fetch_tool() -> Tool:
+    return Tool(
+        name="fetch",
+        description="""Fetches a URL from the internet and optionally extracts its contents as markdown.
+
+Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.""",
+        inputSchema=Fetch.model_json_schema(),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+
+
 async def serve(
     custom_user_agent: str | None = None,
     ignore_robots_txt: bool = False,
@@ -196,15 +213,7 @@ async def serve(
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        return [
-            Tool(
-                name="fetch",
-                description="""Fetches a URL from the internet and optionally extracts its contents as markdown.
-
-Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.""",
-                inputSchema=Fetch.model_json_schema(),
-            )
-        ]
+        return [_make_fetch_tool()]
 
     @server.list_prompts()
     async def list_prompts() -> list[Prompt]:

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -9,8 +9,24 @@ from mcp_server_fetch.server import (
     get_robots_txt_url,
     check_may_autonomously_fetch_url,
     fetch_url,
+    _make_fetch_tool,
     DEFAULT_USER_AGENT_AUTONOMOUS,
 )
+
+
+class TestListTools:
+    """Tests for list_tools handler."""
+
+    def test_fetch_tool_annotations(self):
+        """Test that the fetch tool has correct MCP tool annotations."""
+        tool = _make_fetch_tool()
+
+        assert tool.name == "fetch"
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.destructiveHint is False
+        assert tool.annotations.idempotentHint is True
+        assert tool.annotations.openWorldHint is True
 
 
 class TestGetRobotsTxtUrl:


### PR DESCRIPTION
Closes #3572

## Summary

Adds MCP tool annotations to the `fetch` tool, which currently has zero annotations despite the spec supporting them and `server-filesystem` already annotating all 14 of its tools.

| Tool | `readOnlyHint` | `destructiveHint` | `idempotentHint` | `openWorldHint` |
|------|----------------|-------------------|------------------|-----------------|
| `fetch` | `true` | `false` | `true` | `true` |

**Rationale per annotation:**
- `readOnlyHint: true` — the tool performs an HTTP GET and returns content; it does not modify any data locally or on the target server
- `destructiveHint: false` — no side effects
- `idempotentHint: true` — fetching the same URL twice produces the same result (modulo server-side changes)
- `openWorldHint: true` — the tool makes outbound HTTP requests to arbitrary URLs; this is the most safety-relevant annotation as it signals to clients that the tool can reach any internet host

No behaviour changes — annotations are hints only.

## Changes

- `server.py`: import `ToolAnnotations`, extract tool definition into `_make_fetch_tool()` helper, add the four annotations
- `tests/test_server.py`: add `TestListTools.test_fetch_tool_annotations` asserting all four annotation values via `_make_fetch_tool()`

## Test plan

- [x] All 21 existing tests pass (`uv run pytest tests/ -v`)
- [x] New annotation test passes