### PR TITLE
feat(memory): add tool annotations to all 9 tools

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -263,6 +263,12 @@ server.registerTool(
   "create_entities",
   {
     title: "Create Entities",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     description: "Create multiple new entities in the knowledge graph",
     inputSchema: {
       entities: z.array(EntitySchema)
@@ -285,6 +291,12 @@ server.registerTool(
   "create_relations",
   {
     title: "Create Relations",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     description: "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
     inputSchema: {
       relations: z.array(RelationSchema)
@@ -307,6 +319,12 @@ server.registerTool(
   "add_observations",
   {
     title: "Add Observations",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     description: "Add new observations to existing entities in the knowledge graph",
     inputSchema: {
       observations: z.array(z.object({
@@ -335,6 +353,12 @@ server.registerTool(
   "delete_entities",
   {
     title: "Delete Entities",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     description: "Delete multiple entities and their associated relations from the knowledge graph",
     inputSchema: {
       entityNames: z.array(z.string()).describe("An array of entity names to delete")
@@ -358,6 +382,12 @@ server.registerTool(
   "delete_observations",
   {
     title: "Delete Observations",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     description: "Delete specific observations from entities in the knowledge graph",
     inputSchema: {
       deletions: z.array(z.object({
@@ -384,6 +414,12 @@ server.registerTool(
   "delete_relations",
   {
     title: "Delete Relations",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: "Delete multiple relations from the knowledge graph",
     inputSchema: {
       relations: z.array(RelationSchema).describe("An array of relations to delete")
@@ -407,6 +443,12 @@ server.registerTool(
   "read_graph",
   {
     title: "Read Graph",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: "Read the entire knowledge graph",
     inputSchema: {},
     outputSchema: {
@@ -428,6 +470,12 @@ server.registerTool(
   "search_nodes",
   {
     title: "Search Nodes",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: "Search for nodes in the knowledge graph based on a query",
     inputSchema: {
       query: z.string().describe("The search query to match against entity names, types, and observation content")
@@ -451,6 +499,12 @@ server.registerTool(
   "open_nodes",
   {
     title: "Open Nodes",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     description: "Open specific nodes in the knowledge graph by their names",
     inputSchema: {
       names: z.array(z.string()).describe("An array of entity names to retrieve")


### PR DESCRIPTION
## Summary

Add tool annotations to all 9 tools in the memory server, following the patterns established in server-filesystem.

## Changes

### Read-only tools (`readOnlyHint: true`, `idempotentHint: true`)
- `read_graph` - reads entire knowledge graph
- `search_nodes` - searches for nodes by query
- `open_nodes` - retrieves specific nodes by name

### Write tools (`readOnlyHint: false`, `destructiveHint: false`)
- `create_entities` - creates new entities (not idempotent - duplicates possible)
- `create_relations` - creates new relations (not idempotent)
- `add_observations` - adds observations to entities (not idempotent)

### Destructive tools (`destructiveHint: true`)
- `delete_entities` - permanently deletes entities AND cascades to relations (`idempotentHint: false`)
- `delete_observations` - permanently removes observations (`idempotentHint: false`)
- `delete_relations` - removes graph edges (`idempotentHint: true` - deleting already-deleted is no-op)

All tools have `openWorldHint: false` as the knowledge graph is local with no external network calls.

## Rationale

As noted in #3400, without annotations, clients have no way to differentiate risk levels between tools. The delete tools in particular perform permanent, cascading deletions with no undo - `destructiveHint: true` enables annotation-aware clients to add confirmation steps.

This is a metadata-only change (~54 lines). No behavior changes.

Fixes #3400