### PR TITLE
Add Spot.io (Spotinst) MCP server to Community Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,7 @@ search, and comprehensive file analysis.
 - **[Sourcerer](https://github.com/st3v3nmw/sourcerer-mcp)** - MCP for semantic code search & navigation that reduces token waste.
 - **[Specbridge](https://github.com/TBosak/specbridge)** - Easily turn your OpenAPI specs into MCP Tools.
 - **[Splunk](https://github.com/jkosik/mcp-server-splunk)** - Golang MCP server for Splunk (lists saved searches, alerts, indexes, macros...). Supports SSE and STDIO.
+- **[Spot.io (Spotinst)](https://github.com/arnstarn/mcp-server-spotinst)** - MCP server for the Spot.io API with 23 tools for managing Ocean Kubernetes clusters, VNGs, Elastigroups, costs, right-sizing, and logs across AWS and Azure with multi-account support.
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - This MCP allows an LLM to play and use Spotify.
 - **[Spring Initializr](https://github.com/hpalma/springinitializr-mcp)** - This MCP allows an LLM to create Spring Boot projects with custom configurations. Instead of manually visiting start.spring.io, you can now ask your AI assistant to generate projects with specific dependencies, Java versions, and project structures.
 - **[Squad AI](https://github.com/the-basilisk-ai/squad-mcp)** – Product‑discovery and strategy platform integration. Create, query and update opportunities, solutions, outcomes, requirements and feedback from any MCP‑aware LLM.


### PR DESCRIPTION
## New Community Server: mcp-server-spotinst

**Repository:** https://github.com/arnstarn/mcp-server-spotinst
**PyPI:** https://pypi.org/project/mcp-server-spotinst/
**Language:** Python

### Description

MCP server for the Spot.io (Spotinst) API — the first MCP server for this platform. Provides 23 tools for managing Ocean Kubernetes clusters, Virtual Node Groups (VNGs), Elastigroups, cost analysis, right-sizing recommendations, and cluster logs across both AWS and Azure with full multi-account support.

### Key Features

- 19 read-only tools + 4 write tools with safety guards (`confirm=true` required)
- Multi-account support with cross-cloud cluster scanning
- Cost breakdown, right-sizing, rolling restarts, and cluster logs
- Published on PyPI, MIT licensed