### PR TITLE
docs: add Windows npx wrapper examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1600,6 +1600,19 @@ However, running a server on its own isn't very useful, and should instead be co
 }
 ```
 
+On Windows, wrap `npx` with `cmd /c`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}
+```
+
 Additional examples of using the Claude Desktop as an MCP client might look like:
 
 ```json
@@ -1627,6 +1640,8 @@ Additional examples of using the Claude Desktop as an MCP client might look like
   }
 }
 ```
+
+On Windows, apply the same wrapper to each `npx`-based entry above by changing `"command"` to `"cmd"` and prepending `"/c", "npx"` to the existing `args`. Leave `uvx` entries unchanged.
 
 ## 🛠️ Creating Your Own Server
 

--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -31,6 +31,24 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
+On Windows, use `cmd /c` to launch `npx`:
+
+```json
+{
+  "mcpServers": {
+    "everything": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-everything"
+      ]
+    }
+  }
+}
+```
+
 ## Usage with VS Code
 
 For quick installation, use of of the one-click install buttons below...
@@ -57,6 +75,19 @@ Alternatively, you can add the configuration to a file called `.vscode/mcp.json`
     "everything": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-everything"]
+    }
+  }
+}
+```
+
+On Windows, use:
+
+```json
+{
+  "servers": {
+    "everything": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-everything"]
     }
   }
 }
@@ -103,4 +134,3 @@ npx @modelcontextprotocol/server-everything sse
 ```shell
 npx @modelcontextprotocol/server-everything streamableHttp
 ```
-

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -250,6 +250,26 @@ Note: all directories must be mounted to `/projects` by default.
 }
 ```
 
+On Windows, use `cmd /c` to launch `npx`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop",
+        "/path/to/other/allowed/dir"
+      ]
+    }
+  }
+}
+```
+
 ## Usage with VS Code
 
 For quick installation, click the installation buttons below...
@@ -299,6 +319,25 @@ Note: all directories must be mounted to `/projects` by default.
     "filesystem": {
       "command": "npx",
       "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "${workspaceFolder}"
+      ]
+    }
+  }
+}
+```
+
+On Windows, use:
+
+```json
+{
+  "servers": {
+    "filesystem": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
         "-y",
         "@modelcontextprotocol/server-filesystem",
         "${workspaceFolder}"

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -159,6 +159,24 @@ Add this to your claude_desktop_config.json:
 }
 ```
 
+On Windows, use `cmd /c` to launch `npx`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ]
+    }
+  }
+}
+```
+
 #### NPX with custom setting
 
 The server can be configured using the following environment variables:
@@ -169,6 +187,27 @@ The server can be configured using the following environment variables:
     "memory": {
       "command": "npx",
       "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
+      "env": {
+        "MEMORY_FILE_PATH": "/path/to/custom/memory.jsonl"
+      }
+    }
+  }
+}
+```
+
+On Windows, use:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
         "-y",
         "@modelcontextprotocol/server-memory"
       ],
@@ -208,6 +247,24 @@ Alternatively, you can add the configuration to a file called `.vscode/mcp.json`
     "memory": {
       "command": "npx",
       "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ]
+    }
+  }
+}
+```
+
+On Windows, use:
+
+```json
+{
+  "servers": {
+    "memory": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
         "-y",
         "@modelcontextprotocol/server-memory"
       ]

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -59,6 +59,24 @@ Add this to your `claude_desktop_config.json`:
 }
 ```
 
+On Windows, use `cmd /c` to launch `npx`:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    }
+  }
+}
+```
+
 #### docker
 
 ```json
@@ -106,6 +124,24 @@ For NPX installation:
     "sequential-thinking": {
       "command": "npx",
       "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    }
+  }
+}
+```
+
+On Windows, use:
+
+```json
+{
+  "servers": {
+    "sequential-thinking": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
         "-y",
         "@modelcontextprotocol/server-sequential-thinking"
       ]


### PR DESCRIPTION
## Summary\n- add Windows  examples to the root getting-started docs\n- add matching Windows config snippets to the reference server READMEs that currently show  stdio configs\n- keep existing macOS/Linux examples unchanged\n\n## Testing\n- not run (docs-only change)\n\nCloses #3460