### PR TITLE
feat(everything): add tool annotations to reference implementation

### DIFF
--- a/src/everything/tools/echo.ts
+++ b/src/everything/tools/echo.ts
@@ -13,6 +13,11 @@ const config = {
   title: "Echo Tool",
   description: "Echoes back the input string",
   inputSchema: EchoSchema,
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 /**

--- a/src/everything/tools/get-annotated-message.ts
+++ b/src/everything/tools/get-annotated-message.ts
@@ -21,6 +21,11 @@ const config = {
   description:
     "Demonstrates how annotations can be used to provide metadata about content.",
   inputSchema: GetAnnotatedMessageSchema,
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 /**

--- a/src/everything/tools/get-env.ts
+++ b/src/everything/tools/get-env.ts
@@ -8,6 +8,11 @@ const config = {
   description:
     "Returns all environment variables, helpful for debugging MCP server configuration",
   inputSchema: {},
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 /**

--- a/src/everything/tools/get-structured-content.ts
+++ b/src/everything/tools/get-structured-content.ts
@@ -26,6 +26,11 @@ const config = {
   description:
     "Returns structured content along with an output schema for client data validation",
   inputSchema: GetStructuredContentInputSchema,
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
   outputSchema: GetStructuredContentOutputSchema,
 };
 

--- a/src/everything/tools/get-sum.ts
+++ b/src/everything/tools/get-sum.ts
@@ -14,6 +14,11 @@ const config = {
   title: "Get Sum Tool",
   description: "Returns the sum of two numbers",
   inputSchema: GetSumSchema,
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 /**

--- a/src/everything/tools/get-tiny-image.ts
+++ b/src/everything/tools/get-tiny-image.ts
@@ -11,6 +11,11 @@ const config = {
   title: "Get Tiny Image Tool",
   description: "Returns a tiny MCP logo image.",
   inputSchema: {},
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 /**

--- a/src/everything/tools/toggle-simulated-logging.ts
+++ b/src/everything/tools/toggle-simulated-logging.ts
@@ -11,6 +11,11 @@ const config = {
   title: "Toggle Simulated Logging",
   description: "Toggles simulated, random-leveled logging on or off.",
   inputSchema: {},
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  },
 };
 
 // Track enabled clients by session id


### PR DESCRIPTION
## Summary

Add MCP tool annotations to the everything server, which serves as a reference implementation for MCP features.

## Changes

Added `readOnlyHint`, `destructiveHint`, and `idempotentHint` annotations to 7 tools:

| Tool | readOnlyHint | destructiveHint | idempotentHint | Rationale |
|------|--------------|-----------------|----------------|-----------|
| echo | true | false | true | Pure function, returns input |
| get-sum | true | false | true | Pure computation |
| get-env | true | false | true | Environment variable lookup |
| get-tiny-image | true | false | true | Returns static image |
| get-annotated-message | true | false | true | Message formatting |
| get-structured-content | true | false | true | Content generation |
| toggle-simulated-logging | false | false | false | Toggles server state |

## Motivation

The everything server demonstrates MCP protocol features and is often referenced as an example. Adding annotations:

1. Makes the reference implementation more complete
2. Demonstrates annotation patterns for different tool types  
3. Aligns with other MCP servers (filesystem, fetch, memory, git, time) that already include annotations

## Testing

- [x] `npm run build` passes in src/everything
- [x] Manually verified annotation structure matches MCP spec

## Related

- Follows pattern from #3643 (fetch annotations) and #3655 (memory annotations)