### PR TITLE
community: add Trello MCP server by Open Tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,6 +1379,7 @@ search, and comprehensive file analysis.
 - **[Transcribe](https://github.com/transcribe-app/mcp-transcribe)** - An MCP server provides fast and reliable transcriptions for audio/video files and voice memos. It allows LLMs to interact with the text content of audio/video file.
 - **[Travel Planner](https://github.com/GongRzhe/TRAVEL-PLANNER-MCP-Server)** - Travel planning and itinerary management server integrating with Google Maps API for location search, place details, and route calculations.
 - **[Trello MCP Server](https://github.com/lioarce01/trello-mcp-server)** - An MCP server that interact with user Trello boards, modifying them with prompting.
+- **[Trello MCP by Open Tech](https://github.com/Open-Tech-Cl-Spa/trello-mcp)** - Complete Trello integration with 20 tools for managing boards, cards, lists, labels, members, checklists, comments, and search. Includes skills for board setup, bulk card creation, and sprint management. Built with official MCP SDK.
 - **[Trino](https://github.com/tuannvm/mcp-trino)** - A high-performance Model Context Protocol (MCP) server for Trino implemented in Go.
 - **[Tripadvisor](https://github.com/pab1it0/tripadvisor-mcp)** - An MCP server that enables LLMs to interact with Tripadvisor API, supporting location data, reviews, and photos through standardized MCP interfaces
 - **[Triplyfy MCP](https://github.com/helpful-AIs/triplyfy-mcp)** - An MCP server that lets LLMs plan and manage itineraries with interactive maps in Triplyfy; manage itineraries, places and notes, and search/save flights.


### PR DESCRIPTION
Adds Open Tech's Trello MCP server to the community servers list.

**Repository**: https://github.com/Open-Tech-Cl-Spa/trello-mcp
**Transport**: stdio (Node.js)
**Tools**: 20 tools (boards, lists, cards, labels, members, checklists, comments, search, organizations)
**Auth**: API Key + Token via env vars
**Tested**: Production use managing 6 boards with 120+ cards