### PR TITLE
ci: add MCP Observatory health scoring for reference servers

### DIFF
--- a/.github/workflows/observatory.yml
+++ b/.github/workflows/observatory.yml
@@ -1,0 +1,61 @@
+# MCP Observatory Health Check
+# Runs automated health scoring against reference MCP servers to catch
+# protocol conformance regressions, schema quality issues, and reliability problems.
+# See: https://github.com/KryptosAI/mcp-observatory
+
+name: MCP Observatory Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server:
+          - name: server-everything
+            package: "@modelcontextprotocol/server-everything"
+            args: ""
+          - name: server-filesystem
+            package: "@modelcontextprotocol/server-filesystem"
+            args: "/tmp"
+          - name: server-memory
+            package: "@modelcontextprotocol/server-memory"
+            args: ""
+          - name: server-sequential-thinking
+            package: "@modelcontextprotocol/server-sequential-thinking"
+            args: ""
+
+    name: Score ${{ matrix.server.name }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Score ${{ matrix.server.name }}
+        run: |
+          npx -y @kryptosai/mcp-observatory score \
+            --format junit \
+            --output results.xml \
+            npx -y ${{ matrix.server.package }} ${{ matrix.server.args }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: observatory-results-${{ matrix.server.name }}
+          path: results.xml
+
+      - name: Publish test report
+        if: always()
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: results.xml
+          check_name: Observatory - ${{ matrix.server.name }}
+          fail_on_failure: false


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs [MCP Observatory](https://github.com/KryptosAI/mcp-observatory) health scoring against 4 reference servers on every push and PR.

## What it checks

Each server is scored 0-100 across 5 dimensions:
- **Protocol compliance** — capabilities negotiation, JSON-RPC spec adherence
- **Schema quality** — tool descriptions, property docs, required fields
- **Security** — destructive capability detection, path traversal risks
- **Reliability** — endpoint availability, response shape validation
- **Performance** — connection and response latency

## Servers tested

| Server | Current Score | Grade |
|--------|-------------|-------|
| server-sequential-thinking | 95/100 | A |
| server-everything | 88/100 | B |
| server-memory | 87/100 | B |
| server-filesystem | 77/100 | C |

## Configuration

- Results published as JUnit test annotations via `mikepenz/action-junit-report`
- Currently **non-blocking** (`fail_on_failure: false`) — reports scores without failing builds
- Uses `fail-fast: false` so all servers are tested even if one fails
- Each server runs in a separate matrix job for clear per-server reporting

## Related

- Issue #3669 — schema quality findings from these scans