### PR TITLE
fix(filesystem): clarify that search_files matches names, not contents

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -628,7 +628,8 @@ server.registerTool(
   {
     title: "Search Files",
     description:
-      "Recursively search for files and directories matching a pattern. " +
+      "Recursively search for files and directories whose names match a glob pattern. " +
+      "This searches by file/directory name only — it does not search file contents. " +
       "The patterns should be glob-style patterns that match paths relative to the working directory. " +
       "Use pattern like '*.ext' to match files in current directory, and '**/*.ext' to match files in all subdirectories. " +
       "Returns full paths to all matching items. Great for finding files when you don't know their exact location. " +


### PR DESCRIPTION
## Summary

Fixes #896 — the `search_files` tool description was ambiguous, leading AI assistants (including Claude) to misinterpret it as a content search (like grep) when it actually matches file/directory **names** against a glob pattern.

### Changes

- Clarified the opening sentence: "matching a pattern" → "whose names match a glob pattern"
- Added an explicit note: "This searches by file/directory name only — it does not search file contents."

No logic changes — description only.

## Test plan

- [x] Verified the implementation in `lib.ts` uses `minimatch` against `relativePath` (name-based matching)
- [x] Description now unambiguously communicates the tool's actual behavior