### PR TITLE
Add Local MCP — Mail, Calendar, Contacts, Teams & OneDrive on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ search, and comprehensive file analysis.
 - **[LINE](https://github.com/amornpan/py-mcp-line)** (by amornpan) - Implementation for LINE Bot integration that enables Language Models to read and analyze LINE conversations through a standardized interface. Features asynchronous operation, comprehensive logging, webhook event handling, and support for various message types.
 - **[Linear](https://github.com/tacticlaunch/mcp-linear)** - Interact with Linear project management system.
 - **[Linear](https://github.com/jerhadf/linear-mcp-server)** - Allows LLM to interact with Linear's API for project management, including searching, creating, and updating issues.
+- **[Local MCP](https://local-mcp.com)** - Native macOS MCP server that connects AI agents to Mail.app, Calendar, Contacts, Microsoft Teams and OneDrive. All data stays on your Mac — no cloud, no tokens. Supports Gmail, Outlook, Exchange and iCloud. `npm install -g local-mcp`
 - **[Linear (Go)](https://github.com/geropl/linear-mcp-go)** - Allows LLM to interact with Linear's API via a single static binary.
 - **[Linear MCP](https://github.com/anoncam/linear-mcp)** - Full blown implementation of the Linear SDK to support comprehensive Linear management of projects, initiatives, issues, users, teams and states.
 - **[Linked API MCP](https://github.com/Linked-API/linkedapi-mcp)** - MCP server that lets AI assistants control LinkedIn accounts and retrieve real-time data.


### PR DESCRIPTION
Adds Local MCP, a native macOS MCP server for local productivity apps.

**What it does:**
- Email: read, search, send, reply via Mail.app (Gmail, Outlook, iCloud, Exchange)
- Calendar: list, create, delete events with multi-account support
- Contacts: search and list
- Microsoft Teams: read chats and channels (no Graph API tokens needed — reads local IndexedDB)
- OneDrive: full file management (read, write, search, move, delete)
- Documents: Word, Excel, PowerPoint, PDF
- Microsoft Outlook: direct access without Mail.app
- Reminders & Microsoft To Do: via EventKit (no tokens)
- OmniFocus: tasks, projects, tags
- Notes, Messages, Finder, Safari Bookmarks
- Stocks: real-time quotes and historical charts via Yahoo Finance

**Key differentiators:**
- **Privacy-first**: all data stays on the Mac, no cloud processing
- **Zero config**: `npx -y local-mcp@latest setup` auto-detects and configures Claude Desktop, Cursor, Windsurf, VS Code, and Zed
- **82 MCP tools** with safety previews for destructive operations
- **Teams integration** reads local IndexedDB — no OAuth, no tokens, no Microsoft API

**Links:**
- npm: https://www.npmjs.com/package/local-mcp
- Website: https://local-mcp.com?utm_source=github_mcp
- MCP config: `{"command": "npx", "args": ["-y", "local-mcp@latest"]}`
- Discovery: https://www.local-mcp.com/.well-known/mcp.json