### PR TITLE
fix(filesystem): improve edit_file error with nearest-match diagnostics

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -494,13 +494,13 @@ describe('Lib Functions', () => {
         );
       });
 
-      it('throws error for non-matching edits', async () => {
+      it('throws error for non-matching edits with diagnostic info', async () => {
         const edits = [
           { oldText: 'nonexistent line', newText: 'replacement' }
         ];
-        
+
         await expect(applyFileEdits('/test/file.txt', edits, false))
-          .rejects.toThrow('Could not find exact match for edit');
+          .rejects.toThrow('Could not find match for edit');
       });
 
       it('handles complex multi-line edits with indentation', async () => {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -248,7 +248,43 @@ export async function applyFileEdits(
     }
 
     if (!matchFound) {
-      throw new Error(`Could not find exact match for edit:\n${edit.oldText}`);
+      // Find the closest near-match to help diagnose the mismatch
+      const oldLines = normalizedOld.split('\n');
+      const contentLines = modifiedContent.split('\n');
+      let bestScore = 0;
+      let bestLineStart = 0;
+
+      for (let i = 0; i <= contentLines.length - oldLines.length; i++) {
+        const potentialMatch = contentLines.slice(i, i + oldLines.length);
+        let score = 0;
+        for (let j = 0; j < oldLines.length; j++) {
+          if (oldLines[j].trim() === potentialMatch[j].trim()) {
+            score++;
+          }
+        }
+        if (score > bestScore) {
+          bestScore = score;
+          bestLineStart = i;
+        }
+      }
+
+      let diagnostic = `Could not find match for edit in ${filePath}`;
+      if (bestScore > 0) {
+        const matchPct = Math.round((bestScore / oldLines.length) * 100);
+        diagnostic += `\nClosest match (${matchPct}% of lines) at lines ${bestLineStart + 1}-${bestLineStart + oldLines.length}:`;
+        const nearMatchLines = contentLines.slice(bestLineStart, bestLineStart + oldLines.length);
+        for (let j = 0; j < oldLines.length; j++) {
+          const marker = oldLines[j].trim() === nearMatchLines[j].trim() ? ' ' : '!';
+          diagnostic += `\n ${marker} line ${bestLineStart + 1 + j}: ${JSON.stringify(nearMatchLines[j])}`;
+          if (marker === '!') {
+            diagnostic += `\n     expected: ${JSON.stringify(oldLines[j])}`;
+          }
+        }
+      } else {
+        diagnostic += `\nNo similar content found in the file (${contentLines.length} lines).`;
+      }
+      diagnostic += `\n\nEdit oldText:\n${edit.oldText}`;
+      throw new Error(diagnostic);
     }
   }
 


### PR DESCRIPTION
## Summary

When `edit_file` fails to find a match (neither exact nor whitespace-flexible), the error message currently just dumps the `oldText` with no context about what the file actually contains. This makes it hard for both agents and humans to diagnose *why* the match failed.

This PR improves the error to include:
- **File path** in the error message
- **Closest near-match location** with 1-indexed line numbers
- **Match percentage** (how many lines matched after trimming)
- **Line-by-line comparison** showing which lines matched and which diverged, with both the actual and expected content

Example error after this change:
```
Could not find match for edit in /path/to/file.ts
Closest match (75% of lines) at lines 42-45:
   line 42: "  const foo = bar;"
 ! line 43: "  baz();"
     expected: "  baz(x);"
   line 44: "  return result;"
   line 45: "}"

Edit oldText:
  const foo = bar;
  baz(x);
  return result;
}
```

No changes to the actual matching/replacement logic -- this is purely diagnostic improvement.

Fixes #2034

## Test plan
- [x] All 146 existing tests pass
- [x] Updated test name and assertion to match new error format
- [x] Verified error includes file path and diagnostic context on mismatch