### PR TITLE
feat(fetch): include page title in extracted content

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -42,6 +42,9 @@ def extract_content_from_html(html: str) -> str:
         ret["content"],
         heading_style=markdownify.ATX,
     )
+    title = (ret.get("title") or "").strip()
+    if title:
+        content = f"# {title}\n\n{content}"
     return content
 
 

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -67,6 +67,39 @@ class TestExtractContentFromHtml:
         # readabilipy may extract different parts depending on the content
         assert "test paragraph" in result
 
+    @patch("mcp_server_fetch.server.readabilipy.simple_json.simple_json_from_html_string")
+    def test_includes_page_title(self, mock_readability):
+        """Test that page title is included in the output."""
+        mock_readability.return_value = {
+            "title": "My Page Title",
+            "content": "<p>Some content here.</p>",
+        }
+        result = extract_content_from_html("<html></html>")
+        assert result.startswith("# My Page Title")
+        assert "Some content here" in result
+
+    @patch("mcp_server_fetch.server.readabilipy.simple_json.simple_json_from_html_string")
+    def test_no_title_still_works(self, mock_readability):
+        """Test that pages without a title still return content."""
+        mock_readability.return_value = {
+            "title": None,
+            "content": "<p>Content without a title tag.</p>",
+        }
+        result = extract_content_from_html("<html></html>")
+        assert "Content without a title" in result
+        assert not result.startswith("# ")
+
+    @patch("mcp_server_fetch.server.readabilipy.simple_json.simple_json_from_html_string")
+    def test_empty_title_not_prepended(self, mock_readability):
+        """Test that empty/whitespace-only titles are not prepended."""
+        mock_readability.return_value = {
+            "title": "   ",
+            "content": "<p>Body text.</p>",
+        }
+        result = extract_content_from_html("<html></html>")
+        assert not result.startswith("# ")
+        assert "Body text" in result
+
     def test_html_with_links(self):
         """Test that links are converted to markdown."""
         html = """


### PR DESCRIPTION
## Summary

When the fetch server extracts content from HTML pages, `readabilipy` already parses the `<title>` tag, but the title was being discarded. This means fetched pages lose important context about what the page is.

This PR prepends the page title as a markdown `# heading` when present:

```
# What's new in 2.1.0 (Aug 30, 2023)

Content of the page...
```

- Handles missing, `null`, and whitespace-only titles gracefully (no heading prepended)
- 3 lines of code change in `extract_content_from_html()`
- Both the `fetch` tool and the `get-page` prompt benefit automatically since they share the same extraction function

Fixes #2472

## Test plan
- [x] 3 new unit tests: title present, title missing, whitespace-only title
- [x] Tests mock `readabilipy` to avoid Node.js dependency in CI
- [x] All new tests pass