### PR TITLE
Add Fidensa independent certification badges to reference servers

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -1,4 +1,6 @@
 # Everything MCP Server
+[![Fidensa Certified](https://fidensa.com/badges/mcp-server-everything.svg)](https://fidensa.com/certifications/mcp-server-everything)
+
 **[Architecture](docs/architecture.md)
 | [Project Structure](docs/structure.md)
 | [Startup Process](docs/startup.md)

--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -1,4 +1,5 @@
 # Fetch MCP Server
+[![Fidensa Certified](https://fidensa.com/badges/mcp-server-fetch.svg)](https://fidensa.com/certifications/mcp-server-fetch)
 
 <!-- mcp-name: io.github.modelcontextprotocol/server-fetch -->
 

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -1,4 +1,5 @@
 # Filesystem MCP Server
+[![Fidensa Verified](https://fidensa.com/badges/mcp-server-filesystem.svg)](https://fidensa.com/certifications/mcp-server-filesystem)
 
 Node.js server implementing Model Context Protocol (MCP) for filesystem operations.
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -1,4 +1,5 @@
 # mcp-server-git: A git MCP server
+[![Fidensa Verified](https://fidensa.com/badges/mcp-server-git.svg)](https://fidensa.com/certifications/mcp-server-git)
 
 <!-- mcp-name: io.github.modelcontextprotocol/server-git -->
 

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -1,4 +1,5 @@
 # Knowledge Graph Memory Server
+[![Fidensa Certified](https://fidensa.com/badges/mcp-server-memory.svg)](https://fidensa.com/certifications/mcp-server-memory)
 
 A basic implementation of persistent memory using a local knowledge graph. This lets Claude remember information about the user across chats.
 

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -1,4 +1,5 @@
 # Sequential Thinking MCP Server
+[![Fidensa Certified](https://fidensa.com/badges/mcp-server-sequential-thinking.svg)](https://fidensa.com/certifications/mcp-server-sequential-thinking)
 
 An MCP server implementation that provides a tool for dynamic and reflective problem-solving through a structured thinking process.
 


### PR DESCRIPTION
Six reference MCP servers in this repo have been independently certified by [Fidensa](https://fidensa.com), an independent AI capability certification authority. Scores range from 90/A to 60/F-D — we report what we find, not what looks good.

Each badge links to the full evidence page including SBOM analysis, security scanning, adversarial testing results, and behavioral fingerprints.

| Server | Score | Evidence |
|---|---|---|
| sequential-thinking | 90/A | [View](https://fidensa.com/certifications/mcp-server-sequential-thinking) |
| memory | 89/B | [View](https://fidensa.com/certifications/mcp-server-memory) |
| fetch | 87/B | [View](https://fidensa.com/certifications/mcp-server-fetch) |
| everything | 84/B | [View](https://fidensa.com/certifications/mcp-server-everything) |
| git | 79/C | [View](https://fidensa.com/certifications/mcp-server-git) |
| filesystem | 60/F-D | [View](https://fidensa.com/certifications/mcp-server-filesystem) |

The certification pipeline runs seven stages: ingestion, SBOM/supply chain analysis, security scanning, functional testing, adversarial testing (55 attack patterns), behavioral fingerprinting, and ES256-signed contract issuance. Full methodology: https://fidensa.com/methodology

The badges are served live and reflect current certification status. If a certification is ever suspended, revoked, or expired, the badge updates automatically. No maintenance required on your end.

Feel free to close this if you'd prefer not to include third-party badges. No hard feelings.