### PR TITLE
fix(filesystem): move_file outputSchema returns array not string

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -607,7 +607,7 @@ server.registerTool(
       source: z.string(),
       destination: z.string()
     },
-    outputSchema: { content: z.string() },
+    outputSchema: { content: z.array(z.object({ type: z.string(), text: z.string() })) },
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof MoveFileArgsSchema>) => {


### PR DESCRIPTION
## Summary
Fixes #3093

## Problem
The `move_file` tool's `outputSchema` incorrectly declares `content: z.string()` but the handler returns `content: [contentBlock]` (an array). This mismatch causes MCP protocol validation to fail with error -32602:
```
Output validation error: Invalid structured content for tool move_file:
  expected string, received array
```

## Fix
Changed `outputSchema` from:
```ts
outputSchema: { content: z.string() }
```
to:
```ts
outputSchema: { content: z.array(z.object({ type: z.string(), text: z.string() })) }
```

This matches the actual return value:
```ts
return {
  content: [contentBlock],  // array of {type: 'text', text: string}
  structuredContent: { content: text }
};
```

## Testing
The bug was reported by a user on Windows 10 with Claude Desktop 1.0.130.7 and `@modelcontextprotocol/server-filesystem@latest`. The fix aligns the schema declaration with the actual runtime behavior.
