### PR TITLE
test(filesystem): add regression tests for Docker Linux path handling

### DIFF
--- a/src/filesystem/__tests__/path-utils.test.ts
+++ b/src/filesystem/__tests__/path-utils.test.ts
@@ -379,4 +379,62 @@ describe('Path Utilities', () => {
       }
     });
   });
+
+  describe('Linux Docker path handling (issue #3628 fix)', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        writable: true,
+        configurable: true
+      });
+    });
+
+    it('reproduces exact scenario from issue #3628', () => {
+      // Docker Alpine Linux container where /h/username/MCP_Development/data
+      // was incorrectly converted to H:\username\MCP_Development\data
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true
+      });
+
+      const inputPath = '/h/username/MCP_Development/data';
+      const result = normalizePath(inputPath);
+
+      expect(result).toBe('/h/username/MCP_Development/data');
+      expect(result).not.toContain('H:');
+      expect(result).not.toContain('\\');
+    });
+
+    it('preserves single-letter root directories on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true
+      });
+
+      // These look like drive letters but are valid Linux directories
+      expect(normalizePath('/u/local/share')).toBe('/u/local/share');
+      expect(normalizePath('/d/projects/app')).toBe('/d/projects/app');
+      expect(normalizePath('/s/data/files')).toBe('/s/data/files');
+      expect(normalizePath('/e/backups/daily')).toBe('/e/backups/daily');
+    });
+
+    it('convertToWindowsPath leaves single-letter root paths unchanged on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true
+      });
+
+      expect(convertToWindowsPath('/h/username/MCP_Development/data'))
+        .toBe('/h/username/MCP_Development/data');
+      expect(convertToWindowsPath('/c/some/path'))
+        .toBe('/c/some/path');
+      expect(convertToWindowsPath('/d/projects/app'))
+        .toBe('/d/projects/app');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #3628

## Description

Adds regression tests for the Docker/Linux path normalization bug where paths like `/h/username/MCP_Development/data` got wrongly converted to `H:\username\MCP_Development\data`. The code fix already landed on main (commit c9b0135a added platform detection to `normalizePath` and `convertToWindowsPath`), but there were no tests covering the exact scenario from the issue.

New tests mock `process.platform` to `'linux'` (simulating Docker Alpine) and verify that single-letter root directories (`/h/`, `/u/`, `/d/`) aren't mistaken for Windows drive letters. Uses the same mocking pattern already in the WSL test block.

Note: Docker image 1.0.2 still has the bug. It needs rebuilding from current main to pick up the fix.

## Server Details
- Server: filesystem
- Changes to: tests only (`path-utils.test.ts`)

## Motivation and Context

Issue #3628 reports that the filesystem server running in Docker Alpine Linux converts valid Linux paths to Windows-style paths. The fix exists but had no dedicated test coverage for the Docker scenario.

## How Has This Been Tested?

`cd src/filesystem && npm test` — all 149 tests pass (7 test files), including the new regression tests.

## Breaking Changes

None. Test-only change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options