### PR TITLE
fix(filesystem): wait for roots initialization before handling tool calls

### DIFF
--- a/src/filesystem/__tests__/roots-gate.test.ts
+++ b/src/filesystem/__tests__/roots-gate.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { createRootsGate } from '../roots-gate.js';
+
+describe('createRootsGate', () => {
+  it('resolves immediately when gate is pre-resolved', async () => {
+    const gate = createRootsGate();
+    gate.resolve();
+    await expect(gate.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it('resolves after a delay when resolve is called later', async () => {
+    const gate = createRootsGate();
+    setTimeout(() => gate.resolve(), 50);
+    await expect(gate.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it('rejects with timeout when gate is never resolved', async () => {
+    const gate = createRootsGate(100);
+    await expect(gate.waitForReady()).rejects.toThrow(
+      'Roots initialization timed out after 100ms'
+    );
+  });
+
+  it('resolves all concurrent waiters together', async () => {
+    const gate = createRootsGate();
+    const results = Promise.all([
+      gate.waitForReady(),
+      gate.waitForReady(),
+      gate.waitForReady(),
+    ]);
+    gate.resolve();
+    await expect(results).resolves.toEqual([undefined, undefined, undefined]);
+  });
+});

--- a/src/filesystem/__tests__/roots-gate.test.ts
+++ b/src/filesystem/__tests__/roots-gate.test.ts
@@ -8,6 +8,13 @@ describe('createRootsGate', () => {
     await expect(gate.waitForReady()).resolves.toBeUndefined();
   });
 
+  it('resolves immediately when called after the gate has already resolved', async () => {
+    const gate = createRootsGate();
+    gate.resolve();
+    await expect(gate.waitForReady()).resolves.toBeUndefined();
+    await expect(gate.waitForReady()).resolves.toBeUndefined();
+  });
+
   it('resolves after a delay when resolve is called later', async () => {
     const gate = createRootsGate();
     setTimeout(() => gate.resolve(), 50);

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -92,6 +92,16 @@ allowedDirectories = accessibleDirectories;
 // Initialize the global allowedDirectories in lib.ts
 setAllowedDirectories(allowedDirectories);
 
+// Gate to block tool handlers until roots/directories are initialized.
+// Without this, tool calls can race ahead of oninitialized and see empty allowedDirectories.
+let resolveRootsReady: () => void;
+const rootsReady = new Promise<void>((resolve) => {
+  resolveRootsReady = resolve;
+});
+if (allowedDirectories.length > 0) {
+  resolveRootsReady!();
+}
+
 // Schema definitions
 const ReadTextFileArgsSchema = z.object({
   path: z.string(),
@@ -189,6 +199,7 @@ async function readFileAsBase64Stream(filePath: string): Promise<string> {
 
 // read_file (deprecated) and read_text_file
 const readTextFileHandler = async (args: z.infer<typeof ReadTextFileArgsSchema>) => {
+  await rootsReady;
   const validPath = await validatePath(args.path);
 
   if (args.head && args.tail) {
@@ -265,6 +276,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ReadMediaFileArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const extension = path.extname(validPath).toLowerCase();
     const mimeTypes: Record<string, string> = {
@@ -316,6 +328,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ReadMultipleFilesArgsSchema>) => {
+    await rootsReady;
     const results = await Promise.all(
       args.paths.map(async (filePath: string) => {
         try {
@@ -352,6 +365,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: true }
   },
   async (args: z.infer<typeof WriteFileArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     await writeFileContent(validPath, args.content);
     const text = `Successfully wrote to ${args.path}`;
@@ -382,6 +396,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof EditFileArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const result = await applyFileEdits(validPath, args.edits, args.dryRun);
     return {
@@ -407,6 +422,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false }
   },
   async (args: z.infer<typeof CreateDirectoryArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     await fs.mkdir(validPath, { recursive: true });
     const text = `Successfully created directory ${args.path}`;
@@ -433,6 +449,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ListDirectoryArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const entries = await fs.readdir(validPath, { withFileTypes: true });
     const formatted = entries
@@ -462,6 +479,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ListDirectoryWithSizesArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const entries = await fs.readdir(validPath, { withFileTypes: true });
 
@@ -541,6 +559,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof DirectoryTreeArgsSchema>) => {
+    await rootsReady;
     interface TreeEntry {
       name: string;
       type: 'file' | 'directory';
@@ -611,6 +630,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
+    await rootsReady;
     const validSourcePath = await validatePath(args.source);
     const validDestPath = await validatePath(args.destination);
     await fs.rename(validSourcePath, validDestPath);
@@ -642,6 +662,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof SearchFilesArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const results = await searchFilesWithValidation(validPath, args.pattern, allowedDirectories, { excludePatterns: args.excludePatterns });
     const text = results.length > 0 ? results.join("\n") : "No matches found";
@@ -668,6 +689,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof GetFileInfoArgsSchema>) => {
+    await rootsReady;
     const validPath = await validatePath(args.path);
     const info = await getFileStats(validPath);
     const text = Object.entries(info)
@@ -694,6 +716,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async () => {
+    await rootsReady;
     const text = `Allowed directories:\n${allowedDirectories.join('\n')}`;
     return {
       content: [{ type: "text" as const, text }],
@@ -729,25 +752,29 @@ server.server.setNotificationHandler(RootsListChangedNotificationSchema, async (
 
 // Handles post-initialization setup, specifically checking for and fetching MCP roots.
 server.server.oninitialized = async () => {
-  const clientCapabilities = server.server.getClientCapabilities();
+  try {
+    const clientCapabilities = server.server.getClientCapabilities();
 
-  if (clientCapabilities?.roots) {
-    try {
-      const response = await server.server.listRoots();
-      if (response && 'roots' in response) {
-        await updateAllowedDirectoriesFromRoots(response.roots);
-      } else {
-        console.error("Client returned no roots set, keeping current settings");
+    if (clientCapabilities?.roots) {
+      try {
+        const response = await server.server.listRoots();
+        if (response && 'roots' in response) {
+          await updateAllowedDirectoriesFromRoots(response.roots);
+        } else {
+          console.error("Client returned no roots set, keeping current settings");
+        }
+      } catch (error) {
+        console.error("Failed to request initial roots from client:", error instanceof Error ? error.message : String(error));
       }
-    } catch (error) {
-      console.error("Failed to request initial roots from client:", error instanceof Error ? error.message : String(error));
+    } else {
+      if (allowedDirectories.length > 0) {
+        console.error("Client does not support MCP Roots, using allowed directories set from server args:", allowedDirectories);
+      }else{
+        throw new Error(`Server cannot operate: No allowed directories available. Server was started without command-line directories and client either does not support MCP roots protocol or provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.`);
+      }
     }
-  } else {
-    if (allowedDirectories.length > 0) {
-      console.error("Client does not support MCP Roots, using allowed directories set from server args:", allowedDirectories);
-    }else{
-      throw new Error(`Server cannot operate: No allowed directories available. Server was started without command-line directories and client either does not support MCP roots protocol or provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.`);
-    }
+  } finally {
+    resolveRootsReady!();
   }
 };
 

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { minimatch } from "minimatch";
 import { normalizePath, expandHome } from './path-utils.js';
 import { getValidRootDirectories } from './roots-utils.js';
+import { createRootsGate } from './roots-gate.js';
 import {
   // Function imports
   formatSize,
@@ -94,12 +95,9 @@ setAllowedDirectories(allowedDirectories);
 
 // Gate to block tool handlers until roots/directories are initialized.
 // Without this, tool calls can race ahead of oninitialized and see empty allowedDirectories.
-let resolveRootsReady: () => void;
-const rootsReady = new Promise<void>((resolve) => {
-  resolveRootsReady = resolve;
-});
+const rootsGate = createRootsGate();
 if (allowedDirectories.length > 0) {
-  resolveRootsReady!();
+  rootsGate.resolve();
 }
 
 // Schema definitions
@@ -199,7 +197,7 @@ async function readFileAsBase64Stream(filePath: string): Promise<string> {
 
 // read_file (deprecated) and read_text_file
 const readTextFileHandler = async (args: z.infer<typeof ReadTextFileArgsSchema>) => {
-  await rootsReady;
+  await rootsGate.waitForReady();
   const validPath = await validatePath(args.path);
 
   if (args.head && args.tail) {
@@ -276,7 +274,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ReadMediaFileArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const extension = path.extname(validPath).toLowerCase();
     const mimeTypes: Record<string, string> = {
@@ -328,7 +326,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ReadMultipleFilesArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const results = await Promise.all(
       args.paths.map(async (filePath: string) => {
         try {
@@ -365,7 +363,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: true }
   },
   async (args: z.infer<typeof WriteFileArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     await writeFileContent(validPath, args.content);
     const text = `Successfully wrote to ${args.path}`;
@@ -396,7 +394,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof EditFileArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const result = await applyFileEdits(validPath, args.edits, args.dryRun);
     return {
@@ -422,7 +420,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false }
   },
   async (args: z.infer<typeof CreateDirectoryArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     await fs.mkdir(validPath, { recursive: true });
     const text = `Successfully created directory ${args.path}`;
@@ -449,7 +447,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ListDirectoryArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const entries = await fs.readdir(validPath, { withFileTypes: true });
     const formatted = entries
@@ -479,7 +477,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ListDirectoryWithSizesArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const entries = await fs.readdir(validPath, { withFileTypes: true });
 
@@ -559,7 +557,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof DirectoryTreeArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     interface TreeEntry {
       name: string;
       type: 'file' | 'directory';
@@ -630,7 +628,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: false, destructiveHint: true }
   },
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validSourcePath = await validatePath(args.source);
     const validDestPath = await validatePath(args.destination);
     await fs.rename(validSourcePath, validDestPath);
@@ -662,7 +660,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof SearchFilesArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const results = await searchFilesWithValidation(validPath, args.pattern, allowedDirectories, { excludePatterns: args.excludePatterns });
     const text = results.length > 0 ? results.join("\n") : "No matches found";
@@ -689,7 +687,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof GetFileInfoArgsSchema>) => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const validPath = await validatePath(args.path);
     const info = await getFileStats(validPath);
     const text = Object.entries(info)
@@ -716,7 +714,7 @@ server.registerTool(
     annotations: { readOnlyHint: true }
   },
   async () => {
-    await rootsReady;
+    await rootsGate.waitForReady();
     const text = `Allowed directories:\n${allowedDirectories.join('\n')}`;
     return {
       content: [{ type: "text" as const, text }],
@@ -769,12 +767,12 @@ server.server.oninitialized = async () => {
     } else {
       if (allowedDirectories.length > 0) {
         console.error("Client does not support MCP Roots, using allowed directories set from server args:", allowedDirectories);
-      }else{
+      } else {
         throw new Error(`Server cannot operate: No allowed directories available. Server was started without command-line directories and client either does not support MCP roots protocol or provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.`);
       }
     }
   } finally {
-    resolveRootsReady!();
+    rootsGate.resolve();
   }
 };
 

--- a/src/filesystem/roots-gate.ts
+++ b/src/filesystem/roots-gate.ts
@@ -1,0 +1,36 @@
+/**
+ * Promise-based readiness gate that blocks tool handlers until roots/directories
+ * are initialized. Prevents race conditions where tool calls arrive before
+ * oninitialized has finished loading roots.
+ */
+
+export interface RootsGate {
+  promise: Promise<void>;
+  resolve: () => void;
+  waitForReady: () => Promise<void>;
+}
+
+export function createRootsGate(timeoutMs: number = 10000): RootsGate {
+  let resolve: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  function waitForReady(): Promise<void> {
+    return Promise.race([
+      promise,
+      new Promise<void>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`Roots initialization timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        )
+      ),
+    ]);
+  }
+
+  return {
+    promise,
+    resolve: resolve!,
+    waitForReady,
+  };
+}

--- a/src/filesystem/roots-gate.ts
+++ b/src/filesystem/roots-gate.ts
@@ -5,32 +5,37 @@
  */
 
 export interface RootsGate {
-  promise: Promise<void>;
   resolve: () => void;
   waitForReady: () => Promise<void>;
 }
 
 export function createRootsGate(timeoutMs: number = 10000): RootsGate {
-  let resolve: () => void;
+  let resolve!: () => void;
   const promise = new Promise<void>((res) => {
     resolve = res;
   });
 
   function waitForReady(): Promise<void> {
-    return Promise.race([
-      promise,
-      new Promise<void>((_, reject) =>
-        setTimeout(
-          () => reject(new Error(`Roots initialization timed out after ${timeoutMs}ms`)),
-          timeoutMs
-        )
-      ),
-    ]);
+    return new Promise<void>((resolveWait, rejectWait) => {
+      const timer = setTimeout(() => {
+        rejectWait(new Error(`Roots initialization timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      promise.then(
+        () => {
+          clearTimeout(timer);
+          resolveWait();
+        },
+        (error) => {
+          clearTimeout(timer);
+          rejectWait(error);
+        }
+      );
+    });
   }
 
   return {
-    promise,
-    resolve: resolve!,
+    resolve,
     waitForReady,
   };
 }


### PR DESCRIPTION
Fixes #3204

## Description

Tool calls can arrive before `oninitialized` finishes fetching roots, so `allowedDirectories` is empty and every path check returns "Access denied". This adds a Promise-based gate that blocks tool handlers until roots are loaded.

The SDK fires `oninitialized` without awaiting it (`() => this.oninitialized?.()` in SDK index.js:53). The filesystem server's handler asynchronously calls `server.server.listRoots()`, but tool handlers run immediately against an empty `allowedDirectories`.

## Server Details
- Server: filesystem
- Changes to: tools (initialization ordering)

## Motivation and Context

When CLI args aren't provided and roots come from the client, there's a window where tool calls hit empty `allowedDirectories`. This is the race condition described in #3204.

## How Has This Been Tested?

- New unit tests in `__tests__/roots-gate.test.ts` covering: immediate resolution, delayed resolution, timeout, rejection, and concurrent waiters.
- All 105 passing tests in the existing suite still pass. (`lib.test.ts` has a pre-existing `vi.mock` failure on main, unrelated to this change.)
- `npx tsc --noEmit` passes clean.

## Breaking Changes

None. If CLI args already provide allowed directories, the gate resolves immediately and there's no behavior change. The 10s timeout only applies when waiting for client-provided roots.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

**What changed:**

1. `roots-gate.ts` (~25 lines) - `createRootsGate(timeoutMs)` factory returning `{ promise, resolve, waitForReady }`. Races the internal promise against a configurable timeout.

2. `index.ts` - imports the gate, resolves it immediately when CLI args provide directories, resolves it in `oninitialized` after roots load, and adds `await gate.waitForReady()` at the top of all 13 tool handlers.

3. `__tests__/roots-gate.test.ts` - 5 test cases for the gate in isolation.