### PR TITLE
fix(fetch): make fetch tool schema Gemini/OpenAPI 3.0 compatible

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -18,7 +18,7 @@ from mcp.types import (
     INTERNAL_ERROR,
 )
 from protego import Protego
-from pydantic import BaseModel, Field, AnyUrl
+from pydantic import AnyUrl, BaseModel, Field, WithJsonSchema
 
 DEFAULT_USER_AGENT_AUTONOMOUS = "ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)"
 DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://github.com/modelcontextprotocol/servers)"
@@ -151,14 +151,18 @@ async def fetch_url(
 class Fetch(BaseModel):
     """Parameters for fetching a URL."""
 
-    url: Annotated[AnyUrl, Field(description="URL to fetch")]
+    url: Annotated[
+        AnyUrl,
+        Field(description="URL to fetch"),
+        WithJsonSchema({"type": "string", "description": "URL to fetch"}),
+    ]
     max_length: Annotated[
         int,
         Field(
             default=5000,
             description="Maximum number of characters to return.",
-            gt=0,
-            lt=1000000,
+            ge=1,
+            le=999999,
         ),
     ]
     start_index: Annotated[

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -5,12 +5,45 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from mcp.shared.exceptions import McpError
 
 from mcp_server_fetch.server import (
+    Fetch,
     extract_content_from_html,
     get_robots_txt_url,
     check_may_autonomously_fetch_url,
     fetch_url,
     DEFAULT_USER_AGENT_AUTONOMOUS,
 )
+
+
+class TestFetchToolSchema:
+    """Tests for the Fetch model JSON schema compatibility."""
+
+    def test_schema_uses_inclusive_bounds(self):
+        """Ensure the schema uses minimum/maximum instead of exclusiveMinimum/exclusiveMaximum.
+
+        Some LLM providers (e.g. Google Gemini) only support OpenAPI 3.0
+        schema keywords and reject exclusiveMinimum/exclusiveMaximum.
+        """
+        schema = Fetch.model_json_schema()
+        max_length_schema = schema["properties"]["max_length"]
+
+        assert "exclusiveMinimum" not in max_length_schema
+        assert "exclusiveMaximum" not in max_length_schema
+        assert max_length_schema["minimum"] == 1
+        assert max_length_schema["maximum"] == 999999
+
+    def test_url_schema_omits_unsupported_keywords(self):
+        """Ensure the url field schema avoids format/minLength keywords.
+
+        Some LLM providers (e.g. Google Gemini) only support a limited set
+        of keywords for string types and reject unsupported ones like
+        format: "uri" or minLength.
+        """
+        schema = Fetch.model_json_schema()
+        url_schema = schema["properties"]["url"]
+
+        assert "format" not in url_schema
+        assert "minLength" not in url_schema
+        assert url_schema["type"] == "string"
 
 
 class TestGetRobotsTxtUrl:

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -53,11 +53,11 @@ class TestFetchToolSchema:
         must still be rejected at parse time with a ValidationError.
         """
         with pytest.raises(ValidationError):
-            Fetch(url="not-a-url")
+            Fetch.model_validate({"url": "not-a-url"})
 
     def test_url_runtime_validation_accepts_valid_urls(self):
         """Ensure valid URLs still parse successfully after the WithJsonSchema override."""
-        fetch = Fetch(url="https://example.com/page")
+        fetch = Fetch.model_validate({"url": "https://example.com/page"})
         assert str(fetch.url) == "https://example.com/page"
 
 

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -3,6 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from mcp.shared.exceptions import McpError
+from pydantic import ValidationError
 
 from mcp_server_fetch.server import (
     Fetch,
@@ -44,6 +45,20 @@ class TestFetchToolSchema:
         assert "format" not in url_schema
         assert "minLength" not in url_schema
         assert url_schema["type"] == "string"
+
+    def test_url_runtime_validation_still_rejects_invalid_urls(self):
+        """Ensure AnyUrl runtime validation is preserved after the WithJsonSchema override.
+
+        The override only simplifies the emitted JSON schema; invalid URLs
+        must still be rejected at parse time with a ValidationError.
+        """
+        with pytest.raises(ValidationError):
+            Fetch(url="not-a-url")
+
+    def test_url_runtime_validation_accepts_valid_urls(self):
+        """Ensure valid URLs still parse successfully after the WithJsonSchema override."""
+        fetch = Fetch(url="https://example.com/page")
+        assert str(fetch.url) == "https://example.com/page"
 
 
 class TestGetRobotsTxtUrl:


### PR DESCRIPTION
## Summary

Fixes the fetch server's tool schema to be compatible with LLM providers that only support OpenAPI 3.0 schema keywords (e.g. Google Gemini 2.5 Pro), which currently reject the schema with a `400 INVALID_ARGUMENT` error.

Two incompatibilities are addressed:

1. **`max_length` field** used `gt=0` / `lt=1000000` Pydantic constraints, which generate `exclusiveMinimum` / `exclusiveMaximum` in the JSON Schema. Gemini does not recognize these keywords. Changed to `ge=1` / `le=999999` — identical semantics for integers — which emits the universally supported `minimum` / `maximum` keywords instead.

2. **`url` field** used `AnyUrl`, which generates `format: \"uri\"` and `minLength: 1`. Gemini only supports `\"enum\"` and `\"date-time\"` for string `format`, and does not support `minLength`. Added a `WithJsonSchema` override to emit a plain `{"type": "string"}` schema while preserving `AnyUrl` runtime validation — so invalid URLs are still rejected with a proper error, but the schema no longer contains unsupported keywords.

Fixes #1624

## Changes

**`src/fetch/src/mcp_server_fetch/server.py`**
- `max_length` field: `gt=0` → `ge=1`, `lt=1000000` → `le=999999`
- `url` field: added `WithJsonSchema({"type": "string", "description": "URL to fetch"})` to override schema output while keeping `AnyUrl` runtime validation

**`src/fetch/tests/test_server.py`**
- Added `TestFetchToolSchema.test_schema_uses_inclusive_bounds` — asserts `minimum`/`maximum` present, `exclusiveMinimum`/`exclusiveMaximum` absent
- Added `TestFetchToolSchema.test_url_schema_omits_unsupported_keywords` — asserts `format` and `minLength` absent from url schema

## Evidence

Live Gemini validation was run against `gemini-2.5-pro` using the exact generated tool schema sent to `generateContent`.

**Pre-fix schema (reproduced locally):**
- `HTTP 400`
- `INVALID_ARGUMENT`
- Error excerpt:
  - `Unknown name "exclusiveMaximum"`
  - `Unknown name "exclusiveMinimum"`

**Current PR schema:**
- `HTTP 200`
- Gemini accepted the tool declaration payload
- Response text: `Acknowledged.`

## Test plan

- [x] All 22 tests pass (`uv run python -m pytest tests/test_server.py -v`)
- [x] Schema verified: no `exclusiveMinimum`, `exclusiveMaximum`, `format`, or `minLength` in output
- [x] `AnyUrl` runtime validation confirmed: valid URLs accepted, invalid URLs rejected with `ValidationError`
- [x] Live Gemini validation: sent the exact generated schema to `gemini-2.5-pro` via `generateContent`; request was accepted with `HTTP 200` and returned `Acknowledged.`
- [x] No behavioral change — same validation semantics, only schema representation changed