### PR TITLE
Add GuardVibe — Security MCP for vibe coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[GraphQL Schema](https://github.com/hannesj/mcp-graphql-schema)** - Allow LLMs to explore large GraphQL schemas without bloating the context.
 - **[Graylog](https://github.com/Pranavj17/mcp-server-graylog)** - Search Graylog logs by absolute/relative timestamps, filter by streams, and debug production issues directly from Claude Desktop.
 - **[Grok-MCP](https://github.com/merterbak/Grok-MCP)** - MCP server for xAI’s API featuring the latest Grok models, image analysis & generation, and web search.
+- **[GuardVibe](https://github.com/goklab/guardvibe)** - Security MCP for vibe coding with 313 rules and 25 tools for AI-generated code.
 - **[gx-mcp-server](https://github.com/davidf9999/gx-mcp-server)** - Expose Great Expectations data validation and quality checks as MCP tools for AI agents.
 - **[HackMD](https://github.com/yuna0x0/hackmd-mcp)** (by yuna0x0) - An MCP server for HackMD, a collaborative markdown editor. It allows users to create, read, and update documents in HackMD using the Model Context Protocol.
 - **[HAProxy](https://github.com/tuannvm/haproxy-mcp-server)** - A Model Context Protocol (MCP) server for HAProxy implemented in Go, leveraging HAProxy Runtime API.


### PR DESCRIPTION
## New Community Server: GuardVibe

**GitHub:** https://github.com/goklab/guardvibe
**npm:** https://www.npmjs.com/package/guardvibe  
**MCP Registry:** io.github.goklab/guardvibe
**License:** Apache-2.0

Security MCP server purpose-built for AI-generated code (vibe coding). 313 security rules across 23 modules, 25 tools. Scans Next.js, Supabase, Clerk, Stripe, Prisma, Hono, GraphQL and more. Zero config, runs locally, no API keys needed.