### PR TITLE
Add Slashr to community servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a collection of *reference implementations* for the [Model Co
 > [!WARNING]
 > The servers in this repository are intended as **reference implementations** to demonstrate MCP features and SDK usage. They are meant to serve as educational examples for developers building their own MCP servers, not as production-ready solutions. Developers should evaluate their own security requirements and implement appropriate safeguards based on their specific threat model and use case.
 
-The servers in this repository showcase the versatility and extensibility of MCP, demonstrating how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources.
+The servers in this repository showcase the versatility and extensibility of MCP, demonstrating how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources
 Typically, each MCP server is implemented with an MCP SDK:
 
 - [C# MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk)
@@ -1295,6 +1295,7 @@ search, and comprehensive file analysis.
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/mcp)** - MCP to let Claude / Windsurf / Cursor / your LLM control the browser
 - **[Slack](https://github.com/korotovsky/slack-mcp-server)** - The most powerful MCP server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins 😏.
 - **[Slack](https://github.com/zencoderai/slack-mcp-server)** - Slack MCP server which supports both stdio and Streamable HTTP transports. Extended from the original Anthropic's implementation which is now [archived](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/slack)
+- **[Slashr](https://slashr.dev/developers)** - Live validator incident data for AI agents. Query delinquency, slashing, and scan results across Solana, Ethereum, Sui, and Cosmos. Remote MCP server at `mcp.slashr.dev`.
 - **[Slidespeak](https://github.com/SlideSpeak/slidespeak-mcp)** - Create PowerPoint presentations using the [Slidespeak](https://slidespeak.com/) API.
 - **[Smartlead](https://github.com/jean-technologies/smartlead-mcp-server-local)** - MCP to connect to Smartlead. Additional, tooling, functionality, and connection to workflow automation platforms also available.
 - **[Snowflake](https://github.com/Snowflake-Labs/mcp)** - Open-source MCP server for Snowflake from official Snowflake-Labs supports prompting Cortex Agents, querying structured & unstructured data, object management, SQL execution, semantic view querying, and more. RBAC, fine-grained CRUD controls, and all authentication methods supported.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a collection of *reference implementations* for the [Model Co
 > [!WARNING]
 > The servers in this repository are intended as **reference implementations** to demonstrate MCP features and SDK usage. They are meant to serve as educational examples for developers building their own MCP servers, not as production-ready solutions. Developers should evaluate their own security requirements and implement appropriate safeguards based on their specific threat model and use case.
 
-The servers in this repository showcase the versatility and extensibility of MCP, demonstrating how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources
+The servers in this repository showcase the versatility and extensibility of MCP, demonstrating how it can be used to give Large Language Models (LLMs) secure, controlled access to tools and data sources.
 Typically, each MCP server is implemented with an MCP SDK:
 
 - [C# MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk)


### PR DESCRIPTION
## Description

Adds [[Slashr](https://slashr.dev/)](https://slashr.dev) to the community servers list — a live cross-chain validator incident MCP server covering Solana, Ethereum, Sui, and Cosmos.

## Publishing Your Server

Already submitted to the MCP Registry via `mcp-publisher`.

## Server Details

- Server: Slashr (`mcp.slashr.dev`)
- Changes to: Community servers list (README.md)

## Motivation and Context

No existing MCP server surfaces blockchain validator incident data. Slashr tracks delinquency, slashing, jailing, and missed votes in real time across four networks, and exposes this via a hosted remote MCP server. Useful for agents monitoring staking portfolios, validator operations, or delegator health.

Tools exposed:
- `get_validator_incidents` — incident history by address and chain
- `get_validator_stats` — current performance, stake, commission
- `get_scan_results` — infrastructure scan results, CVEs, port states
- `get_rankings` — worst/most reliable validators by period
- `check_wallet` — delegation health for a wallet address

Transport: Streamable HTTP · Auth: Bearer token · Read-only

## How Has This Been Tested?

Tested with Claude Desktop and Claude.ai. Verified all five tools return structured data across Solana, Ethereum, Sui, and Cosmos endpoints.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [[MCP Protocol Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

Developer docs and quickstart at [[slashr.dev/developers](https://slashr.dev/developers)](https://slashr.dev/developers). The server is read-only with Bearer token auth — no write access to any chain or wallet.