### PR TITLE
fix(ci): use pull_request_target in readme-pr-check so fork PRs work

### DIFF
--- a/.github/workflows/readme-pr-check.yml
+++ b/.github/workflows/readme-pr-check.yml
@@ -1,7 +1,7 @@
 name: README PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     paths:
       - 'README.md'
@@ -10,11 +10,12 @@ on:
 
 jobs:
   check-readme-only:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Check files and comment if README-only
         uses: actions/github-script@v8
@@ -61,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Swap labels and minimize comments
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

The `README PR Check` workflow is currently failing on **every PR opened from a fork** (which is the vast majority of contributions to this repo). Example failed runs from the last couple of days: [#24010860831](https://github.com/modelcontextprotocol/servers/actions/runs/24010860831), [#24010684932](https://github.com/modelcontextprotocol/servers/actions/runs/24010684932), [#24007350839](https://github.com/modelcontextprotocol/servers/actions/runs/24007350839), [#24003674827](https://github.com/modelcontextprotocol/servers/actions/runs/24003674827), and many more — the full list on [the workflow page](https://github.com/modelcontextprotocol/servers/actions/workflows/readme-pr-check.yml) shows the pattern: anything from a fork is red, only the one internal-branch run is green.

All of them fail the same way:

```
HttpError: Resource not accessible by integration
POST /repos/modelcontextprotocol/servers/issues/{n}/labels
status: 403
x-accepted-github-permissions: issues=write; pull_requests=write
```

## Root cause

The workflow triggers on `pull_request`. When a `pull_request` event comes from a fork, the `GITHUB_TOKEN` is **read-only** regardless of the `permissions:` block in the job — that is the documented GitHub Actions security model. So `addLabels` / `createComment` can never succeed for the 99% case this workflow was written for.

## Fix

1. Switch the trigger to `pull_request_target`. This runs the workflow in the context of the base repo, so the `permissions:` block is actually honored and the token can write labels/comments.
2. Add `issues: write` next to `pull-requests: write`, since `addLabels` and `createComment` both hit the `/issues/` endpoint (the 403 response header even tells us: `x-accepted-github-permissions: issues=write; pull_requests=write`).
3. Update the `if:` guard on `check-readme-only` to match the new event name.

### Why `pull_request_target` is safe here

`pull_request_target` is normally dangerous because it runs with write privileges against `github.event.pull_request.head.ref` — i.e. attacker-controlled code. **This workflow never does a `checkout`** and never executes anything from the PR. It only calls `octokit` (`pulls.listFiles`, `issues.addLabels`, `issues.createComment`) which read metadata and write labels/comments. There is no code-execution surface from the fork.

## Test plan

- [ ] Merge and confirm the next fork PR against `README.md` gets labeled `readme: pending` and commented instead of erroring
- [ ] Confirm `/i-promise-this-is-not-a-new-server` still swaps labels correctly (the `handle-confirmation` job was already fine — it runs on `issue_comment` which doesn't have the fork-token problem — but I added `issues: write` there too for consistency since it calls `addLabels` / `removeLabel`)
- [ ] Confirm non-README PRs are still skipped (the `files.length !== 1 || files[0].filename !== 'README.md'` check is unchanged)