### PR TITLE
Add Guesty MCP Server to Third-Party Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[GraphQL Schema](https://github.com/hannesj/mcp-graphql-schema)** - Allow LLMs to explore large GraphQL schemas without bloating the context.
 - **[Graylog](https://github.com/Pranavj17/mcp-server-graylog)** - Search Graylog logs by absolute/relative timestamps, filter by streams, and debug production issues directly from Claude Desktop.
 - **[Grok-MCP](https://github.com/merterbak/Grok-MCP)** - MCP server for xAI’s API featuring the latest Grok models, image analysis & generation, and web search.
+- **[Guesty MCP Server](https://github.com/DLJRealty/guesty-mcp-server)** - The first MCP server for [Guesty](https://guesty.com) property management. 38 tools for reservations, guests, messaging, pricing, financials, calendars, reviews, tasks, and webhooks. Connect AI agents to manage short-term rental operations.
 - **[gx-mcp-server](https://github.com/davidf9999/gx-mcp-server)** - Expose Great Expectations data validation and quality checks as MCP tools for AI agents.
 - **[HackMD](https://github.com/yuna0x0/hackmd-mcp)** (by yuna0x0) - An MCP server for HackMD, a collaborative markdown editor. It allows users to create, read, and update documents in HackMD using the Model Context Protocol.
 - **[HAProxy](https://github.com/tuannvm/haproxy-mcp-server)** - A Model Context Protocol (MCP) server for HAProxy implemented in Go, leveraging HAProxy Runtime API.


### PR DESCRIPTION
## Summary
Adds [Guesty MCP Server](https://github.com/DLJRealty/guesty-mcp-server) to the Third-Party Servers list.

- **38 tools** covering reservations, guests, messaging, pricing, financials, calendars, reviews, tasks, and webhooks
- **Published on npm**: [guesty-mcp-server](https://www.npmjs.com/package/guesty-mcp-server) (v0.4.3, 5 releases)
- **First MCP server** for Guesty, the leading property management platform
- Supports stdio and HTTP/SSE transports
- MIT licensed

This is the first MCP integration for the short-term rental / property management industry.