### PR TITLE
Add Pressonify MCP server (press releases + citation tracking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,6 +1221,7 @@ search, and comprehensive file analysis.
 - **[Powerdrill](https://github.com/powerdrillai/powerdrill-mcp)** - Interact with Powerdrill datasets, authenticated with [Powerdrill](https://powerdrill.ai) User ID and Project API Key.
 - **[predictive-maintenance-mcp](https://github.com/LGDiMaggio/predictive-maintenance-mcp)** - AI-powered predictive maintenance and fault diagnosis. Features vibration analysis, bearing diagnostics, ISO 20816-3. compliance, and ML anomaly detection for industrial machinery.
 - **[Prefect](https://github.com/allen-munsch/mcp-prefect)** - MCP Server for workflow orchestration and ELT/ETL with Prefect Server, and Prefect Cloud [https://www.prefect.io/] using the `prefect` python client.
+- **[Pressonify](https://pressonify.ai)** - Generate and publish AI-optimized press releases, then track citations across 10 AI platforms (ChatGPT, Perplexity, Claude, Gemini, SearchGPT, and more). Includes AI visibility scoring, citability analysis, and Shopify store AI-readiness audits. Remote SSE server with OAuth 2.0 + PKCE at `https://pressonify.ai/api/v1/mcp/sse`.
 - **[Producer Pal](https://github.com/adamjmurray/producer-pal)** - MCP server for controlling Ableton Live, embedded in a Max for Live device for easy drag and drop installation.
 - **[Productboard](https://github.com/kenjihikmatullah/productboard-mcp)** - Integrate the Productboard API into agentic workflows via MCP.
 - **[Prometheus](https://github.com/pab1it0/prometheus-mcp-server)** - Query and analyze Prometheus - open-source monitoring system.


### PR DESCRIPTION
Adds Pressonify to the Community Servers list (alphabetical position between Prefect and Producer Pal).

## Pressonify MCP Server

- **Server URL**: `https://pressonify.ai/api/v1/mcp/sse`
- **Transport**: Server-Sent Events (SSE) via FastMCP
- **Authentication**: OAuth 2.0 with PKCE (RFC-compliant, supports dynamic client registration)
- **Website**: https://pressonify.ai

## Tools Exposed (9)

AI-powered press release creation and citation tracking:

- `create_press_release` — Generate and publish press releases, returns a live URL
- `enhance_press_release` — Improve existing press release content
- `research_ai_queries` — Generate 20-30 AI search query variants for targeting
- `get_citation_stats` — Citation analytics across 10 AI platforms
- `check_ai_visibility` — AI discoverability score (0-100)
- `score_citability` — Content citability scoring
- `scan_for_citations` — Scan AI platforms for mentions
- `get_citation_report` — Comprehensive citation report with trends
- `audit_store_readiness` — Shopify store AI-readiness audit

## Use Case

Claude Desktop / Mobile users can publish AI-optimized press releases in ~15 seconds with a single natural language prompt. The tool generates structured content, extracts entities for an auto-generated wiki, and tracks citations across ChatGPT, Perplexity, Claude, Gemini, SearchGPT, DeepSeek, Jina, Bing Copilot, Meta AI, and You.com.

## Verified

- OAuth 2.0 flow end-to-end tested with Claude Desktop
- Live press releases successfully generated via MCP
- Live wiki pages auto-generated from press release entities

I acknowledge community servers are untested and used at the user's own risk, as stated in the section note.