### PR TITLE
Add OMEGA Memory to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,7 @@ search, and comprehensive file analysis.
 - **[Operative WebEvalAgent](https://github.com/Operative-Sh/web-eval-agent)** (by [Operative.sh](https://www.operative.sh)) - An MCP server to test, debug, and fix web applications autonomously.
 - **[OPNSense MCP](https://github.com/vespo92/OPNSenseMCP)** - MCP Server for OPNSense Firewall Management and API access
 - **[Optimade MCP](https://github.com/dianfengxiaobo/optimade-mcp-server)** - An MCP server conducts real-time material science data queries with the Optimade database (for example, elemental composition, crystal structure).
+- **[OMEGA Memory](https://github.com/omega-memory/omega-memory)** - Persistent semantic memory for AI agents. 95.4% on LongMemEval. Local-first with 17 MCP tools: semantic search, auto-capture, contradiction detection, checkpoint/resume, timeline queries. [Website](https://omegamax.co)
 - **[Oracle](https://github.com/marcelo-ochoa/servers)** (by marcelo-ochoa) - Oracle Database integration in NodeJS with configurable access controls, query explain, stats and schema inspection
 - **[Oracle Cloud Infrastructure (OCI)](https://github.com/karthiksuku/oci-mcp)** (by karthiksukumar) - Python MCP server for OCI infrastructure (Compute, Autonomous Database, Object Storage). Read-heavy by default with safe instance actions (start/stop/reset). Includes Claude Desktop config and `.env` compartment scoping.
 - **[Oura MCP server](https://github.com/tomekkorbak/oura-mcp-server)** - MCP server for Oura API to retrieve one's sleep data


### PR DESCRIPTION
Add OMEGA Memory, a persistent semantic memory server for AI agents.

- **Repo**: https://github.com/omega-memory/omega-memory
- **PyPI**: https://pypi.org/project/omega-memory/ (14K+ downloads)
- **LongMemEval**: 95.4% (ICLR 2025 benchmark)
- **Tools**: 17 MCP tools (semantic search, auto-capture, contradiction detection, checkpoint/resume, timeline)
- **Architecture**: Local-first, SQLite + ONNX embeddings, zero cloud dependencies
- **License**: Apache-2.0