### PR TITLE
Restructure community servers into various categories for more visibility and usability

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,30 @@
 
 To publish your server, follow the [quickstart guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx). You can browse published servers at [https://registry.modelcontextprotocol.io/](https://registry.modelcontextprotocol.io/).
 
+---
+
+## Adding to Community Servers (if applicable)
+
+If you're contributing to the [community-servers](../community-servers/) directory, please select the most appropriate category:
+
+- [ ] **AI & Agents** - AI agent frameworks, autonomous systems, and agent orchestration
+- [ ] **Analytics & Data** - Data analysis, business intelligence, data transformation, and reporting
+- [ ] **Blockchain & Web3** - Cryptocurrency, smart contracts, wallet interactions, and blockchain data
+- [ ] **Business & Productivity** - CRM, project management, task tracking, notes, and productivity tools
+- [ ] **Code & Development** - IDEs, code editors, testing tools, build systems, and language servers
+- [ ] **Communication & Messaging** - Email, SMS, chat, messaging platforms, and notifications
+- [ ] **Databases** - Database connectors (SQL, NoSQL), query builders, and database management
+- [ ] **Design & Media** - Image generation, video editing, design tools, and media file processing
+- [ ] **DevOps & Infrastructure** - Cloud platforms, containers, deployment, orchestration, and infrastructure
+- [ ] **Finance & Payments** - Stock data, trading, banking, payments, and financial analytics
+- [ ] **Integration & APIs** - API aggregators, API clients, and cross-platform integrations
+- [ ] **Search & Retrieval** - Web search, document search, RAG, and information retrieval
+- [ ] **Security & Compliance** - Security scanning, vulnerability detection, and compliance management
+- [ ] **Social & Content** - Social media APIs, blogging platforms, and content management systems
+- [ ] **Tools & Utilities** - General utilities, helpers, and miscellaneous tools
+
+---
+
 ## Server Details
 <!-- If modifying an existing server, provide details -->
 - Server: <!-- e.g., filesystem, github -->

--- a/README.md
+++ b/README.md
@@ -54,8 +54,31 @@ The following reference servers are now archived and can be found at [servers-ar
 
 ## 🤝 Third-Party Servers
 
+### 🌎 Community Servers
+
+We've reorganized community servers by category for easier discovery:
+
+📂 **Browse Community Servers by Category:**
+- [AI & Agents](community-servers/ai-agents/) - AI agent frameworks and agent orchestration
+- [Analytics & Data](community-servers/analytics-data/) - Data analysis and business intelligence
+- [Blockchain & Web3](community-servers/blockchain-web3/) - Cryptocurrency and blockchain
+- [Business & Productivity](community-servers/business-productivity/) - CRM, project management, and productivity
+- [Code & Development](community-servers/code-development/) - IDEs, testing, and development tools
+- [Communication & Messaging](community-servers/communication-messaging/) - Email, chat, and notifications
+- [Databases](community-servers/databases/) - Database connectors and query tools
+- [Design & Media](community-servers/design-media/) - Image generation, video, and design tools
+- [DevOps & Infrastructure](community-servers/devops-infrastructure/) - Cloud, containers, and deployment
+- [Finance & Payments](community-servers/finance-payments/) - Stock data, trading, and payments
+- [Integration & APIs](community-servers/integration-apis/) - API aggregators and integrations
+- [Search & Retrieval](community-servers/search-retrieval/) - Web search and information retrieval
+- [Security & Compliance](community-servers/security-compliance/) - Security scanning and compliance
+- [Social & Content](community-servers/social-content/) - Social media and content management
+- [Tools & Utilities](community-servers/tools-utilities/) - General utilities and misc tools
+
+👉 **[View All Community Servers](community-servers/)** organized by category
+
 > [!NOTE]
-The server lists in this README are no longer maintained and will eventually be removed.
+> Community servers are **untested** and should be used at **your own risk**. They are not affiliated with or endorsed by Anthropic.
 
 ### 🎖️ Official Integrations
 
@@ -567,14 +590,7 @@ Official integrations are maintained by companies building production ready MCP 
 - <img height="12" width="12" src="https://www.zine.ai/images/zine-logo.png" alt="Zine Logo" /> **[Zine](https://www.zine.ai)** - Your memory, everywhere AI goes. Think iPhoto for your knowledge - upload and curate. Like ChatGPT but portable - context that travels with you.
 - <img height="12" width="12" src="https://zizai.work/images/logo.jpg" alt="ZIZAI Logo" /> **[ZIZAI Recruitment](https://github.com/zaiwork/mcp)** - Interact with the next-generation intelligent recruitment platform for employees and employers, powered by [ZIZAI Recruitment](https://zizai.work).
 
-### 🌎 Community Servers
-
-A growing set of community-developed and maintained servers demonstrates various applications of MCP across different domains.
-
-> [!NOTE]
-> Community servers are **untested** and should be used at **your own risk**. They are not affiliated with or endorsed by Anthropic.
-
-- **[1mcpserver](https://github.com/particlefuture/1mcpserver)** - MCP of MCPs. Automatically discover, configure, and add MCP servers on your local machine.
+## 📚 Frameworks
 - **[1Panel](https://github.com/1Panel-dev/mcp-1panel)** - MCP server implementation that provides 1Panel interaction.
 - **[A2A](https://github.com/GongRzhe/A2A-MCP-Server)** - An MCP server that bridges the Model Context Protocol (MCP) with the Agent-to-Agent (A2A) protocol, enabling MCP-compatible AI assistants (like Claude) to seamlessly interact with A2A agents.
 - **[Ableton Live](https://github.com/Simon-Kansara/ableton-live-mcp-server)** - an MCP server to control Ableton Live.

--- a/community-servers/README.md
+++ b/community-servers/README.md
@@ -1,0 +1,33 @@
+# 🌎 Community Servers
+
+A growing set of community-developed and maintained servers demonstrates various applications of MCP across different domains.
+
+> [!NOTE]
+> Community servers are **untested** and should be used at **your own risk**. They are not affiliated with or endorsed by Anthropic.
+
+## Browse by Category
+
+Choose a category below to explore community-built MCP servers:
+
+- **[AI & Agents](ai-agents/)** - AI agent frameworks, autonomous systems, and agent orchestration
+- **[Analytics & Data](analytics-data/)** - Data analysis, business intelligence, and reporting tools
+- **[Blockchain & Web3](blockchain-web3/)** - Cryptocurrency, smart contracts, and blockchain interactions
+- **[Business & Productivity](business-productivity/)** - CRM, project management, task tracking, and productivity tools
+- **[Code & Development](code-development/)** - IDEs, code editors, testing, and development utilities
+- **[Communication & Messaging](communication-messaging/)** - Email, SMS, chat, and notification systems
+- **[Databases](databases/)** - Database connectors and query operations
+- **[Design & Media](design-media/)** - Image generation, video, design tools, and media management
+- **[DevOps & Infrastructure](devops-infrastructure/)** - Cloud platforms, deployment, and infrastructure management
+- **[Finance & Payments](finance-payments/)** - Financial data, trading, and payment processing
+- **[Integration & APIs](integration-apis/)** - API aggregation and integration platforms
+- **[Search & Retrieval](search-retrieval/)** - Web search, documentation, and information retrieval
+- **[Security & Compliance](security-compliance/)** - Security scanning, vulnerability management, and compliance
+- **[Social & Content](social-content/)** - Social media, blogging, and content management
+- **[Tools & Utilities](tools-utilities/)** - Miscellaneous tools and utility servers
+
+---
+
+## Quick Navigation
+
+- [Back to Main README](../README.md#-third-party-servers)
+- [Official Integrations](../README.md#-official-integrations)

--- a/community-servers/ai-agents/README.md
+++ b/community-servers/ai-agents/README.md
@@ -1,0 +1,26 @@
+# AI & Agents
+
+AI agent frameworks, autonomous systems, multi-agent collaboration, and agent orchestration platforms.
+
+## Servers in this category
+
+- **[1mcpserver](https://github.com/particlefuture/1mcpserver)** - MCP of MCPs. Automatically discover, configure, and add MCP servers on your local machine.
+- **[A2A](https://github.com/GongRzhe/A2A-MCP-Server)** - An MCP server that bridges the Model Context Protocol (MCP) with the Agent-to-Agent (A2A) protocol, enabling MCP-compatible AI assistants (like Claude) to seamlessly interact with A2A agents.
+- **[Agentic Framework](https://github.com/Piotr1215/mcp-agentic-framework)** - Multi-agent collaboration framework enabling AI agents to register, discover each other, exchange asynchronous messages via HTTP transport, and work together on complex tasks with persistent message history.
+- **[AgentMode](https://www.agentmode.app)** - Connect to dozens of databases, data warehouses, Github & more, from a single MCP server. Run the Docker image locally, in the cloud, or on-premise.
+- **[AI Agent Marketplace Index](https://github.com/AI-Agent-Hub/ai-agent-marketplace-index-mcp)** - MCP server to search more than 5000+ AI agents and tools of various categories from [AI Agent Marketplace Index](http://www.deepnlp.org/store/ai-agent) and monitor traffic of AI Agents.
+- **[Agent Interviews](https://github.com/thinkchainai/agentinterviews_mcp)** - Conduct AI-powered qualitative research interviews and surveys at scale with [Agent Interviews](https://agentinterviews.com).
+- **[AgentBay](https://github.com/Michael98671/agentbay)** - An MCP server for providing serverless cloud infrastructure for AI agents.
+- **[AX-Platform](https://github.com/AX-MCP/PaxAI?tab=readme-ov-file#mcp-setup-guides)** - AI Agent collaboration platform. Collaborate on tasks, share context, and coordinate workflows.
+- **[Actor Critic Thinking](https://github.com/aquarius-wing/actor-critic-thinking-mcp)** - Actor-critic thinking for performance evaluation
+- **[Mandoline](https://github.com/mandoline-ai/mandoline-mcp-server)** - Enable AI assistants to reflect on, critique, and continuously improve their own performance using Mandoline's evaluation framework.
+- **[Think MCP](https://github.com/Rai220/think-mcp)** - Enhances any agent's reasoning capabilities by integrating the think-tools, as described in [Anthropic's article](https://www.anthropic.com/engineering/claude-think-tool).
+- **[Think Node MCP](https://github.com/abhinav-mangla/think-tool-mcp)** - Enhances any agent's reasoning capabilities by integrating the think-tools, as described in [Anthropic's article](https://www.anthropic.com/engineering/claude-think-tool). (Works with Node)
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: None](../README.md)
+- [Next: Analytics & Data →](../analytics-data/README.md)

--- a/community-servers/analytics-data/README.md
+++ b/community-servers/analytics-data/README.md
@@ -1,0 +1,15 @@
+# Analytics & Data
+
+Data analysis, business intelligence, data transformation, reporting tools, and analytical platforms.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: AI & Agents](../ai-agents/README.md)
+- [Next: Blockchain & Web3 →](../blockchain-web3/README.md)

--- a/community-servers/blockchain-web3/README.md
+++ b/community-servers/blockchain-web3/README.md
@@ -1,0 +1,15 @@
+# Blockchain & Web3
+
+Cryptocurrency, smart contracts, wallet interactions, decentralized finance (DeFi), and blockchain data access.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Analytics & Data](../analytics-data/README.md)
+- [Next: Business & Productivity →](../business-productivity/README.md)

--- a/community-servers/business-productivity/README.md
+++ b/community-servers/business-productivity/README.md
@@ -1,0 +1,15 @@
+# Business & Productivity
+
+CRM systems, project management, task tracking, note-taking, and productivity tools.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Blockchain & Web3](../blockchain-web3/README.md)
+- [Next: Code & Development →](../code-development/README.md)

--- a/community-servers/code-development/README.md
+++ b/community-servers/code-development/README.md
@@ -1,0 +1,15 @@
+# Code & Development
+
+IDEs, code editors, testing frameworks, build systems, language servers, and development utilities.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Business & Productivity](../business-productivity/README.md)
+- [Next: Communication & Messaging →](../communication-messaging/README.md)

--- a/community-servers/communication-messaging/README.md
+++ b/community-servers/communication-messaging/README.md
@@ -1,0 +1,15 @@
+# Communication & Messaging
+
+Email, SMS, chat platforms, messaging services, and notification systems.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Code & Development](../code-development/README.md)
+- [Next: Databases →](../databases/README.md)

--- a/community-servers/databases/README.md
+++ b/community-servers/databases/README.md
@@ -1,0 +1,15 @@
+# Databases
+
+Database connectors, query builders, schema explorers, and database management tools.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Communication & Messaging](../communication-messaging/README.md)
+- [Next: Design & Media →](../design-media/README.md)

--- a/community-servers/design-media/README.md
+++ b/community-servers/design-media/README.md
@@ -1,0 +1,15 @@
+# Design & Media
+
+Image generation, video editing, design tools, media file processing, and creative automation.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Databases](../databases/README.md)
+- [Next: DevOps & Infrastructure →](../devops-infrastructure/README.md)

--- a/community-servers/devops-infrastructure/README.md
+++ b/community-servers/devops-infrastructure/README.md
@@ -1,0 +1,15 @@
+# DevOps & Infrastructure
+
+Cloud platforms, container orchestration, deployment automation, infrastructure management, and monitoring.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Design & Media](../design-media/README.md)
+- [Next: Finance & Payments →](../finance-payments/README.md)

--- a/community-servers/finance-payments/README.md
+++ b/community-servers/finance-payments/README.md
@@ -1,0 +1,15 @@
+# Finance & Payments
+
+Stock data, trading platforms, banking services, payment processing, and financial analytics.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: DevOps & Infrastructure](../devops-infrastructure/README.md)
+- [Next: Integration & APIs →](../integration-apis/README.md)

--- a/community-servers/integration-apis/README.md
+++ b/community-servers/integration-apis/README.md
@@ -1,0 +1,15 @@
+# Integration & APIs
+
+API aggregators, universal API clients, multi-service integrations, and integration platforms.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Finance & Payments](../finance-payments/README.md)
+- [Next: Search & Retrieval →](../search-retrieval/README.md)

--- a/community-servers/search-retrieval/README.md
+++ b/community-servers/search-retrieval/README.md
@@ -1,0 +1,15 @@
+# Search & Retrieval
+
+Web search, document search, RAG systems, information retrieval, and knowledge bases.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Integration & APIs](../integration-apis/README.md)
+- [Next: Security & Compliance →](../security-compliance/README.md)

--- a/community-servers/security-compliance/README.md
+++ b/community-servers/security-compliance/README.md
@@ -1,0 +1,15 @@
+# Security & Compliance
+
+Security scanning, vulnerability detection, compliance management, and threat intelligence.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Search & Retrieval](../search-retrieval/README.md)
+- [Next: Social & Content →](../social-content/README.md)

--- a/community-servers/social-content/README.md
+++ b/community-servers/social-content/README.md
@@ -1,0 +1,15 @@
+# Social & Content
+
+Social media APIs, blogging platforms, content management systems, and social network integrations.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Security & Compliance](../security-compliance/README.md)
+- [Next: Tools & Utilities →](../tools-utilities/README.md)

--- a/community-servers/tools-utilities/README.md
+++ b/community-servers/tools-utilities/README.md
@@ -1,0 +1,15 @@
+# Tools & Utilities
+
+General utilities, miscellaneous tools, helpers, and servers that don't fit other categories.
+
+## Servers in this category
+
+*Category server list to be populated with community contributions.*
+
+---
+
+## Category Navigation
+
+- [🌎 All Categories](../README.md)
+- [← Previous: Social & Content](../social-content/README.md)
+- [Next: None](../README.md)


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description
I restructured the readme section with community servers into various sub-readme files to add some structure to the list and have categories. I know its technically not maintained anymore but this should still be useful. 

