### PR TITLE
fix: add tool annotations to server-fetch

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -14,6 +14,7 @@ from mcp.types import (
     PromptMessage,
     TextContent,
     Tool,
+    ToolAnnotations,
     INVALID_PARAMS,
     INTERNAL_ERROR,
 )
@@ -203,6 +204,12 @@ async def serve(
 
 Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.""",
                 inputSchema=Fetch.model_json_schema(),
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
             )
         ]
 


### PR DESCRIPTION
This PR adds missing tool annotations (readOnlyHint, idempotentHint, openWorldHint) to the fetch tool in @modelcontextprotocol/server-fetch. This follows the pattern in other reference servers and provides better metadata for MCP clients. Fixes #3572.