### PR TITLE
Add SUMA Memory — persistent semantic knowledge graph MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,7 @@ search, and comprehensive file analysis.
 - **[Strava API](https://github.com/tomekkorbak/strava-mcp-server)** - MCP server for Strava API to retrieve one's activities
 - **[Stripe](https://github.com/atharvagupta2003/mcp-stripe)** - This MCP allows integration with Stripe for handling payments, customers, and refunds.
 - **[Substack/Medium](https://github.com/jonathan-politzki/mcp-writer-substack)** - Connect Claude to your Substack/Medium writing, enabling semantic search and analysis of your published content.
+- **[SUMA Memory](https://github.com/sumanaddanki/suma-mcp-proxy)** ([npm](https://www.npmjs.com/package/suma-mcp-proxy)) - Persistent semantic knowledge graph for AI assistants. K-WIL Gravity Well Algorithm retrieves the exact context tokens Claude needs from unlimited history — no hallucination, no context window overflow. Supports Claude Code, Cursor, Windsurf. One command install: `npx suma-mcp-proxy --key=YOUR_KEY`
 - **[System Health](https://github.com/thanhtung0201/mcp-remote-system-health)** - The MCP (Multi-Channel Protocol) System Health Monitoring is a robust, real-time monitoring solution designed to provide comprehensive health metrics and alerts for remote Linux servers.
 - **[SystemSage](https://github.com/Tarusharma1/SystemSage)** - A powerful, cross-platform system management and monitoring tool for Windows, Linux, and macOS.
 - **[Talk To Figma](https://github.com/sonnylazuardi/cursor-talk-to-figma-mcp)** - This MCP server enables LLMs to interact with Figma, allowing them to read and modify designs programmatically.


### PR DESCRIPTION
## Summary

**SUMA Memory** is a persistent semantic knowledge graph for AI assistants, distributed as an npm package (`suma-mcp-proxy`).

### What it does

- Gives Claude (and other MCP-compatible AI) **permanent, searchable memory** that survives session boundaries
- Uses the **K-WIL Gravity Well Algorithm** — a retrieval system that scores nodes by Recency × Harmonic Weight × Semantic Similarity × Persona Profile
- At 180K+ tokens of stored knowledge, a single `suma_search` retrieves the exact 800 tokens the AI needs — no hallucination, no context window overflow
- Supports **Claude Code, Cursor, Windsurf** via `.mcp.json`

### Why K-WIL vs standard RAG

Standard RAG does cosine similarity ranking. K-WIL adds:
- **Recency decay** — recent facts rank higher than stale ones
- **Harmonic weight** — well-connected entities rank higher (log-flattened to prevent black holes)
- **Persona profiles** — per-industry weight adjustments (developer, enterprise, healthcare, government)

Result: retrieval precision, not just recall.

### Install

One-line setup — no global install required:
```json
{
  "mcpServers": {
    "suma-memory": {
      "command": "npx",
      "args": ["suma-mcp-proxy", "--key=sk_live_YOUR_KEY"]
    }
  }
}
```

### Links

- **npm:** https://www.npmjs.com/package/suma-mcp-proxy (v1.3.4)
- **Source:** https://github.com/sumanaddanki/suma-mcp-proxy
- **Dashboard:** https://sumapro.quadframe.work

### Tools exposed

| Tool | Description |
|------|-------------|
| `suma_ping` | Verify connection + confirm org_id |
| `suma_ingest` | Store knowledge (auto entity extraction + embedding) |
| `suma_search` | K-WIL ranked retrieval + synthesized answer |
| `suma_talk` | Bidirectional — search AND learn in one call |
| `suma_correct` | Fix an incorrect node (soft delete, audit trail) |
| `suma_clean` | Wipe all data for your org |

### Checklist

- [x] Package published on npm: `suma-mcp-proxy@1.3.4`
- [x] Source repo is public: `github.com/sumanaddanki/suma-mcp-proxy`
- [x] Server tested with MCP Inspector (`npx @modelcontextprotocol/inspector`)
- [x] Missing API key returns readable error (does not crash)
- [x] JSON Schema uses `additionalProperties: false`
- [x] Works with Claude Code, Cursor, Windsurf