### PR TITLE
Add Spring AI Playground to the Frameworks For Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1491,6 +1491,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 - **[R mcptools](https://github.com/posit-dev/mcptools)** - An R SDK for creating R-based MCP servers and retrieving functionality from third-party MCP servers as R functions.
 * **[SAP ABAP MCP Server SDK](https://github.com/abap-ai/mcp)** - Build SAP ABAP based MCP servers. ABAP 7.52 based with 7.02 downport; runs on R/3 & S/4HANA on-premises, currently not cloud-ready.
 * **[Spring AI MCP Server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html)** - Provides auto-configuration for setting up an MCP server in Spring Boot applications.
+* **[Spring AI Playground](https://github.com/spring-ai-community/spring-ai-playground)** - Cross-platform, low-code desktop app for building MCP tools visually and serving them as a live MCP server. Works with any MCP-compatible host.
 * **[Template MCP Server](https://github.com/mcpdotdirect/template-mcp-server)** - A CLI tool to create a new Model Context Protocol server project with TypeScript support, dual transport options, and an extensible structure
 * **[AgentR Universal MCP SDK](https://github.com/universal-mcp/universal-mcp)** - A python SDK to build MCP Servers with inbuilt credential management by **[Agentr](https://agentr.dev/home)**
 * **[Vercel MCP Adapter](https://github.com/vercel/mcp-adapter)** (TypeScript) - A simple package to start serving an MCP server on most major JS meta-frameworks including Next, Nuxt, Svelte, and more.


### PR DESCRIPTION
## Description

Adds Spring AI Playground to the Frameworks section (not a server addition).

## Motivation and Context

Spring AI Playground is a cross-platform, low-code desktop app for building 
MCP tools visually and serving them as a live MCP server. It fits the Frameworks 
section as a tool that helps developers build and expose MCP-compatible servers 
without requiring Java knowledge or backend setup.

Key features:
- Visual, low-code MCP tool builder via Tool Studio
- Built-in live MCP server — tools are immediately exposed to any MCP-compatible host
- Cross-platform desktop app (macOS, Windows, Linux) with bundled runtime
- Agentic Chat, RAG/Vector DB support built-in
- Works with Claude Desktop, Claude Code, Cursor, and any MCP-compatible host
- Sub-millisecond MCP latency (verified by third-party benchmark)
- Part of the spring-ai-community GitHub organization, built on Spring AI

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the MCP Protocol Documentation
- [x] I have updated the server's README accordingly

## Additional context

- GitHub: https://github.com/spring-ai-community/spring-ai-playground
- Docs: https://spring-ai-community.github.io/spring-ai-playground/
- License: Apache-2.0