### PR TITLE
fix(release): include all file changes in version bump detection

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -112,9 +112,8 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
             text=True,
         )
 
-        changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
-        return len(relevant_files) >= 1
+        changed_files = output.stdout.splitlines()
+        return len(changed_files) >= 1
     except subprocess.CalledProcessError:
         return False
 


### PR DESCRIPTION
## Summary

- Remove the `.py`/`.ts` suffix filter from `has_changes()` in `scripts/release.py` so that **all** file changes within a package directory trigger a version bump
- Previously, lockfile-only changes (e.g. `uv.lock` from Dependabot) were silently skipped, leaving stale versions in `pyproject.toml`

Fixes #3870

## Problem

`has_changes()` filtered changed files to only `.py` and `.ts` suffixes:

```python
relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
```

This caused packages with only lockfile changes between tags to retain stale versions. Downstream consumers (SBOM generators, CVE scanners) rely on the version in `pyproject.toml` to match the CalVer release tag.

## Change

Any change within a package directory now counts as a relevant change, removing the suffix filter entirely.

## AI Disclosure

AI assistance (Claude) was used for issue research. The implementation was written and reviewed by the author.