### PR TITLE
fix(memory): resolve Vitest false positive for expected rejection

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -146,11 +146,11 @@ describe('KnowledgeGraphManager', () => {
     });
 
     it('should throw error for non-existent entity', async () => {
-      await expect(
-        manager.addObservations([
+      await expect(async () => {
+        await manager.addObservations([
           { entityName: 'NonExistent', contents: ['some observation'] },
-        ])
-      ).rejects.toThrow('Entity with name NonExistent not found');
+        ]);
+      }).rejects.toThrow('Entity with name NonExistent not found');
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix Vitest reporting a false-positive "Unhandled Errors" warning for the "should throw error for non-existent entity" test in the memory server
- Wrap the `addObservations` call in an async closure before asserting with `.rejects.toThrow()`, so Vitest's global unhandled rejection handler does not capture the expected error before the assertion intercepts it

Fixes #3073

## Root cause

`addObservations` is an async function that throws synchronously inside a `.map()` callback. When passed directly to `expect().rejects.toThrow()`, the resulting Promise rejection is seen by Vitest's global rejection handler before the `.rejects` wrapper can intercept it. Wrapping in `async () => { await ... }` ensures the rejection is properly scoped.

## Changes

- `src/memory/__tests__/knowledge-graph.test.ts`: Wrap the assertion in an async closure

## Test plan

- [x] All 45 memory server tests pass (`npx vitest run`)
- [x] No "Unhandled Errors" warning in test output

## AI Disclosure

AI assistance (Claude) was used for issue research. The implementation was written and reviewed by the author.