### PR TITLE
fix(fetch): fall back to raw HTML conversion when Readability returns empty content

### DIFF
--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated, Tuple
 from urllib.parse import urlparse, urlunparse
 
@@ -23,9 +24,44 @@ from pydantic import BaseModel, Field, AnyUrl
 DEFAULT_USER_AGENT_AUTONOMOUS = "ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)"
 DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://github.com/modelcontextprotocol/servers)"
 
+# Minimum character threshold for Readability output to be considered useful.
+# Pages rendered by SSR frameworks (Next.js, Remix) often produce very short or
+# empty Readability output because their content lives in <script> hydration
+# payloads or elements marked display:none.  When the extracted text falls below
+# this threshold we fall back to a direct HTML→Markdown conversion of the raw
+# page so that callers still receive meaningful content.
+_READABILITY_MIN_CONTENT_LENGTH = 200
+
+# Tags whose content adds no value when doing the raw-HTML fallback conversion.
+_STRIP_TAGS_RE = re.compile(
+    r"<(script|style|nav|footer|header|noscript)[\s>].*?</\1>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _html_to_markdown_fallback(html: str) -> str:
+    """Convert raw HTML to Markdown after stripping noise tags.
+
+    Used as a fallback when Readability fails to extract meaningful content.
+
+    Args:
+        html: Raw HTML content.
+
+    Returns:
+        Plain Markdown text derived directly from the HTML structure.
+    """
+    cleaned = _STRIP_TAGS_RE.sub("", html)
+    return markdownify.markdownify(cleaned, heading_style=markdownify.ATX)
+
 
 def extract_content_from_html(html: str) -> str:
     """Extract and convert HTML content to Markdown format.
+
+    First attempts extraction via Mozilla Readability (via readabilipy).  If
+    Readability returns empty or very short content — which happens on SSR
+    pages built with Next.js or Remix that rely on client-side hydration — the
+    function falls back to a direct HTML→Markdown conversion of the raw page
+    so that meaningful content is always returned.
 
     Args:
         html: Raw HTML content to process
@@ -36,13 +72,25 @@ def extract_content_from_html(html: str) -> str:
     ret = readabilipy.simple_json.simple_json_from_html_string(
         html, use_readability=True
     )
-    if not ret["content"]:
-        return "<error>Page failed to be simplified from HTML</error>"
-    content = markdownify.markdownify(
-        ret["content"],
+
+    readability_content = ret.get("content") or ""
+    readability_text = markdownify.markdownify(
+        readability_content,
         heading_style=markdownify.ATX,
-    )
-    return content
+    ).strip() if readability_content else ""
+
+    # If Readability produced meaningful content, use it.
+    if len(readability_text) >= _READABILITY_MIN_CONTENT_LENGTH:
+        return readability_text
+
+    # Readability returned empty or minimal content (common for SSR pages that
+    # rely on JavaScript hydration).  Fall back to converting the raw HTML
+    # directly so the caller still receives usable content.
+    fallback = _html_to_markdown_fallback(html).strip()
+    if fallback:
+        return fallback
+
+    return "<error>Page failed to be simplified from HTML</error>"
 
 
 def get_robots_txt_url(url: str) -> str:

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -10,6 +10,7 @@ from mcp_server_fetch.server import (
     check_may_autonomously_fetch_url,
     fetch_url,
     DEFAULT_USER_AGENT_AUTONOMOUS,
+    _READABILITY_MIN_CONTENT_LENGTH,
 )
 
 
@@ -86,6 +87,78 @@ class TestExtractContentFromHtml:
         html = ""
         result = extract_content_from_html(html)
         assert "<error>" in result
+
+    def test_ssr_page_falls_back_to_raw_html_conversion(self):
+        """Test that SSR pages with thin Readability output fall back to raw HTML.
+
+        SSR frameworks (Next.js, Remix) often render their primary content
+        inside <script> hydration payloads or hidden elements.  Readability
+        strips those out and returns minimal text.  The fallback must recover
+        content that is visible in the raw HTML tags (e.g. <main>, <p>).
+        """
+        # Simulate an SSR page: the only "real" content is inside a <main> tag
+        # but Readability won't find enough to exceed the threshold because there
+        # is no proper article structure.  The raw-HTML fallback should still
+        # surface the visible text.
+        main_text = "A" * (_READABILITY_MIN_CONTENT_LENGTH + 50)
+        html = f"""
+        <html>
+        <head><title>SSR App</title></head>
+        <body>
+            <main id="__next">
+                <p>{main_text}</p>
+            </main>
+            <script>window.__NEXT_DATA__ = {{"props": {{}}}}</script>
+        </body>
+        </html>
+        """
+
+        with patch("readabilipy.simple_json.simple_json_from_html_string") as mock_readability:
+            # Readability returns near-empty content (typical for SSR pages)
+            mock_readability.return_value = {"content": "<p>A</p>", "title": "SSR App"}
+
+            result = extract_content_from_html(html)
+
+        # The fallback conversion must include the text from the <main> block
+        assert main_text in result
+        assert "<error>" not in result
+
+    def test_readability_content_used_when_sufficient(self):
+        """Test that Readability output is used when it exceeds the threshold."""
+        rich_content = "<p>" + "Word " * 60 + "</p>"  # well above 200 chars
+
+        with patch("readabilipy.simple_json.simple_json_from_html_string") as mock_readability:
+            mock_readability.return_value = {"content": rich_content, "title": "Good Page"}
+
+            result = extract_content_from_html("<html><body></body></html>")
+
+        # Readability result should be used as-is (converted to markdown)
+        assert "Word" in result
+        assert "<error>" not in result
+
+    def test_script_and_style_tags_stripped_in_fallback(self):
+        """Test that <script> and <style> content is removed during fallback."""
+        visible_text = "B" * (_READABILITY_MIN_CONTENT_LENGTH + 50)
+        html = f"""
+        <html>
+        <head>
+            <style>body {{ color: red; }}</style>
+        </head>
+        <body>
+            <p>{visible_text}</p>
+            <script>var x = 1;</script>
+        </body>
+        </html>
+        """
+
+        with patch("readabilipy.simple_json.simple_json_from_html_string") as mock_readability:
+            mock_readability.return_value = {"content": None, "title": ""}
+
+            result = extract_content_from_html(html)
+
+        assert "color: red" not in result
+        assert "var x" not in result
+        assert visible_text in result
 
 
 class TestCheckMayAutonomouslyFetchUrl:


### PR DESCRIPTION
Fixes #3878

Pages rendered by SSR frameworks (Next.js, Remix) often produce empty or near-empty Readability output because their primary content lives in `<script>` hydration payloads or elements that Readability strips out. This causes the fetch server to return an unhelpful `<error>Page failed to be simplified from HTML</error>` response even when the raw HTML contains plenty of readable content.

**Fix:** After running Readability, check the length of the extracted text. If it falls below a configurable threshold (`_READABILITY_MIN_CONTENT_LENGTH = 200` chars), fall back to converting the raw HTML directly with `markdownify` after stripping noise tags (`<script>`, `<style>`, `<nav>`, `<footer>`, `<header>`, `<noscript>`).

**Changes:**
- `server.py`: Added `_html_to_markdown_fallback()` helper and updated `extract_content_from_html()` to use it when Readability returns insufficient content
- `test_server.py`: Added three test cases covering the SSR fallback path, Readability success path (regression guard), and script/style tag stripping

Normal pages with well-structured HTML continue to use Readability as before.