### PR TITLE
feat(everything): add URL elicitation example (SEP-1036)

### DIFF
--- a/src/everything/tools/index.ts
+++ b/src/everything/tools/index.ts
@@ -16,6 +16,7 @@ import { registerTriggerLongRunningOperationTool } from "./trigger-long-running-
 import { registerTriggerSamplingRequestTool } from "./trigger-sampling-request.js";
 import { registerTriggerSamplingRequestAsyncTool } from "./trigger-sampling-request-async.js";
 import { registerTriggerElicitationRequestAsyncTool } from "./trigger-elicitation-request-async.js";
+import { registerTriggerUrlElicitationRequestTool } from "./trigger-url-elicitation-request.js";
 import { registerSimulateResearchQueryTool } from "./simulate-research-query.js";
 
 /**
@@ -50,4 +51,5 @@ export const registerConditionalTools = (server: McpServer) => {
   // Bidirectional task tools - server sends requests that client executes as tasks
   registerTriggerSamplingRequestAsyncTool(server);
   registerTriggerElicitationRequestAsyncTool(server);
+  registerTriggerUrlElicitationRequestTool(server);
 };

--- a/src/everything/tools/trigger-url-elicitation-request.ts
+++ b/src/everything/tools/trigger-url-elicitation-request.ts
@@ -1,0 +1,92 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ElicitResultSchema,
+  CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// Tool configuration
+const name = "trigger-url-elicitation-request";
+const config = {
+  title: "Trigger URL Elicitation Request Tool",
+  description:
+    "Trigger a URL elicitation request (SEP-1036) that asks the client to " +
+    "navigate the user to an external URL for out-of-band interaction, such " +
+    "as OAuth authorization or payment flows.",
+  inputSchema: {},
+};
+
+/**
+ * Registers the 'trigger-url-elicitation-request' tool.
+ *
+ * This tool demonstrates SEP-1036 URL Elicitation, where the server requests
+ * the client to open an external URL for the user. This is used for flows
+ * where sensitive data (credentials, payment info) must not transit through
+ * the MCP client, such as third-party OAuth authorization.
+ *
+ * The client responds with accept (user consented to navigate), decline,
+ * or cancel. The actual interaction happens out-of-band in the browser.
+ *
+ * Requires the client to declare `elicitation.url` capability.
+ *
+ * @param {McpServer} server - The McpServer instance where the tool will be registered.
+ */
+export const registerTriggerUrlElicitationRequestTool = (
+  server: McpServer
+) => {
+  const clientCapabilities = server.server.getClientCapabilities() || {};
+  const elicitationCapability = clientCapabilities.elicitation as
+    | { url?: object }
+    | undefined;
+  const clientSupportsUrlElicitation = elicitationCapability?.url !== undefined;
+
+  if (clientSupportsUrlElicitation) {
+    server.registerTool(
+      name,
+      config,
+      async (args, extra): Promise<CallToolResult> => {
+        const elicitationId = crypto.randomUUID();
+        const elicitationResult = await extra.sendRequest(
+          {
+            method: "elicitation/create",
+            params: {
+              mode: "url",
+              elicitationId,
+              message:
+                "Please authorize access to your GitHub repositories. " +
+                "You will be redirected to GitHub to complete the authorization.",
+              url: "https://github.com/login/oauth/authorize?client_id=EXAMPLE_CLIENT_ID&scope=repo&state=example-state",
+            },
+          },
+          ElicitResultSchema,
+          { timeout: 10 * 60 * 1000 /* 10 minutes */ }
+        );
+
+        const content: CallToolResult["content"] = [];
+
+        if (elicitationResult.action === "accept") {
+          content.push({
+            type: "text",
+            text: "✅ User accepted the URL elicitation request and was directed to the external URL.",
+          });
+        } else if (elicitationResult.action === "decline") {
+          content.push({
+            type: "text",
+            text: "❌ User declined to navigate to the external URL.",
+          });
+        } else if (elicitationResult.action === "cancel") {
+          content.push({
+            type: "text",
+            text: "⚠️ User cancelled the URL elicitation dialog.",
+          });
+        }
+
+        content.push({
+          type: "text",
+          text: `\nRaw result: ${JSON.stringify(elicitationResult, null, 2)}`,
+        });
+
+        return { content };
+      }
+    );
+  }
+};


### PR DESCRIPTION
## Summary

Add a `trigger-url-elicitation-request` tool to the Everything server that demonstrates SEP-1036 URL Elicitation — the new `url` mode for secure out-of-band interactions.

Closes #3034

## What is URL Elicitation?

SEP-1036 extends MCP elicitation with a `url` mode for scenarios where sensitive data (credentials, payment info) must not transit through the MCP client:
- Third-party OAuth authorisation flows
- Payment/subscription flows (PCI compliance)
- Sensitive credential collection

The server sends `elicitation/create` with `mode: "url"`, and the client navigates the user to the specified URL. The actual interaction happens out-of-band in the browser.

## Changes

- `src/everything/tools/trigger-url-elicitation-request.ts`: New tool that sends a URL elicitation request with an example GitHub OAuth URL
- `src/everything/tools/index.ts`: Register the tool in `registerConditionalTools` (only when client declares `elicitation.url` capability)

## Design

Follows the same pattern as the existing `trigger-elicitation-request` tool:
- Conditionally registered based on client capabilities (`elicitation.url`)
- Handles all three response actions (accept, decline, cancel)
- Includes raw result for debugging
- Uses `ElicitResultSchema` for response validation

## Test plan

- [x] TypeScript compiles (`npx tsc --noEmit`)
- [x] All 95 existing Everything server tests pass (`npx vitest run`)

## AI Disclosure

AI assistance (Claude) was used for issue research and understanding SEP-1036. The implementation was written and reviewed by the author.