### PR TITLE
Add RemembrallMCP to community servers - persistent memory and code graph for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[RedNote MCP](https://github.com/ifuryst/rednote-mcp)** - MCP server for accessing RedNote(XiaoHongShu, xhs) content
 - **[Reed Jobs](https://github.com/kld3v/reed_jobs_mcp)** - Search and retrieve job listings from Reed.co.uk.
 - **[Rememberizer AI](https://github.com/skydeckai/mcp-server-rememberizer)** - An MCP server designed for interacting with the Rememberizer data source, facilitating enhanced knowledge retrieval.
+- **[RemembrallMCP](https://github.com/cdnsteve/remembrallmcp)** - Persistent knowledge memory layer for AI agents. Hybrid semantic + full-text search backed by Postgres/pgvector, code dependency graph with blast-radius impact analysis, incremental indexing for Python, TypeScript, Rust, Go, Java, Ruby, and Kotlin. In-process ONNX embeddings - no external API required.
 - **[Replicate](https://github.com/deepfates/mcp-replicate)** - Search, run and manage machine learning models on Replicate through a simple tool-based interface. Browse models, create predictions, track their status, and handle generated images.
 - **[Resend](https://github.com/Klavis-AI/klavis/tree/main/mcp_servers/resend)** - Send email using Resend services
 - **[Revit MCP](https://github.com/revit-mcp)** - A service implementing the MCP protocol for Autodesk Revit.


### PR DESCRIPTION
## Summary

Adds RemembrallMCP to the Community Servers section.

**Repository:** https://github.com/cdnsteve/remembrallmcp

## What it does

RemembrallMCP is a self-hosted MCP server providing persistent memory and code graph capabilities for AI agents.

**Memory tools:**
- `remembrall_store` - store decisions, patterns, knowledge with tags and scope
- `remembrall_recall` - hybrid semantic + full-text search across stored memories
- `remembrall_update` / `remembrall_delete` - maintain memory accuracy over time
- `remembrall_ingest_github` - bulk import merged PRs from a GitHub repo
- `remembrall_ingest_docs` - ingest markdown files from a project directory

**Code graph tools:**
- `remembrall_index` - build a dependency graph from a project directory (7 languages)
- `remembrall_impact` - blast-radius analysis: what breaks if this symbol changes
- `remembrall_lookup_symbol` - find where a function or class is defined

**Implementation:**
- Written in Rust
- Postgres + pgvector backend (Docker provided)
- In-process ONNX embeddings via fastembed - no external embedding API needed
- Supports Python, TypeScript, Rust, Go, Java, Ruby, Kotlin

## Checklist

- [x] Server is functional and publicly available
- [x] Entry follows the formatting of existing community server entries
- [x] Description is factual and accurate