### PR TITLE
docs: add independent trust assessment resource for MCP server security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1640,6 +1640,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributing to thi
 
 See [SECURITY.md](SECURITY.md) for reporting security vulnerabilities.
 
+### Independent Trust Assessment
+
+Before connecting an MCP server to your AI agent in production, consider evaluating its trust and safety posture. MCP servers can have write access to critical systems (databases, payments, cloud infrastructure) and should be assessed for input validation, permission scope, data sensitivity, and rollback capability.
+
+An independent trust assessment of MCP servers listed in this repository is available at [trustmodel.ai/mcp-servers](https://trustmodel.ai/mcp-servers) — covering tool safety, authentication, rate limiting, and 7 additional security dimensions.
+
 ## 📜 License
 
 This project is licensed under the Apache License, Version 2.0 for new contributions, with existing code under MIT - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Adds a brief note under the existing Security section pointing developers to an independent trust assessment resource for MCP servers before production deployment.

## Why

MCP servers often have write access to critical systems (databases, payments, cloud infrastructure, email). Developers connecting these to AI agents in production should evaluate:

- Input validation (SQL injection, path traversal via tool arguments)
- Permission scope (read-only vs. full access)
- Rate limiting (can a runaway agent exhaust resources?)
- Audit trail (are tool calls logged?)
- Rollback capability (can destructive operations be undone?)

This adds a single paragraph with a link to an independent assessment covering 10 security dimensions for 91 servers from this list.

## Change

6 lines added under `## 🔒 Security` — a subheading and brief description with link.

No changes to server code, configurations, or the server listing itself.