### PR TITLE
Add mdshare — Markdown collaboration for AI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,7 @@ search, and comprehensive file analysis.
 - **[MCPJungle](https://github.com/mcpjungle/MCPJungle)** - Self-hosted MCP Registry and Gateway for enterprise AI Agents
 - **[MCPShell](https://github.com/inercia/mcpshell)** - Tool that allows LLMs to safely execute command-line tools, providing a secure bridge between LLMs and operating system commands.
 - **[Md2doc](https://github.com/Yorick-Ryu/md2doc-mcp)** - Convert Markdown text to DOCX format using an external conversion service
+- **[mdshare](https://github.com/urbanmorph/mdshare)** - Free markdown collaboration for AI workflows. Share markdown via public links with four permission levels (admin, edit, comment, view), inline comments anchored to text, real-time WebSocket sync, and version history. `npx mdshare-mcp` lets AI agents read docs, review comments, incorporate feedback, and resolve threads — the full review loop without copy-pasting between tools.
 - **[MeasureSpace MCP](https://github.com/MeasureSpace/measure-space-mcp-server)** - A free [Model Context Protocol (MCP) Server](https://smithery.ai/server/@MeasureSpace/measure-space-mcp-server) that provides global weather, climate, air quality forecast and geocoding services by [measurespace.io](https://measurespace.io).
 - **[MediaWiki](https://github.com/ProfessionalWiki/MediaWiki-MCP-Server)** - A Model Context Protocol (MCP) Server that interacts with any MediaWiki wiki
 - **[MediaWiki MCP adapter](https://github.com/lucamauri/MediaWiki-MCP-adapter)** - A custom Model Context Protocol adapter for MediaWiki and WikiBase APIs


### PR DESCRIPTION
## Summary

Adds [mdshare](https://github.com/urbanmorph/mdshare) to the Community Servers section.

mdshare is a free, no-login markdown collaboration tool built for AI workflows. Users share markdown via public links with four permission levels (admin, edit, comment, view), inline comments anchored to text, and real-time WebSocket sync. The MCP server (`npx mdshare-mcp`) gives AI agents the full review loop — read documents, review comments, incorporate feedback, and resolve threads — without copy-pasting between tools.

## Links

- **App:** https://mdshare.live
- **GitHub:** https://github.com/urbanmorph/mdshare
- **npm:** https://www.npmjs.com/package/mdshare-mcp (v1.3.0)
- **MCP Registry:** `io.github.sathya-sankaran/mdshare` (published via `mcp-publisher publish` — [registry entry](https://registry.modelcontextprotocol.io/v0/servers?search=mdshare))
- **Docs:** https://mdshare.live/docs

## Placement

Inserted alphabetically between `Md2doc` and `MeasureSpace MCP` in the Community Servers M-section.

## Notes

- MIT licensed, open source
- Runs on Cloudflare Workers free tier
- Also ships as VS Code extension and Obsidian plugin (both already in their respective marketplaces)
- MCP server works with Claude, ChatGPT/Codex, Gemini CLI, Cursor, and Windsurf
