### PR TITLE
feat: add Agentra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1655,3 +1655,4 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+- [agentra](https://github.com/agentrapay/Agentrapay-test) - 🦀 Rust — Non-custodial identity oracle and trust layer for autonomous AI agent payments. Bidirectional trust scoring, authorization gating, and on-chain attestations via EAS.


### PR DESCRIPTION
Adding Agentra (https://agentrapay.ai) — non-custodial identity oracle and trust layer for autonomous AI agent transactions. Rust/Axum. MCP Registry: ai.agentrapay/agentra. Patent pending.