### PR TITLE
Add Swiss Truth MCP — verified knowledge base for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,7 @@ search, and comprehensive file analysis.
 - **[Strava API](https://github.com/tomekkorbak/strava-mcp-server)** - MCP server for Strava API to retrieve one's activities
 - **[Stripe](https://github.com/atharvagupta2003/mcp-stripe)** - This MCP allows integration with Stripe for handling payments, customers, and refunds.
 - **[Substack/Medium](https://github.com/jonathan-politzki/mcp-writer-substack)** - Connect Claude to your Substack/Medium writing, enabling semantic search and analysis of your published content.
+- **[Swiss Truth MCP](https://github.com/swisstruthorg/swiss-truth-mcp)** - Verified knowledge base for AI agents. Stop hallucinations with certified, source-backed facts. 8 MCP tools: search, verify, batch-verify, hallucination risk scoring. Covers Swiss law, health, finance, climate, AI/ML and more. Public, no auth required.
 - **[System Health](https://github.com/thanhtung0201/mcp-remote-system-health)** - The MCP (Multi-Channel Protocol) System Health Monitoring is a robust, real-time monitoring solution designed to provide comprehensive health metrics and alerts for remote Linux servers.
 - **[SystemSage](https://github.com/Tarusharma1/SystemSage)** - A powerful, cross-platform system management and monitoring tool for Windows, Linux, and macOS.
 - **[Talk To Figma](https://github.com/sonnylazuardi/cursor-talk-to-figma-mcp)** - This MCP server enables LLMs to interact with Figma, allowing them to read and modify designs programmatically.


### PR DESCRIPTION
## Swiss Truth MCP

**URL:** https://swisstruth.org/mcp
**GitHub:** https://github.com/swisstruthorg/swiss-truth-mcp
**PyPI:** https://pypi.org/project/swiss-truth-mcp/

### What it does

Swiss Truth MCP is a verified knowledge base for AI agents — a "Wikipedia for AI" that helps reduce hallucinations by providing certified, source-backed facts via MCP.

**8 MCP tools:**
- `search_knowledge` — semantic search across 12+ knowledge domains (Swiss law, health, finance, climate, AI/ML, world science and more)
- `verify_claim` — fact-check a statement: returns `supported` / `contradicted` / `unknown`
- `verify_claims_batch` — verify up to 20 claims in parallel
- `verify_response` — check a full response paragraph for hallucination risk (`low` / `medium` / `high`)
- `get_claim` — retrieve a claim with full provenance (validator, institution, SHA256 hash)
- `list_domains` — browse available knowledge domains
- `submit_claim` — submit new facts for expert review
- `get_claim_status` — track validation status

### Key properties
- **Public, no API key required**
- **Multilingual** — DE, EN, FR, IT, ES, ZH auto-detected
- **5-stage validation pipeline** — AI pre-screen → source verification → expert peer review → SHA256 signing + confidence decay
- **MCP auto-discovery** via `/.well-known/mcp.json`

### Quick setup (Claude Desktop)
```json
{
  "mcpServers": {
    "swiss-truth": {
      "command": "npx",
      "args": ["-y", "mcp-remote", "https://swisstruth.org/mcp"]
    }
  }
}
```

Alphabetically placed after **Substack/Medium** and before **System Health**.
