### PR TITLE
Add wisdomGraph — Neo4j-native DIKW accumulative memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1437,6 +1437,7 @@ search, and comprehensive file analysis.
 - **[Wordle MCP](https://github.com/cr2007/mcp-wordle-python)** - MCP Server that gets the Wordle Solution for a particular date.
 - **[WordPress MCP](https://github.com/Automattic/wordpress-mcp)** - Make your WordPress site into a simple MCP server, exposing functionality to LLMs and AI agents.
 - **[WordPress MCP Adapter](https://github.com/WordPress/mcp-adapter)** - An MCP adapter that bridges the Abilities API to the Model Context Protocol, enabling MCP clients to discover and invoke WordPress plugin, theme, and core abilities programmatically.
+- **[wisdomGraph](https://github.com/cklam12345/wisdomGraph)** - Accumulative Neo4j-native DIKW memory for Claude Code. Stores knowledge across sessions using MERGE semantics; promotes Facts → Experience → Insight → Wisdom via a feedback loop. One command to install: `pip install 'wisdomgraph[mcp]' && wisdom mcp-install`.
 - **[Workflowy](https://github.com/danield137/mcp-workflowy)** - A server that interacts with [workflowy](https://workflowy.com/).
 - **[World Bank data API](https://github.com/anshumax/world_bank_mcp_server)** - A server that fetches data indicators available with the World Bank as part of their data API
 - **[Wren Engine](https://github.com/Canner/wren-engine)** - The Semantic Engine for Model Context Protocol(MCP) Clients and AI Agents


### PR DESCRIPTION
## Summary

Adds **wisdomGraph** to the community servers list (alphabetically under W, between WordPress MCP Adapter and Workflowy).

- **Repo:** https://github.com/cklam12345/wisdomGraph
- **PyPI:** https://pypi.org/project/wisdomgraph/
- **License:** MIT

## What it does

wisdomGraph is a Neo4j-native MCP server that gives Claude Code **permanent, accumulative memory** across sessions.

It exposes 5 tools:
- `wisdom_ingest` — absorb files, directories, or URLs into Neo4j
- `wisdom_remember` — store facts, decisions, bugs fixed explicitly
- `wisdom_query` — read-only Cypher traversal over the graph
- `wisdom_reflect` — DIKW promotion pipeline (Knowledge → Experience → Insight → Wisdom)
- `wisdom_report` — graph status + top Wisdom nodes as markdown

Uses **MERGE semantics** — every session accumulates, nothing resets. The DIKW pyramid models how human experts organize knowledge: facts promoted to patterns, patterns to insights, insights to actionable principles.

## Setup

```bash
pip install 'wisdomgraph[mcp]' && wisdom mcp-install
```

This writes to `.claude/settings.json`:
```json
{
  "mcpServers": {
    "wisdomGraph": { "command": "wisdom", "args": ["mcp"] }
  }
}
```

## Checklist

- [x] Entry is alphabetically placed in the community servers list
- [x] Description is concise and accurate
- [x] Links to public GitHub repo with MIT license
- [x] Package published on PyPI (`pip install wisdomgraph`)
- [x] 88 passing tests (Python 3.10 / 3.11 / 3.12)