### PR TITLE
Add Admit Coach to Community Servers — free college application MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,9 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[1mcpserver](https://github.com/particlefuture/1mcpserver)** - MCP of MCPs. Automatically discover, configure, and add MCP servers on your local machine.
 - **[1Panel](https://github.com/1Panel-dev/mcp-1panel)** - MCP server implementation that provides 1Panel interaction.
 - **[A2A](https://github.com/GongRzhe/A2A-MCP-Server)** - An MCP server that bridges the Model Context Protocol (MCP) with the Agent-to-Agent (A2A) protocol, enabling MCP-compatible AI assistants (like Claude) to seamlessly interact with A2A agents.
+- **[Admit Coach](https://admit-coach.com/mcp/sse)** - Free AI college application platform. Search 3,500+ US universities, estimate admission chances, check financial aid by income bracket, and build balanced college lists. Data from IPEDS and College Scorecard. No API key required.
 - **[Ableton Live](https://github.com/Simon-Kansara/ableton-live-mcp-server)** - an MCP server to control Ableton Live.
+- **[Admit Coach](https://admit-coach.com/mcp/sse)** - Free AI college application platform. Search 3,500+ US universities, estimate admission chances, check financial aid by income bracket, and build balanced college lists. Data from IPEDS and College Scorecard. No API key required.
 - **[Ableton Live](https://github.com/ahujasid/ableton-mcp)** (by ahujasid) - Ableton integration allowing prompt enabled music creation.
 - **[ActivityPub MCP](https://github.com/cameronrye/activitypub-mcp)** - A comprehensive MCP server that enables LLMs to explore and interact with the Fediverse through ActivityPub protocol, supporting actor discovery, timeline fetching, instance exploration, and WebFinger resolution across decentralized social networks.
 - **[Actor Critic Thinking](https://github.com/aquarius-wing/actor-critic-thinking-mcp)** - Actor-critic thinking for performance evaluation


### PR DESCRIPTION
## New Community Server: Admit Coach

**Remote MCP server** for US college application data. No installation or API key needed.

- **SSE endpoint**: `https://admit-coach.com/mcp/sse`
- **Registry**: Already published as `com.admit-coach/university-data` on registry.modelcontextprotocol.io
- **Language**: Python (FastMCP)
- **Auth**: None required

### Tools
| Tool | Description |
|------|-------------|
| `search_universities` | Search 3,500+ US universities by name, state, major, or acceptance rate |
| `get_university_details` | Full admission, financial aid, and outcome data |
| `estimate_admission_chances` | Chance estimate from GPA/SAT/ACT |
| `get_financial_aid` | Net price by income bracket |
| `find_colleges_for_profile` | Auto-build a reach/target/safety college list |

### Data Sources
IPEDS (U.S. Department of Education) and College Scorecard. Federal data, no user-reported estimates.