### PR TITLE
Add Oracle EPM Cloud MCP Server to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,6 +1187,7 @@ search, and comprehensive file analysis.
 - **[OPNSense MCP](https://github.com/vespo92/OPNSenseMCP)** - MCP Server for OPNSense Firewall Management and API access
 - **[Optimade MCP](https://github.com/dianfengxiaobo/optimade-mcp-server)** - An MCP server conducts real-time material science data queries with the Optimade database (for example, elemental composition, crystal structure).
 - **[Oracle](https://github.com/marcelo-ochoa/servers)** (by marcelo-ochoa) - Oracle Database integration in NodeJS with configurable access controls, query explain, stats and schema inspection
+- - **[Oracle EPM Cloud](https://github.com/fmepm/oracle-epm-mcp-server)** - Connect AI agents to Oracle EPM Cloud (Planning, PBCS, EPBCS) via REST APIs. Automate month-end close, run business rules, manage substitution variables, and export data through natural language.
 - **[Oracle Cloud Infrastructure (OCI)](https://github.com/karthiksuku/oci-mcp)** (by karthiksukumar) - Python MCP server for OCI infrastructure (Compute, Autonomous Database, Object Storage). Read-heavy by default with safe instance actions (start/stop/reset). Includes Claude Desktop config and `.env` compartment scoping.
 - **[Oura MCP server](https://github.com/tomekkorbak/oura-mcp-server)** - MCP server for Oura API to retrieve one's sleep data
 - **[Oura Ring](https://github.com/rajvirtual/oura-mcp-server)** (by Rajesh Vijay) - MCP Server to access and analyze your Oura Ring data. It provides a structured way to fetch and understand your health metrics.


### PR DESCRIPTION
## Description
Adding Oracle EPM Cloud MCP Server to the community servers list.

- Server: https://github.com/fmepm/oracle-epm-mcp-server
## Motivation and Context
This is the first MCP server specifically built for Oracle EPM Cloud (Planning/PBCS/EPBCS). It wraps Oracle EPM REST APIs to enable AI agents to automate financial close operations, run business rules, manage substitution variables, and export data through natural language.

## How Has This Been Tested?
Tested with Claude Desktop using both mock mode (no EPM environment required) and live mode against Oracle EPM Cloud environments.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)