### PR TITLE
Add Grovs to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,6 +891,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[GraphQL Schema](https://github.com/hannesj/mcp-graphql-schema)** - Allow LLMs to explore large GraphQL schemas without bloating the context.
 - **[Graylog](https://github.com/Pranavj17/mcp-server-graylog)** - Search Graylog logs by absolute/relative timestamps, filter by streams, and debug production issues directly from Claude Desktop.
 - **[Grok-MCP](https://github.com/merterbak/Grok-MCP)** - MCP server for xAI’s API featuring the latest Grok models, image analysis & generation, and web search.
+- **[Grovs](https://github.com/grovs-io/mcp)** - Manage deep links, attribution, analytics, and campaigns for mobile apps with [Grovs](https://grovs.io) — an open-source, privacy-first alternative to Branch and AppsFlyer.
 - **[gx-mcp-server](https://github.com/davidf9999/gx-mcp-server)** - Expose Great Expectations data validation and quality checks as MCP tools for AI agents.
 - **[HackMD](https://github.com/yuna0x0/hackmd-mcp)** (by yuna0x0) - An MCP server for HackMD, a collaborative markdown editor. It allows users to create, read, and update documents in HackMD using the Model Context Protocol.
 - **[HAProxy](https://github.com/tuannvm/haproxy-mcp-server)** - A Model Context Protocol (MCP) server for HAProxy implemented in Go, leveraging HAProxy Runtime API.


### PR DESCRIPTION
## Summary

Adds [Grovs](https://grovs.io) to the community servers list.

Grovs is an open-source, privacy-first deep linking, attribution, and analytics platform for mobile apps — a self-hostable alternative to Branch and AppsFlyer. The MCP server lets AI assistants manage deep links, view analytics, run campaigns, and configure app settings through natural language.

- **Repo:** https://github.com/grovs-io/mcp
- **Remote endpoint:** `https://mcp.grovs.io/mcp` (Streamable HTTP with OAuth 2.1)
- **Registry:** Published as `io.grovs/mcp` on registry.modelcontextprotocol.io
- **16 tools** covering links, analytics, campaigns, and platform configuration
- **MIT licensed**