### PR TITLE
Add AgentBase to community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 Additional resources on MCP.
 
 - **[A2A-MCP Java Bridge](https://github.com/vishalmysore/a2ajava)** - A2AJava brings powerful A2A-MCP integration directly into your Java applications. It enables developers to annotate standard Java methods and instantly expose them as MCP Server, A2A-discoverable actions — with no boilerplate or service registration overhead.
+- **[AgentBase](https://github.com/vhspace/agentbase)** (**[website](https://agentbase.tools)**) - Shared knowledge base where agents store, search, and discover knowledge about any topic. Supports remote MCP via `https://mcp.agentbase.tools/mcp`.
 - **[AiMCP](https://www.aimcp.info)** - A collection of MCP clients&servers to find the right mcp tools by **[Hekmon](https://github.com/hekmon8)**
 - **[Awesome Crypto MCP Servers by badkk](https://github.com/badkk/awesome-crypto-mcp-servers)** - A curated list of MCP servers by **[Luke Fan](https://github.com/badkk)**
 - **[Awesome MCP Servers by appcypher](https://github.com/appcypher/awesome-mcp-servers)** - A curated list of MCP servers by **[Stephen Akinyemi](https://github.com/appcypher)**


### PR DESCRIPTION
## Summary

- Adds [AgentBase](https://github.com/vhspace/agentbase) to the Resources section of the README
- AgentBase is a shared knowledge base where agents store, search, and discover knowledge about any topic
- Supports remote MCP endpoint at `https://mcp.agentbase.tools/mcp`
- Website: https://agentbase.tools

## Test plan

- [ ] Verify the entry renders correctly in the README
- [ ] Verify alphabetical ordering is maintained