### PR TITLE
fix(memory): remove Zod-based outputSchema to fix serialization failures

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -266,16 +266,12 @@ server.registerTool(
     description: "Create multiple new entities in the knowledge graph",
     inputSchema: {
       entities: z.array(EntitySchema)
-    },
-    outputSchema: {
-      entities: z.array(EntitySchema)
     }
   },
   async ({ entities }) => {
     const result = await knowledgeGraphManager.createEntities(entities);
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      structuredContent: { entities: result }
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }]
     };
   }
 );
@@ -288,16 +284,12 @@ server.registerTool(
     description: "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
     inputSchema: {
       relations: z.array(RelationSchema)
-    },
-    outputSchema: {
-      relations: z.array(RelationSchema)
     }
   },
   async ({ relations }) => {
     const result = await knowledgeGraphManager.createRelations(relations);
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      structuredContent: { relations: result }
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }]
     };
   }
 );
@@ -313,19 +305,12 @@ server.registerTool(
         entityName: z.string().describe("The name of the entity to add the observations to"),
         contents: z.array(z.string()).describe("An array of observation contents to add")
       }))
-    },
-    outputSchema: {
-      results: z.array(z.object({
-        entityName: z.string(),
-        addedObservations: z.array(z.string())
-      }))
     }
   },
   async ({ observations }) => {
     const result = await knowledgeGraphManager.addObservations(observations);
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
-      structuredContent: { results: result }
+      content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }]
     };
   }
 );
@@ -338,17 +323,12 @@ server.registerTool(
     description: "Delete multiple entities and their associated relations from the knowledge graph",
     inputSchema: {
       entityNames: z.array(z.string()).describe("An array of entity names to delete")
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string()
     }
   },
   async ({ entityNames }) => {
     await knowledgeGraphManager.deleteEntities(entityNames);
     return {
-      content: [{ type: "text" as const, text: "Entities deleted successfully" }],
-      structuredContent: { success: true, message: "Entities deleted successfully" }
+      content: [{ type: "text" as const, text: "Entities deleted successfully" }]
     };
   }
 );
@@ -364,17 +344,12 @@ server.registerTool(
         entityName: z.string().describe("The name of the entity containing the observations"),
         observations: z.array(z.string()).describe("An array of observations to delete")
       }))
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string()
     }
   },
   async ({ deletions }) => {
     await knowledgeGraphManager.deleteObservations(deletions);
     return {
-      content: [{ type: "text" as const, text: "Observations deleted successfully" }],
-      structuredContent: { success: true, message: "Observations deleted successfully" }
+      content: [{ type: "text" as const, text: "Observations deleted successfully" }]
     };
   }
 );
@@ -387,17 +362,12 @@ server.registerTool(
     description: "Delete multiple relations from the knowledge graph",
     inputSchema: {
       relations: z.array(RelationSchema).describe("An array of relations to delete")
-    },
-    outputSchema: {
-      success: z.boolean(),
-      message: z.string()
     }
   },
   async ({ relations }) => {
     await knowledgeGraphManager.deleteRelations(relations);
     return {
-      content: [{ type: "text" as const, text: "Relations deleted successfully" }],
-      structuredContent: { success: true, message: "Relations deleted successfully" }
+      content: [{ type: "text" as const, text: "Relations deleted successfully" }]
     };
   }
 );
@@ -408,17 +378,12 @@ server.registerTool(
   {
     title: "Read Graph",
     description: "Read the entire knowledge graph",
-    inputSchema: {},
-    outputSchema: {
-      entities: z.array(EntitySchema),
-      relations: z.array(RelationSchema)
-    }
+    inputSchema: {}
   },
   async () => {
     const graph = await knowledgeGraphManager.readGraph();
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
-      structuredContent: { ...graph }
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }]
     };
   }
 );
@@ -431,17 +396,12 @@ server.registerTool(
     description: "Search for nodes in the knowledge graph based on a query",
     inputSchema: {
       query: z.string().describe("The search query to match against entity names, types, and observation content")
-    },
-    outputSchema: {
-      entities: z.array(EntitySchema),
-      relations: z.array(RelationSchema)
     }
   },
   async ({ query }) => {
     const graph = await knowledgeGraphManager.searchNodes(query);
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
-      structuredContent: { ...graph }
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }]
     };
   }
 );
@@ -454,17 +414,12 @@ server.registerTool(
     description: "Open specific nodes in the knowledge graph by their names",
     inputSchema: {
       names: z.array(z.string()).describe("An array of entity names to retrieve")
-    },
-    outputSchema: {
-      entities: z.array(EntitySchema),
-      relations: z.array(RelationSchema)
     }
   },
   async ({ names }) => {
     const graph = await knowledgeGraphManager.openNodes(names);
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }],
-      structuredContent: { ...graph }
+      content: [{ type: "text" as const, text: JSON.stringify(graph, null, 2) }]
     };
   }
 );


### PR DESCRIPTION
## What's broken?

The memory server's tool definitions pass Zod schema objects directly to `outputSchema`, which violates the [MCP spec](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) requiring plain JSON Schema objects. This causes `_zod` serialization errors when the `tools/list` endpoint serializes schemas to JSON-RPC responses.

## Who is affected?

Projects using the npm `@modelcontextprotocol/sdk` directly (rather than Claude Desktop's bundled SDK) encounter serialization failures when calling `tools/list` or invoking tools with `outputSchema` defined.

## Root cause

`outputSchema` fields use Zod raw shapes like:
```ts
outputSchema: {
  entities: z.array(EntitySchema),
  relations: z.array(RelationSchema)
}
```
The MCP spec requires these to be plain JSON Schema objects.

## Why not just replace with plain JSON Schema?

I investigated replacing Zod schemas with hand-written JSON Schema objects (the approach suggested in the issue). However, the current SDK (v1.26.0–1.29.0) **cannot accept plain JSON Schema for `outputSchema`**:

1. **`tools/list` silently drops it** — `normalizeObjectSchema()` returns `undefined` for non-Zod objects, so `outputSchema` never appears in the response
2. **Tool calls crash** — `validateToolOutput()` calls `safeParseAsync(undefined, ...)` which throws `Cannot read properties of undefined (reading '_zod')`

This is a TypeScript SDK limitation, not a spec issue. Until the SDK adds native JSON Schema passthrough for `outputSchema`, the safest fix is to remove it entirely.

## Fix

Remove `outputSchema` and `structuredContent` from all 9 tool registrations. Tools continue to return data via the `content` array (JSON text), preserving full functionality. The only change is that `tools/list` no longer advertises output schemas for these tools.

## Testing

- `npm run build` passes (TypeScript compilation clean)
- Verified at runtime that tools still return correct JSON data via `content`
- Verified that removing `outputSchema` skips output validation (no crashes)

Fixes #3622
