### PR TITLE
Add ControlKeel to MCP resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Additional resources on MCP.
 - **[Awesome MCP Servers by wong2](https://github.com/wong2/awesome-mcp-servers)** (**[website](https://mcpservers.org)**) - A curated list of MCP servers by **[wong2](https://github.com/wong2)**
 - **[Awesome Remote MCP Servers by JAW9C](https://github.com/jaw9c/awesome-remote-mcp-servers)** - A curated list of **remote** MCP servers, including their authentication support by **[JAW9C](https://github.com/jaw9c)**
 - **[Discord Server](https://glama.ai/mcp/discord)** – A community discord server dedicated to MCP by **[Frank Fiegel](https://github.com/punkpeye)**
+- **[ControlKeel](https://github.com/aryaminus/controlkeel)** - Control plane for governed AI coding: validates agent changes, enforces policy gates, tracks findings, and ships with proof context.
 - **[Install This MCP](https://installthismcp.com)** - Reduce Installation Friction with beautiful installation guides
 - <img height="12" width="12" src="https://raw.githubusercontent.com/klavis-ai/klavis/main/static/klavis-ai.png" alt="Klavis Logo" /> **[Klavis AI](https://www.klavis.ai)** - Open Source MCP Infra. Hosted MCP servers and MCP clients on Slack and Discord.
 - **[MCP Badges](https://github.com/mcpx-dev/mcp-badges)** – Quickly highlight your MCP project with clear, eye-catching badges, by **[Ironben](https://github.com/nanbingxyz)**


### PR DESCRIPTION
## Summary
- add ControlKeel to the README Resources section as a governance-focused MCP project

## Why
ControlKeel is part of the MCP ecosystem and helps users discover governance tooling for policy gates, findings tracking, and proof-oriented workflows.