### PR TITLE
docs(git,time): fix invalid JSON in Zed uvx config examples

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -222,14 +222,14 @@ Add to your Zed settings.json:
 <summary>Using uvx</summary>
 
 ```json
-"context_servers": [
+"context_servers": {
   "mcp-server-git": {
     "command": {
       "path": "uvx",
       "args": ["mcp-server-git"]
     }
   }
-],
+},
 ```
 </details>
 

--- a/src/time/README.md
+++ b/src/time/README.md
@@ -100,12 +100,12 @@ Add to your Zed settings.json:
 <summary>Using uvx</summary>
 
 ```json
-"context_servers": [
+"context_servers": {
   "mcp-server-time": {
     "command": "uvx",
     "args": ["mcp-server-time"]
   }
-],
+},
 ```
 </details>
 


### PR DESCRIPTION
The ""Using uvx"" Zed configuration snippets in `src/git/README.md` and `src/time/README.md` wrap an object-style key-value entry in square brackets:

```json
"context_servers": [
  "mcp-server-time": {
    ...
  }
],
```

That is not valid JSON — the key-with-colon form only parses inside an object. The adjacent ""Using pip"" snippets in the same files already use the correct `{ ... }` form, so this change just makes the uvx variants consistent with them.

### Why

Users copy-pasting the uvx example straight into Zed's `settings.json` will hit a JSON parse error. Switching the two brackets to braces makes the example parse and matches the corrected pattern from PR #114 (which fixed the same issue elsewhere in the repo but missed these two uvx blocks).

### Scope

- Docs-only, no code touched
- 8 lines changed across 2 files (well under the 50 LOC limit)
- No new dependencies, no breaking changes
- One concern: invalid JSON in Zed uvx examples

### Types of changes

- [x] Documentation update

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._