### PR TITLE
fix(release): include lock files in version bump check

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,7 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
         )
 
         changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
+        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts", ".lock"]]
         return len(relevant_files) >= 1
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
## Summary
- Added `.lock` to the list of file extensions checked in `has_changes()` function
- This ensures packages with only lockfile changes (e.g., uv.lock from dependabot) get version bumped

## Why
The `has_changes()` function in `scripts/release.py` only considered `.py` and `.ts` files when deciding which packages to version-bump. If a sub-package only had lockfile changes between tags, it would be skipped.

## Validation
- [x] Only one line changed in one file
- [x] Fix matches the issue description

## Related
Fixes Issue #3870