### PR TITLE
fix(filesystem): prevent MCP roots from overriding CLI-provided directories

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,7 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
         )
 
         changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
+        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts", ".lock"]]
         return len(relevant_files) >= 1
     except subprocess.CalledProcessError:
         return False

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,7 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
         )
 
         changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts", ".lock"]]
+        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
         return len(relevant_files) >= 1
     except subprocess.CalledProcessError:
         return False

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -89,6 +89,9 @@ if (accessibleDirectories.length === 0 && allowedDirectories.length > 0) {
 
 allowedDirectories = accessibleDirectories;
 
+// Track if directories were explicitly provided via CLI args
+const hasCliDirectories = args.length > 0;
+
 // Initialize the global allowedDirectories in lib.ts
 setAllowedDirectories(allowedDirectories);
 
@@ -703,7 +706,13 @@ server.registerTool(
 );
 
 // Updates allowed directories based on MCP client roots
+// Only overrides if no CLI directories were explicitly provided
 async function updateAllowedDirectoriesFromRoots(requestedRoots: Root[]) {
+  // If CLI directories were explicitly provided, MCP roots should not override them
+  if (hasCliDirectories) {
+    console.error("Ignoring MCP roots: CLI-provided directories take precedence");
+    return;
+  }
   const validatedRootDirs = await getValidRootDirectories(requestedRoots);
   if (validatedRootDirs.length > 0) {
     allowedDirectories = [...validatedRootDirs];


### PR DESCRIPTION
## Summary
- Added check in `updateAllowedDirectoriesFromRoots` to skip overriding if CLI directories were explicitly provided
- When CLI directories are provided via command-line args, MCP roots from the client will not override them

## Why
Previously, MCP roots would unconditionally replace `allowedDirectories` even when the user explicitly provided directories via CLI args. This made it impossible to scope the server to a directory outside the client's project root.

## Validation
- [x] TypeScript build passes
- [x] Only one file modified with minimal changes
- [x] Logic: if `hasCliDirectories` is true, the function returns early without overriding

## Related
Fixes Issue #3929