### PR TITLE
fix(git): auto-detect repo root from --repository

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -119,6 +119,12 @@ python -m mcp_server_git
 
 ## Configuration
 
+`--repository` accepts any path inside a Git working tree. On startup the server walks up to the enclosing `.git/`, the same way `git rev-parse --show-toplevel` does. So `--repository .` works when a shared config is run from any subdirectory of the repo.
+
+Note that this also means `--repository /repo/subdir` resolves to `/repo` and allows tool calls anywhere under it. If the resolved path differs from the input, startup logs show the rewrite. If you want to restrict operations to a subtree, this flag alone won't do it; use a separate repo or an external sandbox.
+
+Per-tool `repo_path` arguments are not resolved this way and must point at the repo root.
+
 ### Usage with Claude Desktop
 
 Add this to your `claude_desktop_config.json`:

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -234,6 +234,14 @@ def git_show(repo: git.Repo, revision: str) -> str:
             output.append(d.diff)
     return "".join(output)
 
+def resolve_repo_root(path: Path) -> Path:
+    """Return the enclosing repo root for ``path``, like ``git rev-parse --show-toplevel``."""
+    repo = git.Repo(path, search_parent_directories=True)
+    if repo.working_dir:
+        return Path(repo.working_dir)
+    return Path(path).resolve()
+
+
 def validate_repo_path(repo_path: Path, allowed_repository: Path | None) -> None:
     """Validate that repo_path is within the allowed repository path."""
     if allowed_repository is None:
@@ -295,11 +303,14 @@ async def serve(repository: Path | None) -> None:
 
     if repository is not None:
         try:
-            git.Repo(repository)
-            logger.info(f"Using repository at {repository}")
+            resolved = resolve_repo_root(repository)
         except git.InvalidGitRepositoryError:
-            logger.error(f"{repository} is not a valid Git repository")
+            logger.error(f"{repository} is not inside a Git repository")
             return
+        if resolved != repository:
+            logger.info(f"Resolved --repository {repository} to repo root {resolved}")
+        repository = resolved
+        logger.info(f"Using repository at {repository}")
 
     server = Server("mcp-git")
 

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import pytest
 from pathlib import Path
 import git
@@ -15,6 +17,8 @@ from mcp_server_git.server import (
     git_log,
     git_create_branch,
     git_show,
+    resolve_repo_root,
+    serve,
     validate_repo_path,
 )
 import shutil
@@ -250,6 +254,77 @@ def test_git_show_initial_commit(test_repository):
     assert "Commit:" in result
     assert "initial commit" in result
     assert "test.txt" in result
+
+
+# Tests for resolve_repo_root (#3029)
+
+def test_resolve_repo_root_at_root(tmp_path: Path):
+    repo_path = tmp_path / "repo"
+    git.Repo.init(repo_path)
+    assert resolve_repo_root(repo_path).resolve() == repo_path.resolve()
+
+
+def test_resolve_repo_root_from_subdirectory(tmp_path: Path):
+    repo_path = tmp_path / "repo"
+    git.Repo.init(repo_path)
+    subdir = repo_path / "nested" / "deeper"
+    subdir.mkdir(parents=True)
+    assert resolve_repo_root(subdir).resolve() == repo_path.resolve()
+
+
+def test_resolve_repo_root_outside_any_repository(tmp_path: Path):
+    non_repo = tmp_path / "not_a_repo"
+    non_repo.mkdir()
+    with pytest.raises(git.InvalidGitRepositoryError):
+        resolve_repo_root(non_repo)
+
+
+def test_resolve_repo_root_dot_from_subdirectory(tmp_path: Path, monkeypatch):
+    # `--repository .` from a subdir should walk up to the repo root.
+    repo_path = tmp_path / "repo"
+    git.Repo.init(repo_path)
+    subdir = repo_path / "nested"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    assert resolve_repo_root(Path(".")).resolve() == repo_path.resolve()
+
+
+class _StopServe(Exception):
+    pass
+
+
+def _fake_stdio_server():
+    raise _StopServe()
+
+
+def test_serve_resolves_subdirectory_at_startup(tmp_path: Path, monkeypatch, caplog):
+    repo_path = tmp_path / "repo"
+    git.Repo.init(repo_path)
+    subdir = repo_path / "nested"
+    subdir.mkdir()
+
+    monkeypatch.setattr("mcp_server_git.server.stdio_server", _fake_stdio_server)
+    caplog.set_level(logging.INFO, logger="mcp_server_git.server")
+
+    with pytest.raises(_StopServe):
+        asyncio.run(serve(subdir))
+
+    messages = [r.message for r in caplog.records]
+    assert any("Resolved --repository" in m and str(subdir) in m for m in messages)
+    assert any(f"Using repository at {repo_path}" in m for m in messages)
+
+
+def test_serve_rejects_path_outside_any_repository(tmp_path: Path, monkeypatch, caplog):
+    non_repo = tmp_path / "not_a_repo"
+    non_repo.mkdir()
+
+    monkeypatch.setattr("mcp_server_git.server.stdio_server", _fake_stdio_server)
+    caplog.set_level(logging.ERROR, logger="mcp_server_git.server")
+
+    asyncio.run(serve(non_repo))
+
+    messages = [r.message for r in caplog.records]
+    assert any("is not inside a Git repository" in m for m in messages)
 
 
 # Tests for validate_repo_path (repository scoping security fix)


### PR DESCRIPTION
Lets mcp-server-git --repository <path> accept any path inside a Git working tree instead of only the repo root. At startup the server walks up parents to find .git/, like git rev-parse--show-toplevel.                                                                                                                                                                        
                  
  Fixes the case in #3029 where --repository . only works when the client is launched from the repo root. Now it works from any subdirectory, so a checked-in mcp.json works for everyone without per-developer absolute paths.

**Closes #3029.**                                                                                                                                                                            
                  
  Real git walks up the tree from any subdir. The server should too, otherwise --repository. It is basically unusable in a shared config.                                                    
   
  On the thread, @jonathanhefner and @domdomegg both said not to special-case, so this applies to any path passed to --repository.                                                       
                  
  **How Has This Been Tested?**                                                                                                                                                                
                  
  - Unit tests for resolve_repo_root: root path, nested subdir, non-repo path, and Path(".") via monkeypatch.chdir.                                                                        
  - Two integration tests that drive serve() with a stubbed stdio_server to confirm the resolver is actually wired into startup and the rewrite gets logged.
  - Local smoke test: ran mcp-server-git --repository . from a few nested subdirs and confirmed it picks up the right repo.                                                                
                                                                                                                                                                                           
  **Breaking Changes**                                                                                                                                                                         
                                                                                                                                                                                           
  No impact for configs that already point at the repo root.                                                                                                                               
   
  One behavior change: --repository /repo/non_repo_subdir used to fail with "not a valid Git repository". Now it resolves upward to /repo and starts. If the resolved path differs from the input, it logs it at INFO so it's visible. The README documents this and notes that the flag alone doesn't enforce subtree scoping.
                                                                                                                                                                                           
  The error message also changed from "is not a valid Git repository" to "is not inside a Git repository".                                                                                     
   
  **Types of changes**                                                                                                                                                                         
                  
  - Bug fix (non-breaking change which fixes an issue)                                                                                                                                     
  - New feature (non-breaking change which adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to change)                                                                                                     
  - Documentation update

  **Checklist**                                                                                                                                                                                
   
  - I have read the MCP Protocol Documentation                                                                                                                                             
  - My changes follow MCP security best practices
  - I have updated the server's README accordingly
  - I have tested this with an LLM client
  - My code follows the repository's style guidelines                                                                                                                                      
  - New and existing tests pass locally
  - I have added appropriate error handling                                                                                                                                                
  - I have documented all environment variables and configuration options                                                                                                                  
   
  **Additional context**                                                                                                                                                                       
                  
  Kept the fix scoped to the --repository CLI flag. Applying the same parent-walking to per-tool repo_path would break git_add semantics: repo.git.add(".") runs at the repo root, so passing repo_path=/repo/subdir with files=["."] would stage the whole repo instead of just the subdir. Leaving repo_path strict avoids that. The README says so explicitly.