### PR TITLE
fix(resources): add resourceType description to resourceTypeCompleter

### DIFF
--- a/.changeset/add-resource-ref-resourceType-description.md
+++ b/.changeset/add-resource-ref-resourceType-description.md
@@ -1,0 +1,11 @@
+---
+"servers/everything" patch
+---
+
+Fix `get-resource-reference` / `resource-prompt` prompt argument missing description for `resourceType`
+
+The `resourceType` prompt argument on `resource-prompt` (and `get-resource-reference` tool) now includes the allowed values in its description: `"Type of resource — must be 'Text' or 'Blob'."`. This allows automated callers to determine valid values without guessing or relying on error messages.
+
+Previously the description only said `"Type of resource to fetch"` with no enumeration of allowed values, causing schema-completeness warnings and hard failures during automated invocation (e.g., mcp-probe).
+
+See [issue #3985](https://github.com/modelcontextprotocol/servers/issues/3985) for context.

--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -25,7 +25,7 @@ export const RESOURCE_TYPES: string[] = [
  * The completion logic matches the input against available resource types.
  */
 export const resourceTypeCompleter = completable(
-  z.string().describe("Type of resource to fetch"),
+  z.string().describe("Type of resource — must be 'Text' or 'Blob'."),
   (value: string) => {
     return RESOURCE_TYPES.filter((t) => t.startsWith(value));
   }


### PR DESCRIPTION
## Summary
Adds `description` field with allowed values (`Text` or `Blob`) to `resourceTypeCompleter` in `templates.ts`.

## Fixes
Closes #3985

## Testing
`npm test` passes