### PR TITLE
docs(everything): warn that get-env may expose secrets

### DIFF
--- a/src/everything/tools/get-env.ts
+++ b/src/everything/tools/get-env.ts
@@ -6,7 +6,7 @@ const name = "get-env";
 const config = {
   title: "Print Environment Tool",
   description:
-    "Returns all environment variables, helpful for debugging MCP server configuration",
+    "Returns all environment variables, helpful for debugging MCP server configuration. Warning: values may include secrets (API keys, tokens); only enable this tool in trusted environments.",
   inputSchema: {},
 };
 


### PR DESCRIPTION
Extend the `get-env` tool description so operators know environment values can include API keys and tokens.
