### PR TITLE
fix(everything): require key parameter for get-env tool to prevent env leakage

### DIFF
--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -162,20 +162,22 @@ describe('Tools', () => {
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');
 
-      const envJson = JSON.parse(result.content[0].text);
-      expect(envJson.TEST_VAR_EVERYTHING).toBe('test_value');
+      const text = result.content[0].text;
+      expect(text).toBe('TEST_VAR_EVERYTHING=test_value');
 
       delete process.env.TEST_VAR_EVERYTHING;
     });
 
-    it('should return valid JSON', async () => {
+    it('should return valid output', async () => {
       const { mockServer, handlers } = createMockServer();
       registerGetEnvTool(mockServer);
 
       const handler = handlers.get('get-env')!;
       const result = await handler({ key: 'PATH' });
 
-      expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toMatch(/^PATH=/);
     });
   });
 

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -157,7 +157,7 @@ describe('Tools', () => {
 
       const handler = handlers.get('get-env')!;
       process.env.TEST_VAR_EVERYTHING = 'test_value';
-      const result = await handler({});
+      const result = await handler({ key: 'TEST_VAR_EVERYTHING' });
 
       expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('text');
@@ -173,7 +173,7 @@ describe('Tools', () => {
       registerGetEnvTool(mockServer);
 
       const handler = handlers.get('get-env')!;
-      const result = await handler({});
+      const result = await handler({ key: 'PATH' });
 
       expect(() => JSON.parse(result.content[0].text)).not.toThrow();
     });

--- a/src/everything/tools/get-env.ts
+++ b/src/everything/tools/get-env.ts
@@ -1,5 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+// Tool input schema
+export const GetEnvSchema = z.object({
+  key: z.string().describe(
+    "The name of the environment variable to retrieve (e.g., 'PATH', 'HOME', 'USER')",
+  ),
+});
 
 // Tool configuration
 const name = "get-env";
@@ -7,17 +15,7 @@ const config = {
   title: "Print Environment Tool",
   description:
     "Returns the value of a specific environment variable, helpful for debugging MCP server configuration",
-  inputSchema: {
-    type: "object",
-    properties: {
-      key: {
-        type: "string",
-        description:
-          "The name of the environment variable to retrieve (e.g., 'PATH', 'HOME', 'USER')",
-      },
-    },
-    required: ["key"],
-  },
+  inputSchema: GetEnvSchema,
 };
 
 /**
@@ -31,7 +29,7 @@ const config = {
  */
 export const registerGetEnvTool = (server: McpServer) => {
   server.registerTool(name, config, async (args): Promise<CallToolResult> => {
-    const { key } = args as { key: string };
+    const { key } = GetEnvSchema.parse(args);
     const value = process.env[key];
 
     if (value === undefined) {

--- a/src/everything/tools/get-env.ts
+++ b/src/everything/tools/get-env.ts
@@ -6,26 +6,50 @@ const name = "get-env";
 const config = {
   title: "Print Environment Tool",
   description:
-    "Returns all environment variables, helpful for debugging MCP server configuration",
-  inputSchema: {},
+    "Returns the value of a specific environment variable, helpful for debugging MCP server configuration",
+  inputSchema: {
+    type: "object",
+    properties: {
+      key: {
+        type: "string",
+        description:
+          "The name of the environment variable to retrieve (e.g., 'PATH', 'HOME', 'USER')",
+      },
+    },
+    required: ["key"],
+  },
 };
 
 /**
  * Registers the 'get-env' tool.
  *
- * The registered tool Retrieves and returns the environment variables
- * of the current process as a JSON-formatted string encapsulated in a text response.
+ * The registered tool retrieves and returns the value of a specific
+ * environment variable from the current process.
  *
  * @param {McpServer} server - The McpServer instance where the tool will be registered.
  * @returns {void}
  */
 export const registerGetEnvTool = (server: McpServer) => {
   server.registerTool(name, config, async (args): Promise<CallToolResult> => {
+    const { key } = args as { key: string };
+    const value = process.env[key];
+
+    if (value === undefined) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Environment variable '${key}' is not set.`,
+          },
+        ],
+      };
+    }
+
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify(process.env, null, 2),
+          text: `${key}=${value}`,
         },
       ],
     };


### PR DESCRIPTION
## Summary
- Change get-env inputSchema from empty object {} to require a key parameter; returns only the specified environment variable value instead of full process.env

## Why
Issue #3986: get-env tool returns the entire process.env object without any parameters, potentially leaking all environment variables including API keys and tokens.

## Validation
- [x] Syntax check passed
- [x] Fix pushed to fork