### PR TITLE
docs(everything): add allowed values description to resourceType in get-resource-reference

### DIFF
--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -25,7 +25,7 @@ export const RESOURCE_TYPES: string[] = [
  * The completion logic matches the input against available resource types.
  */
 export const resourceTypeCompleter = completable(
-  z.string().describe("Type of resource to fetch"),
+  z.string().describe("Type of resource — must be 'Text' or 'Blob'"),
   (value: string) => {
     return RESOURCE_TYPES.filter((t) => t.startsWith(value));
   }


### PR DESCRIPTION
## Summary
- Add description to resourceType parameter clarifying it must be 'Text' or 'Blob'

## Why
Issue #3985: resourceType parameter lacks allowed values description, preventing automated callers from knowing which values are accepted.

## Validation
- [x] Syntax check passed
- [x] Fix pushed to fork