### PR TITLE
Add AgentCard to Resources — open A2A identity standard with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 Additional resources on MCP.
 
 - **[A2A-MCP Java Bridge](https://github.com/vishalmysore/a2ajava)** - A2AJava brings powerful A2A-MCP integration directly into your Java applications. It enables developers to annotate standard Java methods and instantly expose them as MCP Server, A2A-discoverable actions — with no boilerplate or service registration overhead.
+- **[AgentCard](https://github.com/kwailapt/AgentCard)** - Open standard for agent-to-agent (A2A) identity: declare capabilities, resolve peers, and validate agent cards using a framework-neutral JSON schema. Analogous to HTTP headers for the agent web. Includes MCP server (`pip install agentcard-mcp`), LangChain/CrewAI/AutoGen adapters, and JSON Schema. Apache 2.0. by **[kwailapt](https://github.com/kwailapt)**
 - **[AiMCP](https://www.aimcp.info)** - A collection of MCP clients&servers to find the right mcp tools by **[Hekmon](https://github.com/hekmon8)**
 - **[Awesome Crypto MCP Servers by badkk](https://github.com/badkk/awesome-crypto-mcp-servers)** - A curated list of MCP servers by **[Luke Fan](https://github.com/badkk)**
 - **[Awesome MCP Servers by appcypher](https://github.com/appcypher/awesome-mcp-servers)** - A curated list of MCP servers by **[Stephen Akinyemi](https://github.com/appcypher)**


### PR DESCRIPTION
## What is AgentCard?

**AgentCard v1.0** is an open standard for agent-to-agent (A2A) identity — analogous to HTTP headers for the agent web.

- **Framework-neutral JSON schema**: works with LangChain, CrewAI, AutoGen, MCP, or any custom agent
- **MCP server included**: `pip install agentcard-mcp` — 4 tools + 2 resources
- **Open standard**: Apache 2.0 + CC-BY 4.0, patent non-reservation

## Why this belongs in Resources

AgentCard provides the identity layer that lets MCP agents identify themselves and each other in multi-agent systems. It's not just another MCP server — it's a **protocol standard** that MCP servers can implement to declare compliance.

## What's changed

Added one line to the `📚 Resources` section (alphabetically between "A2A-MCP Java Bridge" and "AiMCP"):

```markdown
- **[AgentCard](https://github.com/kwailapt/AgentCard)** - Open standard for agent-to-agent (A2A) identity: declare capabilities, resolve peers, and validate agent cards using a framework-neutral JSON schema. Analogous to HTTP headers for the agent web. Includes MCP server (`pip install agentcard-mcp`), LangChain/CrewAI/AutoGen adapters, and JSON Schema. Apache 2.0. by **[kwailapt](https://github.com/kwailapt)**
```

## Links

- Spec + schema: https://github.com/kwailapt/AgentCard
- JSON Schema: https://github.com/kwailapt/AgentCard/blob/main/schema.json
- MCP server: https://github.com/kwailapt/AgentCard/tree/main/adapters/python/mcp-server
- LangChain/CrewAI/AutoGen adapters: https://github.com/kwailapt/AgentCard/tree/main/adapters/python

## MCP server tools

| Tool | Description |
|------|-------------|
| `agentcard_declare` | Register an agent's identity (AgentCard JSON) |
| `agentcard_resolve` | Look up a peer by name or ULID |
| `agentcard_validate` | Validate against AgentCard v1.0 schema |
| `agentcard_list` | List all registered agents |

Resources: `agentcard://schema`, `agentcard://registry`