### PR TITLE
fix(filesystem): add optional depth parameter to list_directory

### DIFF
--- a/src/everything/tools/get-resource-reference.ts
+++ b/src/everything/tools/get-resource-reference.ts
@@ -15,7 +15,8 @@ import {
 const GetResourceReferenceSchema = z.object({
   resourceType: z
     .enum([RESOURCE_TYPE_TEXT, RESOURCE_TYPE_BLOB])
-    .default(RESOURCE_TYPE_TEXT),
+    .default(RESOURCE_TYPE_TEXT)
+    .describe("Type of resource — must be 'Text' or 'Blob'."),
   resourceId: z
     .number()
     .default(1)

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -132,6 +132,7 @@ const CreateDirectoryArgsSchema = z.object({
 
 const ListDirectoryArgsSchema = z.object({
   path: z.string(),
+  depth: z.number().optional().describe('Maximum directory depth to list (default: 1, max: 10)')
 });
 
 const ListDirectoryWithSizesArgsSchema = z.object({
@@ -427,17 +428,35 @@ server.registerTool(
       "prefixes. This tool is essential for understanding directory structure and " +
       "finding specific files within a directory. Only works within allowed directories.",
     inputSchema: {
-      path: z.string()
+      path: z.string(),
+      depth: z.number().optional().describe('Maximum directory depth to list (default: 1, max: 10)')
     },
     outputSchema: { content: z.string() },
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ListDirectoryArgsSchema>) => {
     const validPath = await validatePath(args.path);
-    const entries = await fs.readdir(validPath, { withFileTypes: true });
-    const formatted = entries
-      .map((entry) => `${entry.isDirectory() ? "[DIR]" : "[FILE]"} ${entry.name}`)
-      .join("\n");
+    const maxDepth = Math.min(args.depth ?? 1, 10);
+
+    async function listDirRecursive(currentPath: string, currentDepth: number): Promise<string[]> {
+      const entries = await fs.readdir(currentPath, { withFileTypes: true });
+      const lines: string[] = [];
+
+      for (const entry of entries) {
+        const indent = '  '.repeat(currentDepth - 1);
+        lines.push(`${indent}${entry.isDirectory() ? "[DIR]" : "[FILE]"} ${entry.name}`);
+
+        if (entry.isDirectory() && currentDepth < maxDepth) {
+          const subPath = path.join(currentPath, entry.name);
+          const subEntries = await listDirRecursive(subPath, currentDepth + 1);
+          lines.push(...subEntries);
+        }
+      }
+
+      return lines;
+    }
+
+    const formatted = (await listDirRecursive(validPath, 1)).join("\n");
     return {
       content: [{ type: "text" as const, text: formatted }],
       structuredContent: { content: formatted }


### PR DESCRIPTION
## Summary
- Adds optional `depth` parameter to `list_directory` tool
- When `depth > 1`, recursively lists subdirectories with indentation
- Clamps depth to max 10 to prevent excessive recursion

## Problem
LLMs (e.g., LM Studio with gpt-oss-120b-MLX-8bit model) are calling `list_directory` with a `depth` argument, but the schema rejected it with:
```
params is not allowed to have the additional property "depth"
```

## Solution
1. Added `depth: z.number().optional()` to `ListDirectoryArgsSchema`
2. Updated `inputSchema` in tool registration
3. Implemented recursive listing with indentation for `depth > 1`

## Test Plan
- [x] `npm run build` passes
- [x] Existing tests pass (2 pre-existing Unicode/root-dir failures unrelated to this change)