### PR TITLE
fix(release): include lockfile changes in has_changes()

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,12 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
         )
 
         changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
+        relevant_files = [
+            f
+            for f in changed_files
+            if f.suffix in [".py", ".ts"]
+            or f.name in ("uv.lock", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
+        ]
         return len(relevant_files) >= 1
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
## Summary
- `has_changes()` in `scripts/release.py` now also checks for lockfile changes (`uv.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`) in addition to `.py` and `.ts` files

## Why
Issue #3870: When a package only has lockfile changes between release tags, `has_changes()` returned `False` because it only checked `.py` and `.ts` suffixes. This caused `pyproject.toml` versions to be skipped during version bump (e.g., `src/git/` stayed at `0.6.2` instead of the CalVer tag), breaking SBOM/CVE scanners that key off the version field.

## Fix
```python
# Before
relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]

# After
relevant_files = [
    f
    for f in changed_files
    if f.suffix in [".py", ".ts"]
    or f.name in ("uv.lock", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
]
```

## Validation
- Python syntax check passed
- Only affects release script (`scripts/release.py`), no runtime code changes

## Related
- Fixes #3870

🤖 Generated with [Claude Code](https://claude.com/claude-code)