### PR TITLE
fix(everything): add description to get-resource-reference resourceType

### DIFF
--- a/src/everything/tools/get-resource-reference.ts
+++ b/src/everything/tools/get-resource-reference.ts
@@ -15,7 +15,8 @@ import {
 const GetResourceReferenceSchema = z.object({
   resourceType: z
     .enum([RESOURCE_TYPE_TEXT, RESOURCE_TYPE_BLOB])
-    .default(RESOURCE_TYPE_TEXT),
+    .default(RESOURCE_TYPE_TEXT)
+    .describe("Type of resource — must be 'Text' or 'Blob'."),
   resourceId: z
     .number()
     .default(1)


### PR DESCRIPTION
## Summary
- Added `.describe()` to `resourceType` field in `get-resource-reference` tool schema
- Fixes issue where the `resourceType` argument was missing a description for MCP clients

## Test plan
- [x] Build passes (`npm run build`)
- [x] No other changes to logic or behavior

Fixes #3985