### PR TITLE
docs(readme): remove outdated GitLab server reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The following reference servers are now archived and can be found at [servers-ar
 - **[Brave Search](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/brave-search)** - Web and local search using Brave's Search API.  Has been replaced by the [official server](https://github.com/brave/brave-search-mcp-server).
 - **[EverArt](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/everart)** - AI image generation using various models.
 - **[GitHub](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github)** - Repository management, file operations, and GitHub API integration.
-- **[GitLab](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gitlab)** - GitLab API, enabling project management.
 - **[Google Drive](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/gdrive)** - File access and search capabilities for Google Drive.
 - **[Google Maps](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/google-maps)** - Location services, directions, and place details.
 - **[PostgreSQL](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/postgres)** - Read-only database access with schema inspection.


### PR DESCRIPTION
## Summary
- Remove GitLab server reference from README since it was archived

## Why
GitLab server was archived in commit d53d6cc75c but the reference remains in README. Closes #3347.

## Validation
- [x] Only README.md modified
- [x] Change is a simple line deletion

## Related
- Fixes #3347