### PR TITLE
feat(filesystem): add head/tail support to read_multiple_files

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -108,6 +108,8 @@ const ReadMultipleFilesArgsSchema = z.object({
     .array(z.string())
     .min(1, "At least one file path must be provided")
     .describe("Array of file paths to read. Each path must be a string pointing to a valid file within allowed directories."),
+  head: z.number().int().positive().optional().describe("If provided, returns only the first N lines of each file"),
+  tail: z.number().int().positive().optional().describe("If provided, returns only the last N lines of each file")
 });
 
 const WriteFileArgsSchema = z.object({
@@ -305,22 +307,36 @@ server.registerTool(
       "Read the contents of multiple files simultaneously. This is more " +
       "efficient than reading files one by one when you need to analyze " +
       "or compare multiple files. Each file's content is returned with its " +
-      "path as a reference. Failed reads for individual files won't stop " +
-      "the entire operation. Only works within allowed directories.",
+      "path as a reference. Use 'head' to read only the first N lines of each " +
+      "file, or 'tail' to read only the last N lines. Failed reads for " +
+      "individual files won't stop the entire operation. Only works within allowed directories.",
     inputSchema: {
       paths: z.array(z.string())
         .min(1)
-        .describe("Array of file paths to read. Each path must be a string pointing to a valid file within allowed directories.")
+        .describe("Array of file paths to read. Each path must be a string pointing to a valid file within allowed directories."),
+      head: z.number().int().positive().optional().describe("If provided, returns only the first N lines of each file"),
+      tail: z.number().int().positive().optional().describe("If provided, returns only the last N lines of each file")
     },
     outputSchema: { content: z.string() },
     annotations: { readOnlyHint: true }
   },
   async (args: z.infer<typeof ReadMultipleFilesArgsSchema>) => {
+    if (args.head && args.tail) {
+      throw new Error("Cannot specify both head and tail parameters simultaneously");
+    }
+
     const results = await Promise.all(
       args.paths.map(async (filePath: string) => {
         try {
           const validPath = await validatePath(filePath);
-          const content = await readFileContent(validPath);
+          let content: string;
+          if (args.tail) {
+            content = await tailFile(validPath, args.tail);
+          } else if (args.head) {
+            content = await headFile(validPath, args.head);
+          } else {
+            content = await readFileContent(validPath);
+          }
           return `${filePath}:\n${content}\n`;
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## What

Add optional `head` and `tail` parameters to the `read_multiple_files` tool, allowing line-limited reads across multiple files at once.

## Why

The single-file `read_text_file` already supports `head` and `tail`, but `read_multiple_files` does not. When working with multiple large files (logs, configs, data files), agents often only need the first/last N lines of each.

Currently the only option is to call `read_text_file` with head/tail N times, which is slower and more verbose.

## How

```
read_multiple_files({
  paths: ["log1.txt", "log2.txt", "log3.txt"],
  tail: 20  // last 20 lines of each file
})
```

- `head` — returns only the first N lines of each file
- `tail` — returns only the last N lines of each file
- Cannot use both simultaneously (throws error, same as `read_text_file`)
- Omitting both reads full files (backward compatible)

## Changes

- `src/filesystem/index.ts`:
  - Added `head` and `tail` to `ReadMultipleFilesArgsSchema`
  - Updated handler to use `headFile`/`tailFile` from lib.ts
  - Updated tool description
  - Added mutual exclusion check (same pattern as `read_text_file`)