### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,5 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+
+- [REG-Vault](https://regvault.org/docs/api) — Retro-gaming metadata catalog (91k games, 99 systems) with box art, manuals and gameplay previews.


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
