### PR TITLE
docs+chore(filesystem): batch Info findings — read_file deprecation signal + read_media_file docstring

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -217,7 +217,8 @@ server.registerTool(
     description: "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead.",
     inputSchema: ReadTextFileArgsSchema.shape,
     outputSchema: { content: z.string() },
-    annotations: { readOnlyHint: true }
+    annotations: { readOnlyHint: true },
+    _meta: { deprecated: true, replacement: "read_text_file" }
   },
   readTextFileHandler
 );
@@ -250,7 +251,11 @@ server.registerTool(
   {
     title: "Read Media File",
     description:
-      "Read an image or audio file. Returns the base64 encoded data and MIME type. " +
+      "Read a binary file (image or audio) and return its base64-encoded data with detected MIME type. " +
+      "Use this tool for binary content such as PNG/JPEG/GIF/WebP/BMP/SVG images or MP3/WAV/OGG/FLAC audio; " +
+      "for plain-text files use read_text_file instead, since base64 encoding inflates text payloads ~33% with no benefit. " +
+      "MIME type is derived from the file extension; unknown extensions silently fall back to application/octet-stream " +
+      "and are returned with a generic \"blob\" content type. " +
       "Only works within allowed directories.",
     inputSchema: {
       path: z.string()


### PR DESCRIPTION
## Summary

Two batched Info-level documentation/metadata improvements to `src/filesystem/index.ts`, surfaced by an external MCP audit using the [`mcp-audit` skill](https://github.com/yakuphanycl/wrg-skills/tree/main/skills/mcp-audit).

Per the audit's disclosure SOP, [Info-severity findings are batched into a single PR](https://github.com/yakuphanycl/wrg-skills/blob/main/docs/disclosure-sop.md#2-decision-tree) rather than scattered across the tracker. No security impact, no behavioural change.

## Findings addressed

### F-007 — `read_file` lacks structured deprecation signal
**Default severity**: Info ([`SHAPE-`-class observation](https://github.com/yakuphanycl/wrg-skills/blob/main/skills/mcp-audit/SEVERITY.md))

`read_file` already carries the human-readable deprecation in `title` ("Read File (Deprecated)") and `description` ("DEPRECATED: Use read_text_file instead."). What's missing is a *programmatic* signal an MCP client can detect without parsing English from the description.

**Fix**: add the SDK-supported `_meta` slot to the `registerTool` config:

```ts
_meta: { deprecated: true, replacement: "read_text_file" }
```

The SDK already exposes `_meta?: Record<string, unknown>` in the `registerTool` config object (`@modelcontextprotocol/sdk@^1.26.0`, [`server/mcp.d.ts`](https://github.com/modelcontextprotocol/typescript-sdk) line ~156), so this is purely additive — no SDK upgrade required, no spec deviation. Clients that ignore `_meta` see no change; clients that opt in get a stable, parseable signal.

### F-008 — `read_media_file` description missing when-to-use + MIME fallback
**Default severity**: Info ([`DISC-003` / `DISC-004`](https://github.com/yakuphanycl/wrg-skills/blob/main/skills/mcp-audit/SEVERITY.md))

The current two-line description tells *what* the tool does but not *when* an agent should reach for it instead of `read_text_file`, and silently elides the `application/octet-stream` fallback for unknown extensions.

**Fix**: rewrite description to add (a) when-to-use guidance — binary content (PNG/JPEG/GIF/WebP/BMP/SVG/MP3/WAV/OGG/FLAC); for plain text use `read_text_file` because base64 encoding inflates text payloads ~33% with no benefit — and (b) the MIME-fallback note (unknown extensions return as a generic `blob` with `application/octet-stream`).

Description-only edit. The handler block (lines 267-298 in current source) is untouched.

## Why batched

Per [disclosure-sop §2](https://github.com/yakuphanycl/wrg-skills/blob/main/docs/disclosure-sop.md#2-decision-tree), Info-severity findings (documentation, discoverability, metadata) are batched into one PR per upstream repo. Scattering 2 separate issues for non-functional improvements is unfriendly to maintainers.

## Diff

7 insertions, 2 deletions in `src/filesystem/index.ts`. No new files, no new dependencies, no behavioural change.

## Test plan

- [x] Edits are mechanically safe: `_meta` is part of the SDK's `registerTool` config interface; description change is a pure string concat.
- [x] `read_media_file` handler block (lines 267-298) untouched — only the registration metadata above it changes.
- [x] Branch built off `upstream/main` at commit `4503e2d`.
- [ ] Maintainer review of description wording.

## Reference

Audit case-study (pending publication on the auditor's side): `wrg-skills/docs/case-studies/filesystem-mcp-2026-04-26.md`. This PR is independent of the case-study landing — the canonical evidence is the diff itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)