### PR TITLE
fix+docs(git): consistent error idiom for git_branch + expanded tool descriptions

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -282,7 +282,10 @@ def git_branch(repo: git.Repo, branch_type: str, contains: str | None = None, no
         case 'all':
             b_type = "-a"
         case _:
-            return f"Invalid branch type: {branch_type}"
+            # Surface invalid input via exception, consistent with the rest
+            # of this module (git_diff, git_checkout, git_show, git_create_branch,
+            # git_log all raise on invalid input rather than returning a string).
+            raise ValueError(f"Invalid branch type: '{branch_type}' - must be 'local', 'remote', or 'all'")
 
     # None value will be auto deleted by GitPython
     branch_info = repo.git.branch(b_type, *contains_sha, *not_contains_sha)
@@ -308,7 +311,11 @@ async def serve(repository: Path | None) -> None:
         return [
             Tool(
                 name=GitTools.STATUS,
-                description="Shows the working tree status",
+                description=(
+                    "Show the working tree status (modified, staged, and untracked files). "
+                    "Use before staging or committing to see what has changed. "
+                    "Returns the git status output as text."
+                ),
                 inputSchema=GitStatus.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -319,7 +326,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.DIFF_UNSTAGED,
-                description="Shows changes in the working directory that are not yet staged",
+                description=(
+                    "Show changes in the working directory that are not yet staged. "
+                    "Use to review modifications before running git_add. "
+                    "Returns a unified diff as text (empty string if there are no unstaged changes)."
+                ),
                 inputSchema=GitDiffUnstaged.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -330,7 +341,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.DIFF_STAGED,
-                description="Shows changes that are staged for commit",
+                description=(
+                    "Show changes that are staged for commit. "
+                    "Use to review what git_commit would record before committing. "
+                    "Returns a unified diff as text (empty string if nothing is staged)."
+                ),
                 inputSchema=GitDiffStaged.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -341,7 +356,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.DIFF,
-                description="Shows differences between branches or commits",
+                description=(
+                    "Show differences between the working tree and a target ref (branch, tag, or commit hash). "
+                    "Use to compare the current state against another branch or a specific commit. "
+                    "Returns a unified diff as text. Refs starting with '-' are rejected (flag-injection guard)."
+                ),
                 inputSchema=GitDiff.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -352,7 +371,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.COMMIT,
-                description="Records changes to the repository",
+                description=(
+                    "Record currently staged changes as a new commit with the given message. "
+                    "Use after git_add to finalise a snapshot. "
+                    "Returns a confirmation string including the new commit hash."
+                ),
                 inputSchema=GitCommit.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
@@ -363,7 +386,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.ADD,
-                description="Adds file contents to the staging area",
+                description=(
+                    "Stage file contents from the working directory for the next commit. "
+                    "Pass [\".\"] to stage everything, or specific paths to stage individual files. "
+                    "Use before git_commit. Returns a confirmation that files were staged."
+                ),
                 inputSchema=GitAdd.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
@@ -374,7 +401,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.RESET,
-                description="Unstages all staged changes",
+                description=(
+                    "Unstage all currently staged changes (working-tree files are left untouched). "
+                    "Use to undo a git_add before committing. "
+                    "Returns a confirmation that staging was reset."
+                ),
                 inputSchema=GitReset.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
@@ -385,7 +416,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.LOG,
-                description="Shows the commit logs",
+                description=(
+                    "List recent commits, optionally filtered by date range. "
+                    "Use to inspect history, find recent activity, or scope commits to a time window. "
+                    "Returns a list of commit entries each containing hash, author, date, and message."
+                ),
                 inputSchema=GitLog.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -396,7 +431,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.CREATE_BRANCH,
-                description="Creates a new branch from an optional base branch",
+                description=(
+                    "Create a new branch from an optional base branch (defaults to the currently checked-out branch). "
+                    "Use to start work on a new feature without checking out the new branch immediately. "
+                    "Returns a confirmation including the source branch name."
+                ),
                 inputSchema=GitCreateBranch.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
@@ -407,7 +446,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.CHECKOUT,
-                description="Switches branches",
+                description=(
+                    "Switch the working tree to an existing branch by name. "
+                    "Use to move between in-progress work on different branches. "
+                    "Returns a confirmation of the now-active branch. Branch names starting with '-' are rejected."
+                ),
                 inputSchema=GitCheckout.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=False,
@@ -418,7 +461,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.SHOW,
-                description="Shows the contents of a commit",
+                description=(
+                    "Show the contents of a specific commit (header metadata plus per-file diffs against the parent). "
+                    "Use to inspect a single commit in depth, e.g. to understand what a hash introduced. "
+                    "Returns the commit header followed by unified diffs as text. Revisions starting with '-' are rejected."
+                ),
                 inputSchema=GitShow.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -429,7 +476,11 @@ async def serve(repository: Path | None) -> None:
             ),
             Tool(
                 name=GitTools.BRANCH,
-                description="List Git branches",
+                description=(
+                    "List git branches scoped to local, remote, or all, optionally filtered by which commit they "
+                    "(do not) contain. Use to enumerate branches matching a specific commit or to inspect remote "
+                    "branches. Returns the branch list as text."
+                ),
                 inputSchema=GitBranch.model_json_schema(),
                 annotations=ToolAnnotations(
                     readOnlyHint=True,

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -482,3 +482,13 @@ def test_git_branch_rejects_contains_flag_injection(test_repository):
 
     with pytest.raises(BadName):
         git_branch(test_repository, "local", not_contains="--exec=evil")
+
+
+def test_git_branch_rejects_invalid_branch_type(test_repository):
+    """git_branch should raise ValueError for invalid branch_type values, consistent
+    with how the other helpers in this module surface invalid input (raise rather
+    than return an in-band error string)."""
+    with pytest.raises(ValueError) as exc_info:
+        git_branch(test_repository, "invalid-type")
+    assert "Invalid branch type" in str(exc_info.value)
+    assert "'invalid-type'" in str(exc_info.value)


### PR DESCRIPTION
## Summary

External MCP audit of `src/git/` (using the [`mcp-audit` skill](https://github.com/yakuphanycl/wrg-skills/tree/main/skills/mcp-audit)) surfaced one Low and one Info finding. Batched into a single PR per the audit's [disclosure SOP §2](https://github.com/yakuphanycl/wrg-skills/blob/main/docs/disclosure-sop.md#2-decision-tree).

No behavioural change to any tool dispatch path, no schema change, no new dependencies. The mutation tool gating (`--repository` + `validate_repo_path`), flag-injection guards, and security tests are untouched.

## Findings addressed

### F-001 — `git_branch` error idiom inconsistent with peers (Low)
**Severity rubric**: [`ERR-002`](https://github.com/yakuphanycl/wrg-skills/blob/main/skills/mcp-audit/SEVERITY.md) — mixed `raise` vs in-band string across surface.

`git_branch` returned `f\"Invalid branch type: {branch_type}\"` (a normal-looking string) on invalid input, while every other helper in the module raises (`git_diff`, `git_checkout`, `git_show`, `git_create_branch`, `git_log` all use `raise BadName/ValueError`). The string return reaches the MCP client masquerading as a successful tool result.

**Fix**: change to `raise ValueError(...)` with a message that names the valid options (`'local'`, `'remote'`, `'all'`). Added `test_git_branch_rejects_invalid_branch_type` in the same style as the existing flag-injection guard tests.

### F-003 — In-code Tool() descriptions lack when-to-use + return-shape (Info, surface-wide)
**Severity rubric**: [`DISC-002`](https://github.com/yakuphanycl/wrg-skills/blob/main/skills/mcp-audit/SEVERITY.md) + [`DISC-004`](https://github.com/yakuphanycl/wrg-skills/blob/main/skills/mcp-audit/SEVERITY.md) — discoverability axis, applied surface-wide.

All 12 in-code descriptions in `@server.list_tools()` were concise WHAT-statements (e.g., \"Shows the working tree status\", \"Switches branches\"). The README has more detail, but agents reading the MCP tool surface only see the in-code description.

**Fix**: rewrote all 12 descriptions to follow a consistent shape:
- WHAT (preserved from the existing description)
- when-to-use (one short clause)
- return-shape hint (text / list of commit entries / unified diff / etc.)

For tools with flag-injection guards (`git_diff`, `git_checkout`, `git_show`), the description now mentions that refs starting with `-` are rejected — the existing safety guarantee is now discoverable from the tool surface, not only from reading the source.

## Findings deferred

### F-002 — No MCP-layer dispatch test (Low, deferred)
The existing tests exercise the helper functions (`git_status`, `git_commit`, …) directly. None round-trip through the `@server.call_tool()` dispatcher with `(name, arguments)` to verify the `match` cases and the `TextContent` wrapping. This is a real coverage gap, but adding async dispatch fixtures is a separate scope worth its own PR — flagged in the audit's next-session backlog rather than batched here.

## Test plan

- [x] All 12 helper tests still pass after description rewrites (descriptions are not asserted in tests, but ran the full suite locally).
- [x] New test `test_git_branch_rejects_invalid_branch_type` passes.
- [x] On Windows the existing test_repository fixture has a pre-existing `shutil.rmtree` flake (`PermissionError: WinError 32`); test bodies pass, only fixture teardown errors. Unrelated to this PR — Linux CI will be clean.
- [ ] Maintainer review of description wording — open to tightening if too verbose.

## Audit reference

- Severity rubric and disclosure SOP applied: [`yakuphanycl/wrg-skills`](https://github.com/yakuphanycl/wrg-skills/tree/main/skills/mcp-audit)
- Audit case-study (pending publication on the auditor's side): `wrg-skills/docs/case-studies/git-mcp-2026-04-26.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)