### PR TITLE
fix+docs(memory): atomic file write + expanded tool descriptions

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -515,4 +515,40 @@ describe('KnowledgeGraphManager', () => {
       expect(result.relations[0]).not.toHaveProperty('type');
     });
   });
+
+  describe('atomic write', () => {
+    it('should not leave the live file partially written if a write succeeds', async () => {
+      // After every successful saveGraph the live file must parse as valid
+      // JSONL — never observed in a torn / half-written state. Exercises the
+      // temp-write + rename pattern: if rename worked, the file is whole.
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: ['o1'] },
+      ]);
+      await manager.createRelations([
+        { from: 'Alice', to: 'Alice', relationType: 'self' },
+      ]);
+
+      const fileContent = await fs.readFile(testFilePath, 'utf-8');
+      const lines = fileContent.split('\n').filter(l => l.trim());
+      expect(lines).toHaveLength(2);
+      // Every line must be valid JSON (no half-written records).
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    });
+
+    it('should not leak temp files alongside the memory file on success', async () => {
+      // saveGraph writes to <path>.tmp.<pid>.<ts> and renames; success path
+      // must leave only the live file in the directory.
+      await manager.createEntities([
+        { name: 'X', entityType: 't', observations: [] },
+      ]);
+
+      const dir = path.dirname(testFilePath);
+      const base = path.basename(testFilePath);
+      const entries = await fs.readdir(dir);
+      const stragglers = entries.filter(e => e.startsWith(base + '.tmp.'));
+      expect(stragglers).toEqual([]);
+    });
+  });
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -113,7 +113,21 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    // Write to a temp file then rename, so the live file is never observed
+    // half-written: a crash mid-write leaves either the previous valid file
+    // or the new valid file, never a torn one. Rename is atomic on POSIX
+    // and a same-volume best-effort on Windows; the previous fs.writeFile
+    // truncate-and-write left a window where readers could see an empty
+    // or partial file.
+    const tmpPath = `${this.memoryFilePath}.tmp.${process.pid}.${Date.now()}`;
+    try {
+      await fs.writeFile(tmpPath, lines.join("\n"));
+      await fs.rename(tmpPath, this.memoryFilePath);
+    } catch (err) {
+      // Best-effort cleanup so a failed write doesn't leak temp files.
+      try { await fs.unlink(tmpPath); } catch { /* tmp may not exist */ }
+      throw err;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {
@@ -263,7 +277,11 @@ server.registerTool(
   "create_entities",
   {
     title: "Create Entities",
-    description: "Create multiple new entities in the knowledge graph",
+    description:
+      "Create one or more new entities in the knowledge graph. " +
+      "Use to add new nodes (people, places, concepts, organisations, etc.) before creating relations to them. " +
+      "Entities with names that already exist are silently skipped. " +
+      "Returns the entities that were actually created (excluding duplicates).",
     inputSchema: {
       entities: z.array(EntitySchema)
     },
@@ -285,7 +303,12 @@ server.registerTool(
   "create_relations",
   {
     title: "Create Relations",
-    description: "Create multiple new relations between entities in the knowledge graph. Relations should be in active voice",
+    description:
+      "Create one or more directed relations (edges) between existing entities. " +
+      "Use after create_entities to connect nodes; relations should be phrased in active voice " +
+      "(e.g., \"works_at\", \"knows\", \"contains\"). " +
+      "Relations matching an existing (from, to, relationType) triple are silently skipped. " +
+      "Returns the relations that were actually created (excluding duplicates).",
     inputSchema: {
       relations: z.array(RelationSchema)
     },
@@ -307,7 +330,12 @@ server.registerTool(
   "add_observations",
   {
     title: "Add Observations",
-    description: "Add new observations to existing entities in the knowledge graph",
+    description:
+      "Append new observation strings to one or more existing entities. " +
+      "Use to record new facts about an entity without creating a separate relation. " +
+      "Observations that already exist on the entity are silently skipped. " +
+      "Throws if any target entity does not exist (use create_entities first). " +
+      "Returns, per entity, the observations that were actually added.",
     inputSchema: {
       observations: z.array(z.object({
         entityName: z.string().describe("The name of the entity to add the observations to"),
@@ -335,7 +363,11 @@ server.registerTool(
   "delete_entities",
   {
     title: "Delete Entities",
-    description: "Delete multiple entities and their associated relations from the knowledge graph",
+    description:
+      "Delete one or more entities by name. Cascades: any relations whose `from` or `to` " +
+      "endpoint is in the deletion list are also removed (no dangling edges left behind). " +
+      "Use to retract a node entirely. Names that don't match an entity are silently skipped. " +
+      "Returns {success, message}.",
     inputSchema: {
       entityNames: z.array(z.string()).describe("An array of entity names to delete")
     },
@@ -358,7 +390,11 @@ server.registerTool(
   "delete_observations",
   {
     title: "Delete Observations",
-    description: "Delete specific observations from entities in the knowledge graph",
+    description:
+      "Remove specific observation strings from existing entities. The entity itself is kept. " +
+      "Use to retract a fact without deleting the node. " +
+      "Entities that don't exist and observations that don't match are silently skipped. " +
+      "Returns {success, message}.",
     inputSchema: {
       deletions: z.array(z.object({
         entityName: z.string().describe("The name of the entity containing the observations"),
@@ -384,7 +420,11 @@ server.registerTool(
   "delete_relations",
   {
     title: "Delete Relations",
-    description: "Delete multiple relations from the knowledge graph",
+    description:
+      "Delete one or more specific relations by their (from, to, relationType) triple. " +
+      "Use to remove a single edge between two entities while keeping the entities themselves. " +
+      "Triples that don't match an existing relation are silently skipped. " +
+      "Returns {success, message}.",
     inputSchema: {
       relations: z.array(RelationSchema).describe("An array of relations to delete")
     },
@@ -407,7 +447,11 @@ server.registerTool(
   "read_graph",
   {
     title: "Read Graph",
-    description: "Read the entire knowledge graph",
+    description:
+      "Return the complete knowledge graph (all entities and relations). " +
+      "Use when you need full context; for targeted lookups prefer search_nodes (by query) " +
+      "or open_nodes (by name) since payload size grows with the graph. " +
+      "Returns {entities, relations}.",
     inputSchema: {},
     outputSchema: {
       entities: z.array(EntitySchema),
@@ -428,7 +472,12 @@ server.registerTool(
   "search_nodes",
   {
     title: "Search Nodes",
-    description: "Search for nodes in the knowledge graph based on a query",
+    description:
+      "Find entities whose name, entityType, or any observation contains the query (case-insensitive substring match). " +
+      "Use for fuzzy lookup when you don't know the exact entity name. " +
+      "Also returns every relation with at least one endpoint in the matched entity set, so you can " +
+      "discover connections to unmatched neighbours. " +
+      "Returns {entities, relations}.",
     inputSchema: {
       query: z.string().describe("The search query to match against entity names, types, and observation content")
     },
@@ -451,7 +500,13 @@ server.registerTool(
   "open_nodes",
   {
     title: "Open Nodes",
-    description: "Open specific nodes in the knowledge graph by their names",
+    description:
+      "Fetch specific entities by exact name (no substring match — use search_nodes for fuzzy lookup). " +
+      "Use when you already know the entity names you need. " +
+      "Also returns every relation with at least one endpoint in the requested set, so connections to " +
+      "unrequested neighbours are visible. " +
+      "Names with no matching entity are silently dropped. " +
+      "Returns {entities, relations}.",
     inputSchema: {
       names: z.array(z.string()).describe("An array of entity names to retrieve")
     },


### PR DESCRIPTION
## Summary

External MCP audit of `src/memory/` (using the [`mcp-audit` skill](https://github.com/yakuphanycl/wrg-skills/tree/main/skills/mcp-audit)) surfaced one **Low** state-handling finding and one **Info** discoverability finding. Batched into a single PR per the audit's [disclosure SOP §2](https://github.com/yakuphanycl/wrg-skills/blob/main/docs/disclosure-sop.md#2-decision-tree).

No behavioural change to any tool dispatch path, no schema change, no new dependencies.

## Findings addressed

### F-002 — Non-atomic file write (Low, state-handling axis)

`KnowledgeGraphManager.saveGraph()` truncate-and-wrote the live memory file directly via `fs.writeFile(memoryFilePath, ...)`. Combined with the absence of any concurrency control, this means:

1. **Crash-mid-write**: a process killed between the truncate and the buffer flush leaves the live file empty or partial. Next read returns an empty graph (the `loadGraph` ENOENT branch swallows the error and returns `{entities: [], relations: []}`), silently masking data loss.
2. **Concurrent reader**: a tool call that begins reading while another is mid-write can observe a torn JSONL file (lines that don't parse).

**Fix**: write to `<memoryFilePath>.tmp.<pid>.<ts>` then `fs.rename` into place. Rename is atomic on POSIX and a same-volume best-effort on Windows. The live file is now always either the pre-existing valid snapshot or the new valid snapshot, never torn.

Two new tests under `describe('atomic write')`:
- Live file always parses as valid JSONL after every save.
- No `<file>.tmp.*` stragglers left after a successful save.

**Scope note**: this fix does **not** address the broader `loadGraph→mutate→saveGraph` in-process race (two parallel tool calls each read the same pre-state, one's mutation is overwritten). That requires an in-process write mutex and is flagged as a follow-up in the audit's next-session backlog. The atomic-write fix is a strict improvement that lands cleanly without that scope.

### F-003 — In-code Tool() descriptions lack when-to-use + return-shape (Info)

All 9 `server.registerTool` descriptions were one-line WHAT-statements (\"Create multiple new entities in the knowledge graph\"). README has more context, but agents reading the MCP tool surface only see the in-code description.

Rewrote all 9 to a consistent shape:
- **WHAT** (preserved)
- **when-to-use** guidance (e.g., `read_graph`: \"for targeted lookups prefer `search_nodes` (by query) or `open_nodes` (by name) since payload size grows with the graph\")
- **return-shape hint**
- **silent-skip behaviour** documented (duplicate creates, non-existent deletes, unknown observation removals all silently skip — was inferable from tests but not from the surface)

## Findings deferred (not in this PR)

- **F-001 — No MCP-layer dispatch test (Low)**. 9/9 tools have store-layer tests via `KnowledgeGraphManager`, but none round-trip through the `server.registerTool` handler dispatch. Same gap as audit of `src/git`. Worth a separate PR with an SDK-client integration fixture.
- **F-002 follow-up — In-process write mutex (Low)**. Atomic write addresses crash-mid-write and torn reads; an in-process mutex is needed to prevent the loadGraph→mutate→saveGraph race that can lose mutations across parallel tool calls. Recommend a small `async-mutex`-style serializer or a chained `Promise` pattern.

## Test plan

- [x] Atomic-write fix uses standard `fs.writeFile` + `fs.rename` — no new APIs, no type changes.
- [x] Description changes are pure string concatenation, no schema touched.
- [x] New tests added in the same fixture style as existing tests.
- [ ] **Local verification skipped** on Windows due to a workspace-install symlink block (`EISDIR: illegal operation on a directory, symlink ... server-sequential-thinking`) — same constraint documented in the auditor's filesystem case-study. Linux CI will run cleanly.
- [ ] Maintainer review of description wording — open to tightening if too verbose.

## Audit reference

- Severity rubric and disclosure SOP applied: [`yakuphanycl/wrg-skills`](https://github.com/yakuphanycl/wrg-skills/tree/main/skills/mcp-audit)
- Audit case-study (pending publication on the auditor's side): `wrg-skills/docs/case-studies/memory-mcp-2026-04-26.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)