### PR TITLE
fix(puppeteer): return isError instead of internal error on navigation failure

### DIFF
--- a/src/puppeteer/index.ts
+++ b/src/puppeteer/index.ts
@@ -217,7 +217,17 @@ async function handleToolCall(name: string, args: any): Promise<CallToolResult> 
 
   switch (name) {
     case "puppeteer_navigate":
-      await page.goto(args.url);
+      try {
+        await page.goto(args.url);
+      } catch (error) {
+        return {
+          content: [{
+            type: "text",
+            text: `Navigation failed: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          isError: true,
+        };
+      }
       return {
         content: [{
           type: "text",


### PR DESCRIPTION
## Summary

`puppeteer_navigate` throws an unhandled CDP `Protocol error` when given an invalid or empty URL. The error propagates as a JSON-RPC `-32603` internal error, which prevents agents from detecting and recovering from the failure.

The fix wraps `page.goto()` in a try/catch and returns `isError: true` with the error message, matching the pattern already used by `puppeteer_screenshot` (which correctly catches missing selectors and returns `isError: true`).

## Reproduction

```bash
# Using mcp-assert (https://github.com/blackwell-systems/mcp-assert)
mcp-assert audit --server "npx @modelcontextprotocol/server-puppeteer"

# Result:
#   puppeteer_navigate    CRASH    internal error: Protocol error (Page.navigate): Cannot navigate to invalid URL
```

Manual reproduction: call `puppeteer_navigate` with `{"url": ""}` or `{"url": "not-a-url"}`.

**Expected**: `{ isError: true, content: [{ text: "Navigation failed: ..." }] }`
**Actual**: JSON-RPC `-32603` internal error (unhandled exception)

## Change

One-line change in `src/puppeteer/index.ts`: wrap the existing `page.goto(args.url)` call in a try/catch block that returns a structured `isError: true` response on failure.

Found with [mcp-assert](https://github.com/blackwell-systems/mcp-assert), a testing tool for MCP servers.