### PR TITLE
feat(fetch): use HTTP content negotiation to request native markdown

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -24,6 +24,12 @@ The fetch tool will truncate the response, but by using the `start_index` argume
   - Arguments:
     - `url` (string, required): URL to fetch
 
+### Content negotiation
+
+The fetch tool sends an `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` request header, asking servers for native markdown when they support it. If the server responds with `Content-Type: text/markdown` (with or without a charset parameter), the response body is returned as-is and the HTML-to-markdown extraction step is skipped. Otherwise the existing readability + markdownify pipeline runs as before.
+
+This benefits sites that serve markdown directly via content negotiation — for example, Cloudflare-hosted sites with the [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) feature enabled (the linked documentation page is itself such a site), content-negotiating CMSes, and raw-content endpoints. Servers that don't recognise the Accept header simply respond with whatever they normally would, so the change is fully backwards-compatible.
+
 ## Installation
 
 Optionally: Install node.js, this will cause the fetch server to use a different HTML simplifier that is more robust.

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -121,7 +121,10 @@ async def fetch_url(
             response = await client.get(
                 url,
                 follow_redirects=True,
-                headers={"User-Agent": user_agent},
+                headers={
+                    "User-Agent": user_agent,
+                    "Accept": "text/markdown, text/html;q=0.9, */*;q=0.8",
+                },
                 timeout=30,
             )
         except HTTPError as e:
@@ -135,6 +138,11 @@ async def fetch_url(
         page_raw = response.text
 
     content_type = response.headers.get("content-type", "")
+
+    # Server provided markdown directly via content negotiation; skip HTML extraction.
+    if content_type.split(";", 1)[0].strip().lower() == "text/markdown":
+        return page_raw, ""
+
     is_page_html = (
         "<html" in page_raw[:100] or "text/html" in content_type or not content_type
     )

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -324,3 +324,102 @@ class TestFetchUrl:
 
             # Verify AsyncClient was called with proxy
             mock_client_class.assert_called_once_with(proxy="http://proxy.example.com:8080")
+
+    @pytest.mark.asyncio
+    async def test_fetch_markdown_returns_early(self):
+        """Test that text/markdown responses skip HTML extraction and return body as-is."""
+        md_content = "# Hello World\n\nThis is markdown."
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = md_content
+        mock_response.headers = {"content-type": "text/markdown"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            content, prefix = await fetch_url(
+                "https://example.com/readme.md",
+                DEFAULT_USER_AGENT_AUTONOMOUS
+            )
+
+            assert content == md_content
+            assert prefix == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_markdown_with_charset(self):
+        """Test that text/markdown with a charset parameter is recognised as markdown."""
+        md_content = "# Title\n\nBody."
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = md_content
+        mock_response.headers = {"content-type": "text/markdown; charset=utf-8"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            content, prefix = await fetch_url(
+                "https://example.com/page.md",
+                DEFAULT_USER_AGENT_AUTONOMOUS
+            )
+
+            assert content == md_content
+            assert prefix == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_x_markdown_does_not_match(self):
+        """Test that non-standard text/x-markdown is NOT treated as markdown and falls through."""
+        body = "some non-standard markdown variant"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = body
+        mock_response.headers = {"content-type": "text/x-markdown"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            content, prefix = await fetch_url(
+                "https://example.com/page",
+                DEFAULT_USER_AGENT_AUTONOMOUS
+            )
+
+            # text/x-markdown is neither text/html nor text/markdown, so it falls
+            # into the raw-fallback branch with the "cannot be simplified" prefix.
+            # This pins the contract: only the standard text/markdown media type
+            # triggers the native-markdown short-circuit.
+            assert content == body
+            assert "cannot be simplified" in prefix
+
+    @pytest.mark.asyncio
+    async def test_fetch_sends_accept_header(self):
+        """Test that fetch_url sends an Accept header advertising markdown preference."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "# md"
+        mock_response.headers = {"content-type": "text/markdown"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await fetch_url(
+                "https://example.com/page",
+                DEFAULT_USER_AGENT_AUTONOMOUS
+            )
+
+            call_kwargs = mock_client.get.call_args.kwargs
+            assert "Accept" in call_kwargs["headers"]
+            accept = call_kwargs["headers"]["Accept"]
+            assert "text/markdown" in accept
+            # Markdown should be preferred over HTML — appear earlier in the q-list.
+            assert accept.index("text/markdown") < accept.index("text/html")


### PR DESCRIPTION
Send `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` with each fetch request and pass the body through unchanged when the server responds with `Content-Type: text/markdown`.

## Description

Adds detection of servers that implement `text/markdown`, fast-track  getting the Markdown content they send natively.

Fully backwards compatible. No change to processing from servers that don't send Markdown.

`fetch_url` now advertises a Markdown preference via the `Accept` header. When the server respond with `Content-Type: text/markdown` (with or without a charset parameter), the body is returned as-is, skipping the readability + markdownify pipeline. Anything else falls through to the existing extraction unchanged.

Strict media-type matching: only `text/markdown` triggers the short-circuit. `text/markdown; charset=utf-8` qualifies; non-standard variants like `text/x-markdown` do not. There's a test pinning this contract.

## Server Details

- Server: fetch
- Changes to: tools (the `fetch` tool's underlying request and response handling)

## Motivation and Context

Some servers can deliver native Markdown directly — Cloudflare zones with [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) enabled, content-negotiating CMSes, raw-content endpoints, and so on. Today `mcp-server-fetch` ignores that and runs every response through readability + markdownify, which is lossy and unnecessary when the server is already offering Markdown.

Cloudflare's own measurements report ~80% token reduction compared to the equivalent HTML — their docs blog post is 16,180 tokens as HTML vs 3,150 tokens as Markdown. Even outside the Cloudflare case, any site that already speaks `text/markdown` benefits from the body being passed through unmodified rather than round-tripped through HTML extraction.

`Accept` is a hint: servers that don't perform content negotiation simply respond with whatever they always would, so the change is fully backwards-compatible.

## How Has This Been Tested?

**Unit tests** — existing `TestFetchUrl` tests pass unchanged. Four new tests appended:

- `test_fetch_markdown_returns_early` — `text/markdown` body returned as-is, no extraction, empty prefix.
- `test_fetch_markdown_with_charset` — `text/markdown; charset=utf-8` qualifies.
- `test_fetch_x_markdown_does_not_match` — `text/x-markdown` falls through to the raw-fallback branch (pins the strict-matching contract).
- `test_fetch_sends_accept_header` — verifies the Accept header is sent and that markdown is preferred over HTML in the q-list.

**MCP Inspector** — `npx @modelcontextprotocol/inspector uv run mcp-server-fetch`. Verified two scenarios:

1. Fast-path: `https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/` (a Markdown-for-Agents-enabled origin) returns native markdown directly. Same URL without the Accept header serves HTML — easy to confirm with `curl -sI`.
2. Existing path unchanged: `https://example.com/` flows through readability + markdownify and produces the expected structured markdown.

**LLM client** — patched `mcp-server-fetch` installed in Claude Desktop, exercised against both URLs above. Fast-path returns clean markdown with a YAML frontmatter (Cloudflare's edge-converted output); readability path returns the existing structured extraction.

## Breaking Changes

None. The change is fully backwards-compatible — servers that don't perform content negotiation ignore the `Accept` header and respond as they always would. Users do not need to update MCP client configurations.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [N/A] I have added appropriate error handling
- [N/A] I have documented all environment variables and configuration options

(Note on the last two: no new error paths or environment/configuration options are introduced — the fast-path inherits the existing GET call's error handling, and the only added logic is a Content-Type string match.)

## Additional context

Cloudflare's [Markdown for Agents documentation page](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) is itself served from a Markdown-for-Agents-enabled origin, so it works as a live test target:

```
$ curl -sI -H "Accept: text/markdown" \
    https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/ \
    | grep -i content-type
content-type: text/markdown; charset=utf-8

$ curl -sI \
    https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/ \
    | grep -i content-type
content-type: text/html; charset=utf-8
```

Same URL, two different Content-Types depending on the Accept header.

The `raw=True` flag is unaffected: when a server returns `text/markdown`, the fast-path returns the raw body (which is what `raw=True` would also produce); when a server returns HTML, `raw=True` continues to short-circuit to the raw HTML branch as before.
