### PR TITLE
Add lanforge-mcp to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Additional resources on MCP.
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.
 - **[Webrix MCP Gateway](https://github.com/webrix-ai/secure-mcp-gateway)** - Enterprise MCP gateway with SSO, RBAC, audit trails, and token vaults for secure, centralized AI agent access control. Deploy via Helm charts on-premise or in your cloud. [webrix.ai](https://webrix.ai)
+- **[lanforge-mcp](https://github.com/machapraveen/lanforge-mcp)** - Drive Candela Technologies' LANforge Wi-Fi test platform conversationally via its JSON-over-HTTP API. Six tools, mock-mode default, no LLM dependency.
 
 
 


### PR DESCRIPTION
**What:** Adds lanforge-mcp — a community MCP server wrapping Candela Technologies' LANforge Wi-Fi test platform — to the Community Servers list.

**Why it might fit:** LANforge is one of the major Wi-Fi/network test platforms in the industry, and to my knowledge no MCP server existed for any test-automation tool. This fills a genuine gap for network/test-engineering use cases.

**Project state:**
- Public, MIT-licensed
- 6 tools, 2 resources, 1 prompt template
- mock-mode default (runs without hardware)
- mypy --strict, 88% test coverage
- Live demo: https://machapraveen.github.io/lanforge-mcp/

Happy to adjust placement, wording, or category as the maintainers see fit.