### PR TITLE
Add SYD by Celerya MCP server to community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Additional resources on MCP.
 - **[MCP.ing](https://mcp.ing/)** - A list of MCP services for discovering MCP servers in the community and providing a convenient search function for MCP services by **[iiiusky](https://github.com/iiiusky)**
 - **[MCP Hunt](https://mcp-hunt.com)** - Realtime platform for discovering trending MCP servers with momentum tracking, upvoting, and community discussions - like Product Hunt meets Reddit for MCP
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
+- SYD by Celerya — Query food-supply-chain batches and Digital Twins from SYD via natural language. NPM: @celerya/mcp-server. Public sandbox available with key sk_test_demo.
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Additional resources on MCP.
 - **[MCP.ing](https://mcp.ing/)** - A list of MCP services for discovering MCP servers in the community and providing a convenient search function for MCP services by **[iiiusky](https://github.com/iiiusky)**
 - **[MCP Hunt](https://mcp-hunt.com)** - Realtime platform for discovering trending MCP servers with momentum tracking, upvoting, and community discussions - like Product Hunt meets Reddit for MCP
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
-- SYD by Celerya — Query food-supply-chain batches and Digital Twins from SYD via natural language. NPM: @celerya/mcp-server. Public sandbox available with key sk_test_demo.
+- **[SYD by Celerya](https://github.com/pyzack/mcp-server)** - Query food-supply-chain batches and Digital Twins via natural language. NPM: `@celerya/mcp-server`. Public sandbox available with key `sk_test_demo`. — Query food-supply-chain batches and Digital Twins from SYD via natural language. NPM: @celerya/mcp-server. Public sandbox available with key sk_test_demo.
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.


### PR DESCRIPTION
Adds SYD by Celerya MCP server to the community list in README.

- NPM package: @celerya/mcp-server
- Repo: https://github.com/pyzack/mcp-server
- Purpose: query food-supply-chain batches and Digital Twins from SYD via natural language
- Public sandbox available with key sk_test_demo for evaluation

Made with [Cursor](https://cursor.com)