### PR TITLE
docs: add Agent Skills Hub to Resources directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 Additional resources on MCP.
 
 - **[A2A-MCP Java Bridge](https://github.com/vishalmysore/a2ajava)** - A2AJava brings powerful A2A-MCP integration directly into your Java applications. It enables developers to annotate standard Java methods and instantly expose them as MCP Server, A2A-discoverable actions — with no boilerplate or service registration overhead.
+- **[Agent Skills Hub](https://agentskillshub.top)** - Searchable directory of 67,000+ MCP servers, Claude Skills, and agent tools indexed from GitHub, quality-scored on 10 dimensions and refreshed every 8 hours by **[Jason Zhu](https://github.com/zhuyansen)**
 - **[AiMCP](https://www.aimcp.info)** - A collection of MCP clients&servers to find the right mcp tools by **[Hekmon](https://github.com/hekmon8)**
 - **[Awesome Crypto MCP Servers by badkk](https://github.com/badkk/awesome-crypto-mcp-servers)** - A curated list of MCP servers by **[Luke Fan](https://github.com/badkk)**
 - **[Awesome MCP Servers by appcypher](https://github.com/appcypher/awesome-mcp-servers)** - A curated list of MCP servers by **[Stephen Akinyemi](https://github.com/appcypher)**


### PR DESCRIPTION
## Summary
Adds [Agent Skills Hub](https://agentskillshub.top) to the Resources section as a third-party directory of MCP servers + Claude Skills + agent tools.

## Why this fits
The Resources section already lists peer directories (MCPHub, MCPServers.com, Smithery, mcp.run, PulseMCP, OpenTools, etc.). Agent Skills Hub serves a complementary slice:

- **Indexes 67,000+ open-source projects** from GitHub (vs. the curated awesome-* lists)
- **Quality-scored on 10 dimensions** (completeness / clarity / specificity / examples / readme structure / agent readiness, plus 4 community signals) — methodology open-source at [github.com/zhuyansen/agent-skills-hub](https://github.com/zhuyansen/agent-skills-hub/blob/main/backend/app/services/quality_analyzer.py)
- **Refreshed every 8 hours** via GitHub Actions sync
- **Free + open source** (CC BY-NC-SA on data, MIT on code)

## Compliance check
- [x] Read CONTRIBUTING.md — community resources/directories are permitted in this section
- [x] Alphabetical placement (between A2A-MCP Java Bridge and AiMCP)
- [x] Format matches existing entries (bold link + " - " separator + descriptor + maintainer link)
- [x] Not a "new server implementation" (per CONTRIBUTING, those go to MCP Registry)

Happy to adjust formatting / wording per maintainer preference.