### PR TITLE
docs: explain how MCP servers actually launch (stdio vs SSE, Inspector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,27 @@ python -m mcp_server_git
 
 Follow [these](https://docs.astral.sh/uv/getting-started/installation/) instructions to install `uv` / `uvx` and [these](https://pip.pypa.io/en/stable/installation/) to install `pip`.
 
+### Understanding How Servers Are Launched
+
+MCP servers communicate over **stdio** (stdin/stdout) by default. If you run a server like `uvx mcp-server-git` directly in your terminal, it will appear to hang — it is waiting for a client to connect over stdin and send JSON-RPC messages. This is expected behaviour, not a bug.
+
+**You do not run MCP servers yourself.** Your MCP client (Claude Desktop, VS Code, Cursor, etc.) reads its config file and spawns the server process automatically. The client and server communicate over the spawned process's stdin/stdout. When you close the client, the server process stops.
+
+**Two transport modes:**
+
+| Transport | How the server runs | When to use |
+|---|---|---|
+| **stdio** (default) | Client spawns the server as a subprocess; communication is over stdin/stdout | Local servers — all reference servers in this repo |
+| **SSE / HTTP** | Server runs as a standalone HTTP service; client connects over a network URL | Remote or shared servers |
+
+**Testing a server without a full client setup:** use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```sh
+npx @modelcontextprotocol/inspector uvx mcp-server-git
+```
+
+The Inspector opens a browser UI that lets you browse available tools, invoke them, and inspect responses — no LLM or client configuration required. It is the recommended way to verify a server works before wiring it into a client.
+
 ### Using an MCP Client
 However, running a server on its own isn't very useful, and should instead be configured into an MCP client. For example, here's the Claude Desktop configuration to use the above server:
 


### PR DESCRIPTION
## Summary

Closes #521 — addresses the recurring confusion around running MCP servers.

- Adds a **"Understanding How Servers Are Launched"** subsection inside Getting Started, between the standalone `npx`/`uvx` examples and the client config section
- Explains that stdio servers block on stdin by design — running one directly in a terminal will look like a hang, which is expected
- Clarifies that **the MCP client spawns the server**; the config file is the trigger, not a manual `uvx` command
- Adds a two-row table contrasting stdio vs SSE/HTTP transport so readers can see at a glance which mode applies to them
- Points to the MCP Inspector (`npx @modelcontextprotocol/inspector uvx mcp-server-git`) as the recommended way to test a server locally without wiring up a full client

No existing content changed. The new subsection slots in cleanly between the two existing subsections.

## Test plan

- [ ] Read the new subsection — confirm it answers the three questions in #521 (why the server appears to hang, who actually spawns the process, how to test without a full client)
- [ ] Verify the Inspector command renders correctly in GitHub markdown
- [ ] Confirm the table renders in GitHub markdown preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)