### PR TITLE
feat(filesystem): add Resources and Prompts

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -10,6 +10,8 @@ Node.js server implementing Model Context Protocol (MCP) for filesystem operatio
 - Search files
 - Get file metadata
 - Dynamic directory access control via [Roots](https://modelcontextprotocol.io/docs/learn/client-concepts#roots)
+- Expose allowed directories and files as MCP Resources
+- Built-in prompt for file review
 
 ## Directory Access Control
 
@@ -203,6 +205,28 @@ The mapping for filesystem tools is:
 | `move_file`                 | `false`      | `false`        | `true`          | Deletes source file                             |
 
 > Note: `idempotentHint` and `destructiveHint` are meaningful only when `readOnlyHint` is `false`, as defined by the MCP spec.
+
+### Resources
+
+- **filesystem://allowed-directories**
+  - Returns the list of directories the server is currently allowed to access
+  - No arguments required
+  - Returns a plain text list with one directory per line
+  - Reflects the live state of allowed directories, whether set via command-line arguments or updated at runtime via MCP Roots
+
+- **file://{path}**
+  - Reads a file within the allowed directories and returns its contents as a resource
+  - URI format: `file:///absolute/path/to/file`
+  - Returns the file contents as plain text
+  - The path is validated against allowed directories before the file is read
+
+### Prompts
+
+- **read-file**
+  - Asks the model to read a file and summarize its contents
+  - Arguments:
+    - `path` (string): Absolute path to the file
+  - Returns a user message that instructs the model to read and summarize the file at the given path
 
 ## Usage with Claude Desktop
 Add this to your `claude_desktop_config.json`:

--- a/src/filesystem/__tests__/prompts.test.ts
+++ b/src/filesystem/__tests__/prompts.test.ts
@@ -1,0 +1,11 @@
+import { it, expect, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerPrompts } from '../prompts.js';
+
+it('registers read-file prompt with path in message', () => {
+  const s = { registerPrompt: vi.fn() } as unknown as McpServer;
+  registerPrompts(s);
+  const [name,, handler] = (s.registerPrompt as any).mock.calls[0];
+  expect(name).toBe('read-file');
+  expect(handler({ path: '/a/b.txt' }).messages[0].content.text).toContain('/a/b.txt');
+});

--- a/src/filesystem/__tests__/resources.test.ts
+++ b/src/filesystem/__tests__/resources.test.ts
@@ -1,0 +1,20 @@
+import { it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { mkdtempSync, rmSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { setAllowedDirectories } from '../lib.js';
+import { registerResources } from '../resources.js';
+
+let dir: string;
+beforeEach(() => { dir = realpathSync(mkdtempSync(join(tmpdir(), 'mcp-fs-'))); setAllowedDirectories([dir]); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); setAllowedDirectories([]); });
+
+it('registers allowed-directories and file resources', () => {
+  const s = { registerResource: vi.fn() } as unknown as McpServer;
+  registerResources(s);
+  const calls = (s.registerResource as any).mock.calls;
+  expect(calls).toHaveLength(2);
+  expect(calls.map((c: any) => c[0])).toEqual(expect.arrayContaining(['allowed-directories', 'file']));
+  expect(calls.find((c: any) => c[0] === 'file')[1]).toBeInstanceOf(ResourceTemplate);
+});

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -27,6 +27,8 @@ import {
   headFile,
   setAllowedDirectories,
 } from './lib.js';
+import { registerResources } from './resources.js';
+import { registerPrompts } from './prompts.js';
 
 // Command line argument parsing
 const args = process.argv.slice(2);
@@ -701,6 +703,9 @@ server.registerTool(
     };
   }
 );
+
+registerResources(server);
+registerPrompts(server);
 
 // Updates allowed directories based on MCP client roots
 async function updateAllowedDirectoriesFromRoots(requestedRoots: Root[]) {

--- a/src/filesystem/prompts.ts
+++ b/src/filesystem/prompts.ts
@@ -1,0 +1,8 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export const registerPrompts = (server: McpServer): void => {
+  server.registerPrompt("read-file",
+    { title: "Read File", description: "Read a file for review.", argsSchema: { path: z.string().describe("Absolute file path") } },
+    ({ path }) => ({ messages: [{ role: "user", content: { type: "text", text: `Read ${path} and summarize.` } }] }));
+};

--- a/src/filesystem/resources.ts
+++ b/src/filesystem/resources.ts
@@ -1,0 +1,14 @@
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { validatePath, readFileContent, getAllowedDirectories } from "./lib.js";
+
+export const registerResources = (server: McpServer): void => {
+  server.registerResource("allowed-directories", "filesystem://allowed-directories",
+    { title: "Allowed Directories", description: "Allowed access directories.", mimeType: "text/plain" },
+    async (uri) => ({ contents: [{ uri: uri.toString(), mimeType: "text/plain", text: getAllowedDirectories().join("\n") || "None configured" }] }));
+  server.registerResource("file", new ResourceTemplate("file://{path}", { list: undefined }),
+    { title: "File", description: "Read a file. URI: file:///path/to/file", mimeType: "text/plain" },
+    async (uri, v) => {
+      const validPath = await validatePath(String(v.path ?? ""));
+      return { contents: [{ uri: uri.toString(), mimeType: "text/plain", text: await readFileContent(validPath) }] };
+    });
+};


### PR DESCRIPTION
## Description

This PR adds Resources and Prompts to the filesystem reference server, which previously exposed only Tools. Per CONTRIBUTING.md, demonstrating underutilized protocol features (Resources, Prompts, Roots) on existing reference servers is explicitly encouraged. The filesystem server is also called out by name in CONTRIBUTING.md as a good vehicle for showcasing these features.

## Server Details

- Server: filesystem
- Changes to: resources, prompts, README

## What is added

**Resources**
- `filesystem://allowed-directories` (static) — exposes the live set of allowed directories. The content reflects whether directories were set via command-line arguments or updated dynamically through MCP Roots.
- `file://{path}` (template) — reads a file within the allowed directories and returns its contents as a resource. The path is validated against the allowed-directories list before the read, so the existing security boundary is preserved.

**Prompts**
- `read-file` — a simple prompt that asks the model to read and summarize a file at a given absolute path.

## Motivation and Context

- `allowed-directories` as a Resource is a natural fit: clients can subscribe to it and get a live, structured view of what the server can see, rather than calling a tool every time they want to check.
- `file://{path}` as a template lets clients reference files declaratively in conversation context, which is what Resources are designed for, complementing the existing `read_text_file` tool rather than duplicating it.
- `read-file` Prompt demonstrates the simplest useful prompt pattern: argument-driven, references a path, and pairs naturally with the tools and resources above.

## How Has This Been Tested?

- `npm run build` — clean
- `npm test` — 151 tests pass
- Tested with MCP Inspector v0.21.2 against the built server. Verified:
  - `resources/list` returns the static resource
  - `resources/templates/list` returns the file template
  - `resources/read` on `filesystem://allowed-directories` returns the configured directory
  - `prompts/list` returns `read-file`
- Tested end-to-end with Claude Desktop: server initializes cleanly, advertises `tools`, `resources`, and `prompts` capabilities, and responds correctly to `tools/list`, `resources/list`, `prompts/list`, and `resources/read`.


<img width="1510" height="857" alt="Screenshot 2026-05-03 at 15 29 33" src="https://github.com/user-attachments/assets/0232eba8-eb55-4982-8b33-8ee10d4230b5" />
<img width="1508" height="862" alt="Screenshot 2026-05-03 at 15 28 04" src="https://github.com/user-attachments/assets/5bd54735-48cc-4c11-83f3-0afd307fa6a5" />
<img width="1510" height="864" alt="Screenshot 2026-05-03 at 15 26 47" src="https://github.com/user-attachments/assets/b44891fe-e903-4026-808c-8141d6fd67b9" />

## Breaking Changes

None. This is a purely additive change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling