### PR TITLE
docs: Fix markdown formatting and file references #4096

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -113,7 +113,7 @@ npm run start:streamableHttp
 ### Install 
 ```shell
 npm install -g @modelcontextprotocol/server-everything@latest
-````
+```
 
 ### Run the default (stdio) server
 ```shell

--- a/src/everything/docs/features.md
+++ b/src/everything/docs/features.md
@@ -19,7 +19,7 @@
 - `get-structured-content` (tools/get-structured-content.ts): Demonstrates structured responses. Accepts `location` input and returns both backward‑compatible `content` (a `text` block containing JSON) and `structuredContent` validated by an `outputSchema` (temperature, conditions, humidity).
 - `get-sum` (tools/get-sum.ts): For two numbers `a` and `b` calculates and returns their sum. Uses Zod to validate inputs.
 - `get-tiny-image` (tools/get-tiny-image.ts): Returns a tiny PNG MCP logo as an `image` content item with brief descriptive text before and after.
-- `trigger-long-running-operation` (tools/trigger-trigger-long-running-operation.ts): Simulates a multi-step operation over a given `duration` and number of `steps`; reports progress via `notifications/progress` when a `progressToken` is provided by the client.
+- `trigger-long-running-operation` (tools/trigger-long-running-operation.ts): Simulates a multi-step operation over a given `duration` and number of `steps`; reports progress via `notifications/progress` when a `progressToken` is provided by the client.
 - `toggle-simulated-logging` (tools/toggle-simulated-logging.ts): Starts or stops simulated, random‑leveled logging for the invoking session. Respects the client’s selected minimum logging level.
 - `toggle-subscriber-updates` (tools/toggle-subscriber-updates.ts): Starts or stops simulated resource update notifications for URIs the invoking session has subscribed to.
 - `trigger-sampling-request` (tools/trigger-sampling-request.ts): Issues a `sampling/createMessage` request to the client/LLM using provided `prompt` and optional generation controls; returns the LLM's response payload.

--- a/src/everything/docs/startup.md
+++ b/src/everything/docs/startup.md
@@ -54,7 +54,7 @@
     - `prompts: {}`
     - `resources: { subscribe: true }`
   - **Server Instructions**
-    - Loaded from the docs folder (`server-instructions.md`).
+    - Loaded from the docs folder (`instructions.md`).
   - **Registrations**
     - Registers **tools** via `registerTools(server)`.
     - Registers **resources** via `registerResources(server)`.

--- a/src/everything/docs/structure.md
+++ b/src/everything/docs/structure.md
@@ -81,8 +81,10 @@ src/everything
 ### `docs/`
 
 - `architecture.md`
+  - Architectural overview.
+- `structure.md`
   - This document.
-- `server-instructions.md`
+- `instructions.md`
   - Human‑readable instructions intended to be passed to the client/LLM as for guidance on server use. Loaded by the server at startup and returned in the "initialize" exchange.
 
 ### `prompts/`


### PR DESCRIPTION
## Description
This pull request addresses several formatting and referential bugs found within the `Everything` MCP server documentation. 

These documentation errors were breaking the rendering of the `README.md` on GitHub/NPM and providing confusing or mislabeled file references to developers.

## Changes Made
1. **Broken Markdown Rendering in `README.md`**
   - **Fix:** Fixed a markdown syntax error in `src/everything/README.md` where an installation code block was closed with 4 backticks (\`\`\`\`) instead of 3 (\`\`\`), which was breaking the remainder of the markdown rendering on the page.

2. **Incorrect Tool Filename in `features.md`**
   - **Fix:** Corrected the typo for the long-running operation tool in `src/everything/docs/features.md`. Changed `tools/trigger-trigger-long-running-operation.ts` to `tools/trigger-long-running-operation.ts`.

3. **Mislabeled Instructions File (`startup.md` & `structure.md`)**
   - **Fix:** Updated references in `src/everything/docs/startup.md` and `src/everything/docs/structure.md` from `server-instructions.md` to `instructions.md` to match the actual file name.

4. **Self-Referential Errors in `structure.md`**
   - **Fix:** Cleaned up the `docs/` folder outline in `src/everything/docs/structure.md`:
     - Labeled `architecture.md` properly as "Architectural overview."
     - Added `structure.md` to the tree and correctly labeled it as "This document."
     - Updated the instructions document reference to `instructions.md`.

## Related Issues
Fixes #4096

## Testing
- [x] Verified that markdown renders correctly in IDE previews.
- [x] Verified all mentioned file paths accurately reflect the repository's file structure.
