### PR TITLE
fix(everything): remove dead code in resource template URI validation and subscription cleanup

### DIFF
--- a/src/everything/resources/subscriptions.ts
+++ b/src/everything/resources/subscriptions.ts
@@ -99,10 +99,9 @@ export const setSubscriptionHandlers = (server: McpServer) => {
 /**
  * Sends simulated resource update notifications to the subscribed client.
  *
- * This function iterates through all resource URIs stored in the subscriptions
- * and checks if the specified session ID is subscribed to them. If so, it sends
- * a notification through the provided server. If the session ID is no longer valid
- * (disconnected), it removes the session ID from the list of subscribers.
+ * Iterates the URIs in `subscriptions` and emits a
+ * `notifications/resources/updated` notification for each URI the given
+ * sessionId is subscribed to.
  *
  * @param {McpServer} server - The server instance used to send notifications.
  * @param {string | undefined} sessionId - The session ID of the client to check for subscriptions.
@@ -122,8 +121,6 @@ const sendSimulatedResourceUpdates = async (
         method: "notifications/resources/updated",
         params: { uri },
       });
-    } else {
-      subscribers.delete(sessionId); // subscriber has disconnected
     }
   }
 };

--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -127,31 +127,26 @@ export const blobResourceUri = (resourceId: number) =>
   new URL(`${blobUriBase}/${resourceId}`);
 
 /**
- * Parses the resource identifier from the provided URI and validates it
- * against the given variables. Throws an error if the URI corresponds
- * to an unknown resource or if the resource identifier is invalid.
+ * Parses the resource identifier from the provided variables and validates
+ * that it is a positive integer.
  *
- * @param {URL} uri - The URI of the resource to be parsed.
- * @param {Record<string, unknown>} variables - A record containing context-specific variables that include the resourceId.
- * @returns {number} The parsed and validated resource identifier as an integer.
- * @throws {Error} Throws an error if the URI matches unsupported base URIs or if the resourceId is invalid.
+ * The SDK only routes URIs that match the registered template to the
+ * resource handler, so by the time we get here the URI prefix is already
+ * known to be one of `textUriBase` / `blobUriBase`. Only the resourceId
+ * variable still needs validating.
+ *
+ * @param {URL} uri - The URI of the resource (used in the error message).
+ * @param {Record<string, unknown>} variables - Context variables including resourceId.
+ * @returns {number} The parsed and validated resource identifier as a positive integer.
+ * @throws {Error} If the resourceId is not a finite positive integer.
  */
 const parseResourceId = (uri: URL, variables: Record<string, unknown>) => {
-  const uriError = `Unknown resource: ${uri.toString()}`;
-  if (
-    uri.toString().startsWith(textUriBase) &&
-    uri.toString().startsWith(blobUriBase)
-  ) {
-    throw new Error(uriError);
-  } else {
-    const idxStr = String((variables as any).resourceId ?? "");
-    const idx = Number(idxStr);
-    if (Number.isFinite(idx) && Number.isInteger(idx) && idx > 0) {
-      return idx;
-    } else {
-      throw new Error(uriError);
-    }
+  const idxStr = String((variables as any).resourceId ?? "");
+  const idx = Number(idxStr);
+  if (Number.isFinite(idx) && Number.isInteger(idx) && idx > 0) {
+    return idx;
   }
+  throw new Error(`Unknown resource: ${uri.toString()}`);
 };
 
 /**


### PR DESCRIPTION
## Description

Two small dead-code removals in `src/everything`'s resource layer. No behavioral change. 95 / 95 tests still pass.

## Server Details
- Server: `everything` (reference server)
- Changes to: resources

## Motivation and Context

Two unreachable branches in the resource handlers were doing more harm than good — once misread, they suggest invariants that don't actually hold.

### `resources/templates.ts` — `parseResourceId`

The guard

```ts
if (uri.toString().startsWith(textUriBase) && uri.toString().startsWith(blobUriBase)) {
  throw new Error(uriError);
}
```

is dead. `textUriBase` and `blobUriBase` are mutually exclusive prefixes, so the `&&` is never true. The SDK's template-based routing already guarantees the URI prefix is one of the two before the handler runs, so the surrounding "unknown URI" error path can't trigger either. Reduced to the only check that still does work — `resourceId` must be a positive integer.

### `resources/subscriptions.ts` — `sendSimulatedResourceUpdates`

```ts
if (subscribers.has(sessionId)) {
  await server.server.notification(...);
} else {
  subscribers.delete(sessionId); // subscriber has disconnected
}
```

The `else` deletes `sessionId` from `subscribers` whenever the session isn't in *one specific URI's* subscriber set. The comment claims the session has disconnected, but that doesn't follow: a session subscribed to URI A but not URI B will hit the `else` for URI B every iteration. And `Set.delete` of an absent element is a no-op, so the branch never had useful effect. Removed.

## How Has This Been Tested?

- `npm test` in `src/everything`: **95 / 95 pass**
- Spot-checked the `everything` server with an LLM client (Claude Code) — `read-resource`, subscribe / unsubscribe flows, and template-routed `text/{id}` and `blob/{id}` reads all behave as before.

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follow MCP security best practices
- [ ] I have updated the server's README accordingly *(no user-facing change)*
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options *(none changed)*

## Additional context

- 1 commit, 2 files (`subscriptions.ts`, `templates.ts`), `+19 / −27` lines.
- No new dependencies, no API surface change.