### PR TITLE
Add Agents Shipgate to MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Additional resources on MCP.
 - **[r/mcp](https://www.reddit.com/r/mcp)** – A Reddit community dedicated to MCP by **[Frank Fiegel](https://github.com/punkpeye)**
 - **[MCP.ing](https://mcp.ing/)** - A list of MCP services for discovering MCP servers in the community and providing a convenient search function for MCP services by **[iiiusky](https://github.com/iiiusky)**
 - **[MCP Hunt](https://mcp-hunt.com)** - Realtime platform for discovering trending MCP servers with momentum tracking, upvoting, and community discussions - like Product Hunt meets Reddit for MCP
+- **[Agents Shipgate](https://github.com/ThreeMoonsLab/agents-shipgate)** - Static release-readiness scanner for AI agent tool surfaces, including exported MCP tools and OpenAPI specs, by **[Three Moons Lab](https://github.com/ThreeMoonsLab)**
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**


### PR DESCRIPTION
This adds Agents Shipgate to the additional MCP resources list.

Why:
- Agents Shipgate is a static release-readiness scanner for AI agent tool surfaces.
- MCP exports are one of its supported inputs, alongside OpenAPI specs and agent framework artifacts.
- This is a docs-only resource entry; it does not add CI or change any reference server implementation.

Trust model:
- No agent execution.
- No LLM calls.
- No tool calls.
- No MCP server connections.
- No scanner network calls.
- No telemetry.

I kept this intentionally small and placed it near related MCP discovery/security/scanning resources.