### PR TITLE
fix(everything): make syncRoots idempotent on error and empty paths

### DIFF
--- a/src/everything/__tests__/roots.test.ts
+++ b/src/everything/__tests__/roots.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncRoots, roots } from '../server/roots.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+const sessionA = 'session-a';
+
+const makeMockServer = (overrides: {
+  listRoots: () => Promise<unknown>;
+  capabilities?: Record<string, unknown>;
+}) => {
+  const setNotificationHandler = vi.fn();
+  const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+  const listRoots = vi.fn(overrides.listRoots);
+  const capabilities = overrides.capabilities ?? { roots: {} };
+
+  const mockServer = {
+    sendLoggingMessage,
+    server: {
+      getClientCapabilities: vi.fn(() => capabilities),
+      listRoots,
+      setNotificationHandler,
+    },
+  } as unknown as McpServer;
+
+  return { mockServer, listRoots, setNotificationHandler, sendLoggingMessage };
+};
+
+describe('syncRoots', () => {
+  beforeEach(() => {
+    roots.clear();
+  });
+
+  it('caches roots and does not re-fetch on subsequent calls', async () => {
+    const { mockServer, listRoots, setNotificationHandler } = makeMockServer({
+      listRoots: () => Promise.resolve({ roots: [{ uri: 'file:///a', name: 'a' }] }),
+    });
+
+    const first = await syncRoots(mockServer, sessionA);
+    const second = await syncRoots(mockServer, sessionA);
+
+    expect(first).toEqual([{ uri: 'file:///a', name: 'a' }]);
+    expect(second).toEqual([{ uri: 'file:///a', name: 'a' }]);
+    expect(listRoots).toHaveBeenCalledTimes(1);
+    expect(setNotificationHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch on subsequent calls when listRoots throws', async () => {
+    const { mockServer, listRoots, setNotificationHandler } = makeMockServer({
+      listRoots: () => Promise.reject(new Error('boom')),
+    });
+
+    await syncRoots(mockServer, sessionA);
+    await syncRoots(mockServer, sessionA);
+    await syncRoots(mockServer, sessionA);
+
+    // The doc claims this function is idempotent and fetches once per session.
+    // After a failed fetch, subsequent calls must not retry the listRoots
+    // request, otherwise every tool call hits the client again.
+    expect(listRoots).toHaveBeenCalledTimes(1);
+    expect(setNotificationHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fetch on subsequent calls when listRoots returns falsy or unshaped', async () => {
+    const { mockServer, listRoots, setNotificationHandler } = makeMockServer({
+      listRoots: () => Promise.resolve(undefined),
+    });
+
+    await syncRoots(mockServer, sessionA);
+    await syncRoots(mockServer, sessionA);
+
+    expect(listRoots).toHaveBeenCalledTimes(1);
+    expect(setNotificationHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined and does not call listRoots when client lacks roots capability', async () => {
+    const { mockServer, listRoots, setNotificationHandler } = makeMockServer({
+      listRoots: () => Promise.resolve({ roots: [] }),
+      capabilities: {},
+    });
+
+    const result = await syncRoots(mockServer, sessionA);
+
+    expect(result).toBeUndefined();
+    expect(listRoots).not.toHaveBeenCalled();
+    expect(setNotificationHandler).not.toHaveBeenCalled();
+  });
+});

--- a/src/everything/server/roots.ts
+++ b/src/everything/server/roots.ts
@@ -11,7 +11,7 @@ export const roots: Map<string | undefined, Root[]> = new Map<
 >();
 
 /**
- * Get the latest the client roots list for the session.
+ * Get the latest client roots list for the session.
  *
  * - Request and cache the roots list for the session if it has not been fetched before.
  * - Return the cached roots list for the session if it exists.
@@ -20,71 +20,79 @@ export const roots: Map<string | undefined, Root[]> = new Map<
  * notification handler. This ensures that updates are automatically fetched and handled
  * in real-time.
  *
- * This function is idempotent. It should only request roots from the client once per session,
- * returning the cached version thereafter.
+ * This function is idempotent. It requests roots from the client at most once per session,
+ * even if the initial request fails or the client returns no roots; callers get the
+ * cached result (possibly an empty list) on subsequent calls. Later `roots/list_changed`
+ * notifications are the only way the cache is refreshed.
  *
  * @param {McpServer} server - An instance of the MCP server used to communicate with the client.
  * @param {string} [sessionId] - An optional session id used to associate the roots list with a specific client session.
- *
- * @throws {Error} In case of a failure to request the roots from the client, an error log message is sent.
  */
 export const syncRoots = async (server: McpServer, sessionId?: string) => {
   const clientCapabilities = server.server.getClientCapabilities() || {};
   const clientSupportsRoots: boolean = clientCapabilities?.roots !== undefined;
 
-  // Fetch the roots list for this client
-  if (clientSupportsRoots) {
-    // Function to request the updated roots list from the client
-    const requestRoots = async () => {
-      try {
-        // Request the updated roots list from the client
-        const response = await server.server.listRoots();
-        if (response && "roots" in response) {
-          // Store the roots list for this client
-          roots.set(sessionId, response.roots);
+  if (!clientSupportsRoots) {
+    return;
+  }
 
-          // Notify the client of roots received
-          await server.sendLoggingMessage(
-            {
-              level: "info",
-              logger: "everything-server",
-              data: `Roots updated: ${response?.roots?.length} root(s) received from client`,
-            },
-            sessionId
-          );
-        } else {
-          await server.sendLoggingMessage(
-            {
-              level: "info",
-              logger: "everything-server",
-              data: "Client returned no roots set",
-            },
-            sessionId
-          );
-        }
-      } catch (error) {
-        console.error(
-          `Failed to request roots from client ${sessionId}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
+  // Function to request the updated roots list from the client
+  const requestRoots = async () => {
+    try {
+      const response = await server.server.listRoots();
+      if (response && "roots" in response) {
+        roots.set(sessionId, response.roots);
+        await server.sendLoggingMessage(
+          {
+            level: "info",
+            logger: "everything-server",
+            data: `Roots updated: ${response?.roots?.length} root(s) received from client`,
+          },
+          sessionId
+        );
+      } else {
+        // Client returned no usable roots. Cache an empty list so the session
+        // is marked as synced and we don't re-fetch on every tool call.
+        roots.set(sessionId, []);
+        await server.sendLoggingMessage(
+          {
+            level: "info",
+            logger: "everything-server",
+            data: "Client returned no roots set",
+          },
+          sessionId
         );
       }
-    };
-
-    // If the roots have not been synced for this client,
-    // set notification handler and request initial roots
-    if (!roots.has(sessionId)) {
-      // Set the list changed notification handler
-      server.server.setNotificationHandler(
-        RootsListChangedNotificationSchema,
-        requestRoots
+    } catch (error) {
+      // Keep the session marked as synced even on failure. Otherwise every
+      // subsequent tool call would re-invoke listRoots and re-register the
+      // list_changed notification handler.
+      if (!roots.has(sessionId)) {
+        roots.set(sessionId, []);
+      }
+      console.error(
+        `Failed to request roots from client ${sessionId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
-
-      // Request the initial roots list immediately
-      await requestRoots();
     }
+  };
 
-    // Return the roots list for this client
-    return roots.get(sessionId);
+  // If the roots have not been synced for this client,
+  // set notification handler and request initial roots.
+  if (!roots.has(sessionId)) {
+    // Mark the session as in-flight before awaiting the request so that a
+    // re-entrant call (e.g. a tool invoked while the initial fetch is still
+    // pending) sees a cached entry and doesn't install a second handler.
+    roots.set(sessionId, []);
+
+    server.server.setNotificationHandler(
+      RootsListChangedNotificationSchema,
+      requestRoots
+    );
+
+    await requestRoots();
   }
+
+  return roots.get(sessionId);
 };


### PR DESCRIPTION
## Description

`syncRoots` in `src/everything/server/roots.ts` claims (in JSDoc) to be idempotent and fetch roots from the client at most once per session, but the previous implementation only populated the cache on the success path. If `listRoots` threw or the client returned a falsy / unshaped response, no entry was written to the cache. Subsequent `syncRoots` calls would then re-issue `roots/list` to the client *and* re-register the `notifications/roots/list_changed` handler — once per tool invocation while the error persisted.

This change makes the cache-write semantics match the documented contract.

## Server Details
- Server: `everything` (reference server)
- Changes to: server/roots.ts (+ new __tests__/roots.test.ts)

## Motivation and Context

Two concrete issues with the old code:

1. **Repeated `listRoots` requests on transient client errors.** Every call to `get-roots-list` (or any caller of `syncRoots`) re-hit the client. With a flaky client this turns one user-initiated tool call into N silent client round-trips.
2. **Repeated `setNotificationHandler` registration.** `server.server.setNotificationHandler(RootsListChangedNotificationSchema, requestRoots)` is invoked on every retry. Whether this is a no-op (last-write-wins) or accumulates depends on SDK internals — either way it shouldn't be re-registered.

The JSDoc already promises "This function is idempotent. It should only request roots from the client once per session." The fix aligns the code with that promise rather than weakening the doc.

### What changed

In `requestRoots`:
- success path: unchanged (`roots.set(sessionId, response.roots)` + log).
- falsy / unshaped response: now caches an **empty array** so the session is marked synced.
- throw path: caches an empty array (only if no entry yet) so subsequent calls don't retry; still logs to stderr.

In `syncRoots`:
- early-return when the client lacks the `roots` capability (one less indent level for the rest).
- before `await requestRoots()`, write a placeholder `roots.set(sessionId, [])`. This guards against a re-entrant call landing while the initial fetch is still in flight (the second caller would otherwise see `!roots.has(sessionId)` and install a second notification handler).
- successful response replaces the placeholder.

Refresh continues to come from the `roots/list_changed` notification channel — that handler is registered exactly once per session.

## How Has This Been Tested?

New test file `src/everything/__tests__/roots.test.ts` (4 tests):

- caches roots and does not re-fetch on subsequent calls (success path; baseline)
- does not re-fetch when `listRoots` throws (before fix: 3 calls, after: 1)
- does not re-fetch when `listRoots` returns falsy / unshaped (before fix: 2 calls, after: 1)
- skips fetch entirely when the client lacks the `roots` capability

Full suite for `src/everything`: **99 / 99 pass** (95 existing + 4 new). `npm run build` clean.

Manual: re-ran `get-roots-list` against the local `everything` server with a working client; behavior unchanged on the success path.

## Breaking Changes

None. Internal cache semantics only; the public tool surface (`get-roots-list`) returns the same shape, including the empty-list-with-helper-text branch when the client has no roots configured.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update *(JSDoc updated alongside the behavioral fix)*

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follow MCP security best practices
- [ ] I have updated the server's README accordingly *(no user-facing change)*
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options *(none changed)*

## Additional context

- 1 commit, 2 files (`server/roots.ts`, new `__tests__/roots.test.ts`), `+148 / −53`.
- No new dependencies, no protocol-level change.