### PR TITLE
docs(everything): describe resource prompt args

### DIFF
--- a/src/everything/__tests__/prompts.test.ts
+++ b/src/everything/__tests__/prompts.test.ts
@@ -111,6 +111,15 @@ describe('Prompts', () => {
   });
 
   describe('resource-prompt', () => {
+    it('should describe prompt arguments', () => {
+      const { mockServer, configs } = createMockServer();
+      registerEmbeddedResourcePrompt(mockServer);
+
+      const config = configs.get('resource-prompt')!;
+      expect(config.argsSchema.resourceType.description).toContain('"Text" or "Blob"');
+      expect(config.argsSchema.resourceId.description).toContain('Positive integer ID');
+    });
+
     it('should return text resource reference', () => {
       const { mockServer, handlers } = createMockServer();
       registerEmbeddedResourcePrompt(mockServer);

--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -25,7 +25,7 @@ export const RESOURCE_TYPES: string[] = [
  * The completion logic matches the input against available resource types.
  */
 export const resourceTypeCompleter = completable(
-  z.string().describe("Type of resource to fetch"),
+  z.string().describe('Type of resource to fetch. Must be "Text" or "Blob".'),
   (value: string) => {
     return RESOURCE_TYPES.filter((t) => t.startsWith(value));
   }
@@ -48,7 +48,7 @@ export const resourceTypeCompleter = completable(
  * This helps validate and suggest appropriate resource IDs.
  */
 export const resourceIdForPromptCompleter = completable(
-  z.string().describe("ID of the text resource to fetch"),
+  z.string().describe("Positive integer ID of the resource to fetch."),
   (value: string) => {
     const resourceId = Number(value);
     return Number.isInteger(resourceId) && resourceId > 0 ? [value] : [];


### PR DESCRIPTION
## Summary
- Clarifies the `resource-prompt` argument descriptions for `resourceType` and `resourceId`
- Adds coverage that the registered prompt exposes the expected descriptions

Fixes #3985.

## Verification
- npm run build --workspace=@modelcontextprotocol/server-everything
- npm test --workspace=@modelcontextprotocol/server-everything -- prompts.test.ts