### PR TITLE
docs(everything): fix markdown and file references

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -110,27 +110,33 @@ npm run start:streamableHttp
 ```
 
 ## Running as an installed package
-### Install 
+
+### Install
+
 ```shell
 npm install -g @modelcontextprotocol/server-everything@latest
-````
+```
 
 ### Run the default (stdio) server
+
 ```shell
 npx @modelcontextprotocol/server-everything
 ```
 
 ### Or specify stdio explicitly
+
 ```shell
 npx @modelcontextprotocol/server-everything stdio
 ```
 
 ### Run the SSE server
+
 ```shell
 npx @modelcontextprotocol/server-everything sse
 ```
 
 ### Run the streamable HTTP server
+
 ```shell
 npx @modelcontextprotocol/server-everything streamableHttp
 ```

--- a/src/everything/docs/features.md
+++ b/src/everything/docs/features.md
@@ -19,7 +19,7 @@
 - `get-structured-content` (tools/get-structured-content.ts): Demonstrates structured responses. Accepts `location` input and returns both backward‑compatible `content` (a `text` block containing JSON) and `structuredContent` validated by an `outputSchema` (temperature, conditions, humidity).
 - `get-sum` (tools/get-sum.ts): For two numbers `a` and `b` calculates and returns their sum. Uses Zod to validate inputs.
 - `get-tiny-image` (tools/get-tiny-image.ts): Returns a tiny PNG MCP logo as an `image` content item with brief descriptive text before and after.
-- `trigger-long-running-operation` (tools/trigger-trigger-long-running-operation.ts): Simulates a multi-step operation over a given `duration` and number of `steps`; reports progress via `notifications/progress` when a `progressToken` is provided by the client.
+- `trigger-long-running-operation` (tools/trigger-long-running-operation.ts): Simulates a multi-step operation over a given `duration` and number of `steps`; reports progress via `notifications/progress` when a `progressToken` is provided by the client.
 - `toggle-simulated-logging` (tools/toggle-simulated-logging.ts): Starts or stops simulated, random‑leveled logging for the invoking session. Respects the client’s selected minimum logging level.
 - `toggle-subscriber-updates` (tools/toggle-subscriber-updates.ts): Starts or stops simulated resource update notifications for URIs the invoking session has subscribed to.
 - `trigger-sampling-request` (tools/trigger-sampling-request.ts): Issues a `sampling/createMessage` request to the client/LLM using provided `prompt` and optional generation controls; returns the LLM's response payload.

--- a/src/everything/docs/startup.md
+++ b/src/everything/docs/startup.md
@@ -54,7 +54,7 @@
     - `prompts: {}`
     - `resources: { subscribe: true }`
   - **Server Instructions**
-    - Loaded from the docs folder (`server-instructions.md`).
+    - Loaded from the docs folder (`instructions.md`).
   - **Registrations**
     - Registers **tools** via `registerTools(server)`.
     - Registers **resources** via `registerResources(server)`.

--- a/src/everything/docs/structure.md
+++ b/src/everything/docs/structure.md
@@ -50,8 +50,11 @@ src/everything
      │   ├── gzip-file-as-resource.ts
      │   ├── toggle-simulated-logging.ts
      │   ├── toggle-subscriber-updates.ts
+     │   ├── simulate-research-query.ts
+     │   ├── trigger-elicitation-request-async.ts
      │   ├── trigger-elicitation-request.ts
      │   ├── trigger-long-running-operation.ts
+     │   ├── trigger-sampling-request-async.ts
      │   └── trigger-sampling-request.ts
      └── transports
          ├── sse.ts
@@ -81,9 +84,19 @@ src/everything
 ### `docs/`
 
 - `architecture.md`
-  - This document.
-- `server-instructions.md`
+  - Describes the server architecture.
+- `extension.md`
+  - Describes extension points for adding tools, prompts, resources, transports, and session behavior.
+- `features.md`
+  - Lists the MCP primitives and protocol features demonstrated by the server.
+- `how-it-works.md`
+  - Explains runtime flows for initialization, tools, resources, prompts, logging, and subscriptions.
+- `instructions.md`
   - Human‑readable instructions intended to be passed to the client/LLM as for guidance on server use. Loaded by the server at startup and returned in the "initialize" exchange.
+- `startup.md`
+  - Documents the startup flow from CLI entry point to transport manager and server factory.
+- `structure.md`
+  - This document.
 
 ### `prompts/`
 


### PR DESCRIPTION
## Summary
- fix the Everything README code fence in the installed-package section
- correct stale file references for instructions and long-running operation docs
- align the structure document with the current docs and async task tool files

Fixes #4096

## Verification
- git diff --check
- npm run build --workspace=@modelcontextprotocol/server-everything