### PR TITLE
Add NEXUS Agent Services - x402 pay-per-call data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,5 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+
+- **[NEXUS Agent Services](https://github.com/RileyCraig14/nexus-agent)** - Pay-per-call crypto prices, Reddit sentiment, DeFi data, stock prices via x402 on Base. `npx @rileycraig/nexus-mcp`


### PR DESCRIPTION
NEXUS Agent Services provides pay-per-call AI data APIs via x402 on Base. Real-time crypto prices, Reddit intelligence with AI sentiment, DeFi TVL data, stock prices. No API keys needed — pay per call in USDC.\n\n- GitHub: https://github.com/RileyCraig14/nexus-agent\n- npm: `npx @rileycraig/nexus-mcp`\n- Endpoint: https://nexus-agent-xa12.onrender.com