### PR TITLE
docs: add ContextMCP to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[cognee-mcp](https://github.com/topoteretes/cognee/tree/main/cognee-mcp)** - GraphRAG memory server with customizable ingestion, data processing and search
 - **[coin_api_mcp](https://github.com/longmans/coin_api_mcp)** - Provides access to [coinmarketcap](https://coinmarketcap.com/) cryptocurrency data.
 - **[Contentful-mcp](https://github.com/ivo-toby/contentful-mcp)** - Read, update, delete, publish content in your [Contentful](https://contentful.com) space(s) from this MCP Server.
+- **[ContextMCP](https://github.com/dodopayments/context-mcp)** - Self-hosted MCP server that indexes your documentation (Mintlify, Fumadocs, Docusaurus, Markdown, OpenAPI) into Pinecone and serves it via MCP + REST API. Deploys to Cloudflare Workers.
 - **[crypto-feargreed-mcp](https://github.com/kukapay/crypto-feargreed-mcp)**  -  Providing real-time and historical Crypto Fear & Greed Index data.
 - **[cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server)** - Providing latest cryptocurrency news to AI agents, powered by CryptoPanic.
 - **[Dappier](https://github.com/DappierAI/dappier-mcp)** - Connect LLMs to real-time, rights-cleared, proprietary data from trusted sources. Access specialized models for Real-Time Web Search, News, Sports, Financial Data, Crypto, and premium publisher content. Explore data models at [marketplace.dappier.com](https://marketplace.dappier.com/marketplace).


### PR DESCRIPTION
## What

Adds **ContextMCP** to the "Community Servers" section in alphabetical order (between `Contentful-mcp` and `crypto-feargreed-mcp`).

## About ContextMCP

ContextMCP is a self-hosted MCP server that turns documentation into a searchable knowledge base for AI assistants. It indexes documentation in multiple formats — Mintlify, Fumadocs, Docusaurus, plain Markdown, and OpenAPI specs — into Pinecone using OpenAI embeddings, then serves them via the Model Context Protocol and a REST API. Ships with a CLI scaffold (`npx contextmcp init`) and deploys to Cloudflare Workers.

- Repo: https://github.com/dodopayments/context-mcp
- Website: https://contextmcp.ai
- npm CLI: https://www.npmjs.com/package/contextmcp
- License: Apache-2.0
- Used in production by: Dodo Payments

## Entry added

```markdown
- **[ContextMCP](https://github.com/dodopayments/context-mcp)** - Self-hosted MCP server that indexes your documentation (Mintlify, Fumadocs, Docusaurus, Markdown, OpenAPI) into Pinecone and serves it via MCP + REST API. Deploys to Cloudflare Workers.
```

## Checklist

- [x] Open-source (Apache-2.0)
- [x] Working MCP server with documented setup
- [x] Alphabetical placement maintained
- [x] Format matches existing entries
- [x] No duplicate entry
