### PR TITLE
Add World Cup History MCP server (community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Additional resources on MCP.
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.
 - **[Webrix MCP Gateway](https://github.com/webrix-ai/secure-mcp-gateway)** - Enterprise MCP gateway with SSO, RBAC, audit trails, and token vaults for secure, centralized AI agent access control. Deploy via Helm charts on-premise or in your cloud. [webrix.ai](https://webrix.ai)
-
+- **[World Cup History](https://github.com/zafronix/zafronix-wc-api/tree/main/mcp)** by [Zafronix](https://api.zafronix.com/) — Every FIFA World Cup since 1930. 23 tournaments, 1,168+ matches, 2,500+ players, 206 stadiums. 15 tools: tournaments, teams, players, matches, stadiums, brackets, standings, trivia. Free tier on api.zafronix.com.
 
 
 ## 🚀 Getting Started


### PR DESCRIPTION
## What

Adds the **World Cup History MCP** by Zafronix — a Model Context Protocol server for the public Zafronix World Cup API.

npm: [@zafronix/wc-mcp](https://www.npmjs.com/package/@zafronix/wc-mcp)
Source: https://github.com/zafronix/zafronix-wc-api/tree/main/mcp

## Why

The current Community Servers list has no sports-domain entries. LLMs are unreliable on FIFA World Cup specifics from before their training window — exact scores, full squads, knockout brackets, stadium altitudes. This MCP wraps a public API covering every FIFA World Cup 1930→2026 so MCP-aware agents can answer those questions with grounded data instead of guessing.

## What's exposed

15 tools: `list_tournaments`, `get_tournament`, `compare_tournaments`, `search_players`, `get_player_career`, `list_teams`, `get_team`, `get_team_roster`, `list_stadiums`, `get_stadium`, `list_matches`, `get_match`, `get_trivia`, `get_standings`, `get_bracket`.

## Install

```json
{
  "mcpServers": {
    "wc": {
      "command": "npx",
      "args": ["-y", "@zafronix/wc-mcp"],
      "env": { "WC_API_KEY": "zwc_pk_..." }
    }
  }
}
```

Free API key at https://api.zafronix.com/signup (1,000 req/day, no card).

## License

MIT.

## Live demo

The companion sample dashboard at https://api.zafronix.com/wc-explorer/ uses the same API. Operators can preview the data shape before installing.