### PR TITLE
docs(time): remove trailing comma in convert_time example response

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -244,7 +244,7 @@ Response:
     "datetime": "2024-01-01T12:30:00+09:00",
     "is_dst": false
   },
-  "time_difference": "+13.0h",
+  "time_difference": "+13.0h"
 }
 ```
 


### PR DESCRIPTION
The example response object for the `convert_time` tool in `src/time/README.md` had a trailing comma after the last key (`"time_difference"`).

```json
  "time_difference": "+13.0h",
}
```

Trailing commas are not valid in standard JSON ([RFC 8259 §2](https://datatracker.ietf.org/doc/html/rfc8259#section-2)), so anyone copy-pasting the example into a strict JSON parser (e.g. `json.loads` in Python, `JSON.parse` in JS, a test fixture, or a schema validator) hits a parse error on what is documented as a valid response.

### Why

Looking at the git history, the trailing comma was left over when a now-removed `"date_changed": true` field was deleted from the example. The comma after the preceding `time_difference` key was never cleaned up.

This makes the README example self-consistent with how the server actually serializes responses (via `pydantic`/`json.dumps`, which never emit trailing commas).

### Scope

- Docs-only, no code touched
- 1-line change in `src/time/README.md`
- No new dependencies, no breaking changes
- Verified the block now parses with `json.loads`

### Types of changes

- [x] Documentation update

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) - maintained by [Abhishek Krishna](https://abhishekkrishna.com)._