### PR TITLE
Add claude-mcp-server-template to Frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 ### For servers
 
 * **[Anubis MCP](https://github.com/zoedsoupe/anubis-mcp)** (Elixir) - A high-performance and high-level Model Context Protocol (MCP) implementation in Elixir. Think like "Live View" for MCP.
+* **[claude-mcp-server-template](https://github.com/alexisgarcia-dev/claude-mcp-server-template)** (Python) - Production-survival Python MCP server template with Streamable HTTP transport, OpenTelemetry observability, JSON-RPC tools/list healthcheck, and 10 ADR-light decisions documented with verified sources.
 * **[ModelFetch](https://github.com/phuctm97/modelfetch/)** (TypeScript) - Runtime-agnostic SDK to create and deploy MCP servers anywhere TypeScript/JavaScript runs
 * **[EasyMCP](https://github.com/zcaceres/easy-mcp/)** (TypeScript)
 * **[FastAPI to MCP auto generator](https://github.com/tadata-org/fastapi_mcp)** – A zero-configuration tool for automatically exposing FastAPI endpoints as MCP tools by **[Tadata](https://tadata.com/)**


### PR DESCRIPTION
This PR adds [alexisgarcia-dev/claude-mcp-server-template](https://github.com/alexisgarcia-dev/claude-mcp-server-template) to the **Frameworks > For servers** section (the section that already lists similar templates like *Template MCP Server* and *Next.js MCP Server Template*).

## What it is

A Python MCP server template focused on production-survival patterns. Built around the 5 patterns that distinguish ~9% healthy from ~52% dead public MCP server endpoints in the April 2026 community scan (Apigene).

## Highlights

- Tools + Resources + Prompts complete (top ~4% of public servers per digitalapplied.com 2026 stats)
- JSON-RPC `tools/list` healthcheck (bearer auth + Streamable HTTP transport + tool registration verified in one call)
- OpenTelemetry + Jaeger 1.62 observability included out of the box
- 10 ADR-light architectural decisions documented with verified tier-2 sources
- End-to-end validated across 4 layers (Layer 4 = clone fresh from public GitHub URL)
- v1.0.0 frozen-by-design stable reference (community-driven roadmap)
- 58 tests passing, GitHub Actions CI matrix Python 3.11/3.12/3.13, CodeQL + Bandit + Dependabot

## Checklist
- [x] One-line entry, alphabetically placed in `Frameworks > For servers`
- [x] Format matches existing entries in that section (`* **[Name](url)** (Lang) - description`)
- [x] Project repo is public, MIT-licensed, with CI and tests
