### PR TITLE
fix(filesystem): preserve root aliases from MCP roots

### DIFF
--- a/src/filesystem/__tests__/roots-utils.test.ts
+++ b/src/filesystem/__tests__/roots-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getValidRootDirectories } from '../roots-utils.js';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, realpathSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import type { Root } from '@modelcontextprotocol/sdk/types.js';
@@ -48,7 +48,7 @@ describe('getValidRootDirectories', () => {
     it('should normalize complex paths', async () => {
       const subDir = join(testDir1, 'subdir');
       mkdirSync(subDir);
-      
+
       const roots = [
         { uri: `file://${testDir1}/./subdir/../subdir`, name: 'Complex Path' }
       ];
@@ -57,6 +57,32 @@ describe('getValidRootDirectories', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]).toBe(subDir);
+    });
+
+    it('keeps both original and resolved forms for roots that resolve differently', async () => {
+      const realDir = join(testDir1, 'real-root');
+      const aliasDir = join(testDir1, 'alias-root');
+      mkdirSync(realDir);
+
+      try {
+        symlinkSync(realDir, aliasDir);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+          return;
+        }
+        throw error;
+      }
+
+      const roots: Root[] = [
+        { uri: `file://${aliasDir}`, name: 'Symlink Root' }
+      ];
+
+      const result = await getValidRootDirectories(roots);
+      const resolvedDir = realpathSync(aliasDir);
+
+      expect(result).toContain(aliasDir);
+      expect(result).toContain(resolvedDir);
+      expect(result).toHaveLength(2);
     });
   });
 

--- a/src/filesystem/roots-utils.ts
+++ b/src/filesystem/roots-utils.ts
@@ -6,19 +6,30 @@ import type { Root } from '@modelcontextprotocol/sdk/types.js';
 import { fileURLToPath } from "url";
 
 /**
- * Converts a root URI to a normalized directory path with basic security validation.
+ * Converts a root URI to normalized directory paths with basic security validation.
+ *
+ * Returns both the original normalized path and the resolved path when they differ.
+ * This keeps roots-provided directories symmetric with command-line directories,
+ * so paths addressed through either a symlink/mapped-drive form or its resolved
+ * target continue to pass allow-list validation.
+ *
  * @param rootUri - File URI (file://...) or plain directory path
- * @returns Promise resolving to validated path or null if invalid
+ * @returns Promise resolving to validated paths or null if invalid
  */
-async function parseRootUri(rootUri: string): Promise<string | null> {
+async function parseRootUri(rootUri: string): Promise<string[] | null> {
   try {
     const rawPath = rootUri.startsWith('file://') ? fileURLToPath(rootUri) : rootUri;
-    const expandedPath = rawPath.startsWith('~/') || rawPath === '~' 
-      ? path.join(os.homedir(), rawPath.slice(1)) 
+    const expandedPath = rawPath.startsWith('~/') || rawPath === '~'
+      ? path.join(os.homedir(), rawPath.slice(1))
       : rawPath;
     const absolutePath = path.resolve(expandedPath);
+    const normalizedOriginal = normalizePath(absolutePath);
     const resolvedPath = await fs.realpath(absolutePath);
-    return normalizePath(resolvedPath);
+    const normalizedResolved = normalizePath(resolvedPath);
+
+    return normalizedOriginal === normalizedResolved
+      ? [normalizedResolved]
+      : [normalizedOriginal, normalizedResolved];
   } catch {
     return null; // Path doesn't exist or other error
   }
@@ -41,11 +52,11 @@ function formatDirectoryError(dir: string, error?: unknown, reason?: string): st
 
 /**
  * Resolves requested root directories from MCP root specifications.
- * 
+ *
  * Converts root URI specifications (file:// URIs or plain paths) into normalized
  * directory paths, validating that each path exists and is a directory.
  * Includes symlink resolution for security.
- * 
+ *
  * @param requestedRoots - Array of root specifications with URI and optional name
  * @returns Promise resolving to array of validated directory paths
  */
@@ -53,25 +64,32 @@ export async function getValidRootDirectories(
   requestedRoots: readonly Root[]
 ): Promise<string[]> {
   const validatedDirectories: string[] = [];
-  
+  const seenDirectories = new Set<string>();
+
   for (const requestedRoot of requestedRoots) {
-    const resolvedPath = await parseRootUri(requestedRoot.uri);
-    if (!resolvedPath) {
+    const candidatePaths = await parseRootUri(requestedRoot.uri);
+    if (!candidatePaths) {
       console.error(formatDirectoryError(requestedRoot.uri, undefined, 'invalid path or inaccessible'));
       continue;
     }
-    
-    try {
-      const stats: Stats = await fs.stat(resolvedPath);
-      if (stats.isDirectory()) {
-        validatedDirectories.push(resolvedPath);
-      } else {
-        console.error(formatDirectoryError(resolvedPath, undefined, 'non-directory root'));
+
+    for (const candidatePath of candidatePaths) {
+      try {
+        const stats: Stats = await fs.stat(candidatePath);
+        if (!stats.isDirectory()) {
+          console.error(formatDirectoryError(candidatePath, undefined, 'non-directory root'));
+          continue;
+        }
+
+        if (!seenDirectories.has(candidatePath)) {
+          validatedDirectories.push(candidatePath);
+          seenDirectories.add(candidatePath);
+        }
+      } catch (error) {
+        console.error(formatDirectoryError(candidatePath, error));
       }
-    } catch (error) {
-      console.error(formatDirectoryError(resolvedPath, error));
     }
   }
-  
+
   return validatedDirectories;
 }


### PR DESCRIPTION
## Summary

Preserve both the original root path and its resolved target when filesystem roots come from the MCP roots protocol. This keeps runtime allow-list checks symmetric with startup args, so mapped-drive or symlink-style paths keep working even when `realpath()` rewrites them.

## Changes

- return both original and resolved root paths from `getValidRootDirectories()` when they differ
- dedupe validated root entries while preserving order
- add a regression test covering roots that resolve through an alias/symlink

## Testing

- `cd src/filesystem && npx vitest run`
- `npm run build --workspace @modelcontextprotocol/server-filesystem`

Fixes modelcontextprotocol/servers#4129