### PR TITLE
Add agents.txt v1.0 at repo root

### DIFF
--- a/agents.txt
+++ b/agents.txt
@@ -1,0 +1,74 @@
+# agents.txt — v1.0
+# https://github.com/barneywohl/agentpress (spec)
+#
+# This file declares what autonomous agents may and may not do in this
+# repository. It is advisory and complements CONTRIBUTING.md, SECURITY.md,
+# and the project's existing review process — it does not override them.
+
+[meta]
+spec_version = 1.0
+project = mcp-servers
+maintainer = modelcontextprotocol-org
+contact_for_agents = https://github.com/modelcontextprotocol/servers/issues
+last_updated = 2026-05-13
+license = Apache-2.0
+ai_disclosure_required = true
+
+[allowed_actions]
+read_documentation
+read_source_code
+run_tests_in_ci
+file_pull_request
+comment_on_issue
+propose_design
+suggest_documentation_fix
+suggest_bug_fix
+reproduce_reported_issue
+
+[prohibited_actions]
+merge_to_main
+deploy_to_production
+publish_package
+modify_secrets
+modify_billing_files
+modify_license
+modify_code_of_conduct
+modify_security_policy
+add_new_reference_server
+add_third_party_server_listing
+rewrite_protocol_semantics
+contact_users_directly
+exfiltrate_secrets
+impersonation
+spam
+
+[requires_human_approval]
+changes_touching = src/**, SECURITY.md, CONTRIBUTING.md, LICENSE, .github/workflows/**, scripts/**
+changes_to_dependencies
+changes_to_test_framework
+changes_to_release_or_publishing_config
+changes_that_alter_public_server_behavior
+changes_that_alter_documented_tool_schemas
+
+[entry_points]
+contributing = CONTRIBUTING.md
+quickstart = README.md
+architecture = README.md
+agent_guide = CLAUDE.md
+
+[scope]
+max_files_per_pr = 25
+max_lines_per_pr = 500
+prefer_single_server_scope = true
+
+[rate_limits]
+max_open_prs_per_agent = 2
+min_hours_between_prs = 24
+
+[disclosure]
+pr_label = agent-authored
+commit_trailer = Co-Authored-By
+require_attribution_in_pr_body = true
+
+[fyi]
+notes = Per CONTRIBUTING.md, bug fixes and usability improvements are welcome; new servers and opinionated features are generally out of scope. New reference servers belong in the MCP Server Registry, not here. Protocol-level changes belong in modelcontextprotocol/specification.


### PR DESCRIPTION
## Add `agents.txt` (v1.0) at repo root

Hey — first off, thanks for the work on this repo. We shipped `@agent_press/mcp-server` yesterday on top of the MCP TypeScript SDK, and a lot of what makes that possible is the clarity these reference implementations provide. This PR is meant in that spirit: a small, peer contribution from a project that builds on MCP.

### What this PR adds

A single file: `agents.txt` at the repository root.

`agents.txt` is a new open standard (v1.0, shipped this week) that lets a repository declare, in a machine-readable INI format, what autonomous AI agents are permitted to do when interacting with the project. It sits in the same lineage as `robots.txt`, `sitemap.xml`, and `llms.txt` — advisory, static, no runtime component. Spec: https://github.com/barneywohl/agentpress/blob/main/docs/AGENTSTXT_SPEC.md

The version proposed here is intentionally conservative for a monorepo of reference implementations:

- `allowed_actions` covers reading, running tests in CI, opening PRs, and commenting on issues
- `prohibited_actions` covers merging, publishing packages, modifying `SECURITY.md` / `LICENSE` / `CODE_OF_CONDUCT.md`, adding new reference servers, and any protocol-spec changes
- `requires_human_approval` flags anything under `src/**`, `.github/workflows/**`, dependency changes, and behavior changes to documented tool schemas
- `entry_points` points to existing `README.md`, `CONTRIBUTING.md`, and `CLAUDE.md`
- `scope` mirrors CONTRIBUTING.md's existing preference for small, focused PRs and explicitly marks new servers and protocol changes as out of scope

### What this PR does *not* do

- No CI changes, no workflow changes, no new dependencies
- No changes to `CONTRIBUTING.md`, `SECURITY.md`, or any existing file
- No protocol-spec implications — `agents.txt` is purely a repo-level declaration
- Does not attempt to enumerate per-server rules; the file is monorepo-root scope only

### Caveats I want to flag

`agents.txt` at the root of a monorepo has real subtleties — different subdirectories have different test commands, different maintainers, and different risk profiles. The version here errs on the side of being restrictive (broad `requires_human_approval` patterns, conservative `scope` limits) rather than precise. Per-server `agents.txt` files could be added later if useful, but that's out of scope for this PR.

Happy to iterate on wording, tighten the `prohibited_actions` list, or close this if it's not a fit for the repo's direction.