### PR TITLE
fix(filesystem): prevent $ replacement patterns in edit_file newText

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -555,15 +555,15 @@ describe('Lib Functions', () => {
 
       it('handles CRLF line endings in file content', async () => {
         mockFs.readFile.mockResolvedValue('line1\r\nline2\r\nline3\r\n');
-        
+
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
+
         mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
+
         expect(mockFs.writeFile).toHaveBeenCalledWith(
           expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
           'line1\nmodified line2\nline3\n',
@@ -572,6 +572,78 @@ describe('Lib Functions', () => {
         expect(mockFs.rename).toHaveBeenCalledWith(
           expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
           '/test/file.txt'
+        );
+      });
+
+      it('treats $$ in newText as literal $$ not a single $', async () => {
+        mockFs.readFile.mockResolvedValue('price: PLACEHOLDER\n');
+
+        const edits = [
+          { oldText: 'PLACEHOLDER', newText: '$$100 USD' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'price: $$100 USD\n',
+          'utf-8'
+        );
+      });
+
+      it('treats $& in newText as literal $& not the matched substring', async () => {
+        mockFs.readFile.mockResolvedValue('value: OLD\n');
+
+        const edits = [
+          { oldText: 'OLD', newText: '$&NEW' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'value: $&NEW\n',
+          'utf-8'
+        );
+      });
+
+      it('treats $` in newText as literal $` not the preceding substring', async () => {
+        mockFs.readFile.mockResolvedValue('hello PLACEHOLDER world\n');
+
+        const edits = [
+          { oldText: 'PLACEHOLDER', newText: '$`literal' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'hello $`literal world\n',
+          'utf-8'
+        );
+      });
+
+      it("treats $' in newText as literal $' not the following substring", async () => {
+        mockFs.readFile.mockResolvedValue('hello PLACEHOLDER world\n');
+
+        const edits = [
+          { oldText: 'PLACEHOLDER', newText: "$'literal" }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          "hello $'literal world\n",
+          'utf-8'
         );
       });
     });

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,10 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      // Use a function as replacement to prevent special replacement patterns
+      // (e.g. $&, $`, $', $$) in normalizedNew from being interpreted by
+      // String.prototype.replace — the callback return value is always literal.
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
## Summary

- `applyFileEdits` called `String.prototype.replace(searchStr, replacementStr)`, where JS interprets special patterns in the replacement argument (`$$`, `$&`, `` $` ``, `$'`), silently corrupting content that contains literal `$` characters
- Fix uses the callback form `replace(searchStr, () => replacement)` — the return value of a callback is always treated as a literal string, disabling pattern interpretation while preserving "replace first occurrence only" semantics
- Added four parametric tests covering each affected replacement pattern

## Test plan

- [x] `$$` in newText preserved as `$$` (not collapsed to `$`)
- [x] `$&` in newText preserved as `$&` (not expanded to matched substring)
- [x] `` $` `` in newText preserved as `` $` `` (not expanded to preceding substring)
- [x] `$'` in newText preserved as `$'` (not expanded to following substring)
- [x] All existing lib.test.ts tests (49 total) continue to pass

Fixes #4157