### PR TITLE
fix(filesystem): treat edit replacements literally

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -472,6 +472,22 @@ describe('Lib Functions', () => {
         );
       });
 
+      it('treats replacement text as literal content', async () => {
+        const edits = [
+          { oldText: 'line2', newText: 'price=$5; match=$&; group=$1; dollar=$$' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'line1\nprice=$5; match=$&; group=$1; dollar=$$\nline3\n',
+          'utf-8'
+        );
+      });
+
       it('handles whitespace-flexible matching', async () => {
         mockFs.readFile.mockResolvedValue('  line1\n    line2\n  line3\n');
         

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
Fixes #4157.

## Summary
- use a replacement callback so edit_file newText is inserted literally instead of being interpreted as a String.prototype.replace replacement pattern
- add regression coverage for literal $, $&, $1, and $$ content in replacements

## Testing
- npm --prefix src/filesystem test