### PR TITLE
fix(filesystem): reject non-media read_media_file inputs

### DIFF
--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -25,6 +25,13 @@ describe('structuredContent schema compliance', () => {
 
     // Create test files
     await fs.writeFile(path.join(testDir, 'test.txt'), 'test content');
+    await fs.writeFile(
+      path.join(testDir, 'pixel.png'),
+      Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+        'base64'
+      )
+    );
     await fs.mkdir(path.join(testDir, 'subdir'));
     await fs.writeFile(path.join(testDir, 'subdir', 'nested.txt'), 'nested content');
 
@@ -153,6 +160,30 @@ describe('structuredContent schema compliance', () => {
       const structuredContent = result.structuredContent as { content: unknown };
       expect(typeof structuredContent.content).toBe('string');
       expect(Array.isArray(structuredContent.content)).toBe(false);
+    });
+  });
+
+  describe('read_media_file', () => {
+    it('returns a valid MCP image content type for images', async () => {
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: path.join(testDir, 'pixel.png') }
+      });
+
+      const [content] = result.content as Array<{ type: string; mimeType?: string; data?: string }>;
+      expect(content.type).toBe('image');
+      expect(content.mimeType).toBe('image/png');
+      expect(content.data).toBeTruthy();
+    });
+
+    it('rejects non-media files instead of returning an invalid blob content type', async () => {
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: path.join(testDir, 'test.txt') }
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toContain('Unsupported media type');
     });
   });
 });

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -257,7 +257,7 @@ server.registerTool(
     },
     outputSchema: {
       content: z.array(z.object({
-        type: z.enum(["image", "audio", "blob"]),
+        type: z.enum(["image", "audio"]),
         data: z.string(),
         mimeType: z.string()
       }))
@@ -280,16 +280,19 @@ server.registerTool(
       ".ogg": "audio/ogg",
       ".flac": "audio/flac",
     };
-    const mimeType = mimeTypes[extension] || "application/octet-stream";
+    const mimeType = mimeTypes[extension];
+    if (!mimeType) {
+      throw new Error(
+        `Unsupported media type for ${args.path}. read_media_file only supports image and audio files.`
+      );
+    }
+
     const data = await readFileAsBase64Stream(validPath);
 
     const type = mimeType.startsWith("image/")
       ? "image"
-      : mimeType.startsWith("audio/")
-        ? "audio"
-        // Fallback for other binary types, not officially supported by the spec but has been used for some time
-        : "blob";
-    const contentItem = { type: type as 'image' | 'audio' | 'blob', data, mimeType };
+      : "audio";
+    const contentItem = { type: type as 'image' | 'audio', data, mimeType };
     return {
       content: [contentItem],
       structuredContent: { content: [contentItem] }


### PR DESCRIPTION
## Summary
- remove the invalid `blob` content type from the filesystem `read_media_file` output schema
- reject unsupported extensions before reading and encoding the file
- add integration coverage for valid image output and non-media rejection

Fixes #4029.

## Tests
- `npm test -- structured-content`
- `npm test`
- `npm run build`