### PR TITLE
fix(filesystem): return protocol error for unknown tools

### DIFF
--- a/src/filesystem/__tests__/unknown-tool.test.ts
+++ b/src/filesystem/__tests__/unknown-tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+describe('unknown tool handling', () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-fs-unknown-tool-'));
+
+    const serverPath = path.resolve(__dirname, '../dist/index.js');
+    transport = new StdioClientTransport({
+      command: 'node',
+      args: [serverPath, testDir],
+    });
+
+    client = new Client({
+      name: 'test-client',
+      version: '1.0.0',
+    }, {
+      capabilities: {}
+    });
+
+    await client.connect(transport);
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns a JSON-RPC error for unknown tools', async () => {
+    const unknownToolName = '__mcp_test_unknown_tool_read_file__';
+    let error: unknown;
+
+    try {
+      await client.callTool({
+        name: unknownToolName,
+        arguments: {}
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toMatchObject({
+      code: ErrorCode.InvalidParams
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(`Unknown tool: ${unknownToolName}`);
+  });
+
+  it('keeps validation failures for known tools as tool errors', async () => {
+    const result = await client.callTool({
+      name: 'read_text_file',
+      arguments: {}
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]).toMatchObject({
+      type: 'text'
+    });
+    expect((result.content[0] as { text: string }).text).toContain('Input validation error');
+  });
+});

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolResult,
+  ErrorCode,
   RootsListChangedNotificationSchema,
   type Root,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -701,6 +702,54 @@ server.registerTool(
     };
   }
 );
+
+type RequestHandler = (request: unknown, extra: unknown) => unknown;
+type RequestHandlerRegistry = {
+  _requestHandlers: Map<string, RequestHandler>;
+};
+type RegisteredToolRegistry = {
+  _registeredTools: Record<string, unknown>;
+};
+
+class JsonRpcError extends Error {
+  constructor(
+    readonly code: ErrorCode,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function preserveUnknownToolProtocolErrors() {
+  const requestHandlers = (
+    server.server as unknown as RequestHandlerRegistry
+  )._requestHandlers;
+  const callToolHandler = requestHandlers.get("tools/call");
+
+  if (!callToolHandler) {
+    return;
+  }
+
+  // The SDK CallTool handler converts tool execution failures to tool results.
+  // Unknown tools are protocol errors, so intercept them before the handler runs.
+  requestHandlers.set("tools/call", (request: unknown, extra: unknown) => {
+    const toolName = (request as { params?: { name?: unknown } }).params?.name;
+    const registeredTools = (
+      server as unknown as RegisteredToolRegistry
+    )._registeredTools;
+
+    if (typeof toolName === "string" && !registeredTools[toolName]) {
+      throw new JsonRpcError(
+        ErrorCode.InvalidParams,
+        `Unknown tool: ${toolName}`
+      );
+    }
+
+    return callToolHandler(request, extra);
+  });
+}
+
+preserveUnknownToolProtocolErrors();
 
 // Updates allowed directories based on MCP client roots
 async function updateAllowedDirectoriesFromRoots(requestedRoots: Root[]) {


### PR DESCRIPTION
## Description

Ensures the filesystem server returns a JSON-RPC `InvalidParams` error when `tools/call` targets an unregistered tool. Known tool validation failures continue to return tool execution errors with `isError: true`.

## Server Details
- Server: filesystem
- Changes to: tools

## Motivation and Context

Closes #4159.

The MCP tools error model treats unknown tools as protocol errors. The filesystem server was surfacing the SDK's unknown-tool failure as a successful `CallToolResult` with `isError: true`, which made conformance checks treat the call as accepted.

## How Has This Been Tested?

- `npm run build -w @modelcontextprotocol/server-filesystem`
- `npm test -w @modelcontextprotocol/server-filesystem`

Added integration coverage for:
- unknown tool calls rejecting with JSON-RPC `-32602`
- known tool input validation continuing to return a tool error result

## Breaking Changes

Unknown filesystem tool calls now surface as JSON-RPC `-32602` errors, matching the protocol error contract.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

The guard is scoped to unregistered tool names. Registered tools still use the existing SDK request handler for validation, execution, and output checks.