### PR TITLE
fix(filesystem): preserve literal $ in edit_file newText (#4157)

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -498,9 +498,39 @@ describe('Lib Functions', () => {
         const edits = [
           { oldText: 'nonexistent line', newText: 'replacement' }
         ];
-        
+
         await expect(applyFileEdits('/test/file.txt', edits, false))
           .rejects.toThrow('Could not find exact match for edit');
+      });
+
+      // Regression test for #4157: newText containing String.prototype.replace
+      // replacement-pattern characters ($$, $&, $`, $', $<name>) must be treated
+      // as a literal string, not a pattern. Otherwise content like "$$100 USD"
+      // silently corrupts to "$100 USD" on the exact-match path.
+      it('preserves literal $ in newText (issue #4157)', async () => {
+        mockFs.readFile.mockResolvedValue('price: PLACEHOLDER\n');
+
+        const cases: Array<[string, string]> = [
+          ['$$100 USD',       'price: $$100 USD\n'],
+          ['cost: $&',        'price: cost: $&\n'],
+          ['var: $`x$\'',     'price: var: $`x$\'\n'],
+          ['template: $<x>',  'price: template: $<x>\n'],
+        ];
+
+        for (const [newText, expected] of cases) {
+          mockFs.writeFile.mockClear();
+          mockFs.rename.mockResolvedValueOnce(undefined);
+
+          await applyFileEdits('/test/file.txt', [
+            { oldText: 'PLACEHOLDER', newText }
+          ], false);
+
+          expect(mockFs.writeFile).toHaveBeenCalledWith(
+            expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+            expected,
+            'utf-8'
+          );
+        }
       });
 
       it('handles complex multi-line edits with indentation', async () => {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -205,9 +205,16 @@ export async function applyFileEdits(
     const normalizedOld = normalizeLineEndings(edit.oldText);
     const normalizedNew = normalizeLineEndings(edit.newText);
 
-    // If exact match exists, use it
+    // If exact match exists, use it.
+    //
+    // Using the function form of replace() is important: with a string
+    // replacement, JavaScript interprets `$$`, `$&`, `` $` ``, `$'`, and
+    // `$<name>` as replacement-pattern syntax, which silently corrupts
+    // content that contains literal `$` characters (e.g. JS/TS code,
+    // currency amounts, shell variables). The arrow function returns
+    // the replacement as a literal string and bypasses the pattern.
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
Fixes #4157.

## Root cause

`applyFileEdits` (in `src/filesystem/lib.ts`) invoked
`String.prototype.replace(searchString, replacementString)` where the
second argument is interpreted as a [replacement-string pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement),
not a literal string. This silently corrupted content containing
literal `$` characters:

| Pattern in `newText` | Replaced by |
|---|---|
| `$$` | a single `$` |
| `$&` | the matched substring |
| `` $` `` | the substring preceding the match |
| `$'` | the substring following the match |
| `$<name>` | (regex named-group syntax) |

Particularly hit JS/TS code with `$variables`, currency amounts, regex
source, and shell scripts. The fallback line-by-line path (via `splice`
/ `join`) was not affected.

## Fix

Pass the replacement via the callback form:

```ts
modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
```

The function's return value is used verbatim, which bypasses the
pattern interpreter while preserving "replace first occurrence only"
semantics. One-line change to the production code.

## Test coverage

Added a regression test in `__tests__/lib.test.ts` covering all five
pattern cases (`$$`, `$&`, `` $` ``, `$'`, `$<name>`). The new test runs
alongside the existing `applyFileEdits` test block and matches the
file's existing style.

Full vitest suite: **147 passed, 0 failed** locally after the change.

## Impact

`@modelcontextprotocol/server-filesystem` has ~297k weekly downloads
per the issue, and the corruption is silent — `edit_file` returns
success and a clean-looking diff while the on-disk content differs
from intent.