### PR TITLE
docs(time): fix response examples

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -212,6 +212,7 @@ Response:
 {
   "timezone": "Europe/Warsaw",
   "datetime": "2024-01-01T13:00:00+01:00",
+  "day_of_week": "Monday",
   "is_dst": false
 }
 ```
@@ -232,15 +233,17 @@ Response:
 {
   "source": {
     "timezone": "America/New_York",
-    "datetime": "2024-01-01T12:30:00-05:00",
+    "datetime": "2024-01-01T16:30:00-05:00",
+    "day_of_week": "Monday",
     "is_dst": false
   },
   "target": {
     "timezone": "Asia/Tokyo",
-    "datetime": "2024-01-01T12:30:00+09:00",
+    "datetime": "2024-01-02T06:30:00+09:00",
+    "day_of_week": "Tuesday",
     "is_dst": false
   },
-  "time_difference": "+13.0h",
+  "time_difference": "+14.0h"
 }
 ```
 

--- a/src/time/test/time_server_test.py
+++ b/src/time/test/time_server_test.py
@@ -1,4 +1,7 @@
 
+import json
+from pathlib import Path
+
 from freezegun import freeze_time
 from mcp.shared.exceptions import McpError
 import pytest
@@ -6,6 +9,33 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from mcp_server_time.server import TimeServer, get_local_tz
+
+
+def readme_response_blocks():
+    readme = Path(__file__).parents[1] / "README.md"
+    blocks = []
+    for chunk in readme.read_text(encoding="utf-8").split("Response:\n```json\n")[1:]:
+        raw_json, _, _ = chunk.partition("\n```")
+        blocks.append(json.loads(raw_json))
+    return blocks
+
+
+def test_readme_response_examples_match_server_output():
+    time_server = TimeServer()
+
+    with freeze_time("2024-01-01 12:00:00+00:00"):
+        current_time = time_server.get_current_time("Europe/Warsaw").model_dump()
+
+    with freeze_time("2024-01-01 12:00:00+00:00"):
+        converted_time = time_server.convert_time(
+            "America/New_York",
+            "16:30",
+            "Asia/Tokyo",
+        ).model_dump()
+
+    readme_blocks = readme_response_blocks()
+    assert current_time in readme_blocks
+    assert converted_time in readme_blocks
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add the `day_of_week` field to the Time server response examples
- fix the conversion example so the New York to Tokyo datetime values and `time_difference` are internally consistent
- add a regression test that parses the README response JSON blocks and compares them with frozen `TimeServer` output

## Validation

Run from `src/time`:

- `uv run pytest`
- `uv run ruff check .`

Local result: `39 passed`, ruff clean.