### PR TITLE
fix(filesystem): ignore final newline in tail output

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -553,6 +553,23 @@ describe('Lib Functions', () => {
     });
 
     describe('tailFile', () => {
+      const mockTailReadableFile = (content: string) => {
+        const fileBuffer = Buffer.from(content, 'utf-8');
+        mockFs.stat.mockResolvedValue({ size: fileBuffer.length } as any);
+
+        const mockFileHandle = {
+          read: vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+            const chunk = fileBuffer.subarray(position, position + length);
+            chunk.copy(buffer, offset);
+            return { bytesRead: chunk.length, buffer };
+          }),
+          close: vi.fn().mockResolvedValue(undefined)
+        } as any;
+
+        mockFs.open.mockResolvedValue(mockFileHandle);
+        return mockFileHandle;
+      };
+
       it('handles empty files', async () => {
         mockFs.stat.mockResolvedValue({ size: 0 } as any);
         
@@ -583,23 +600,29 @@ describe('Lib Functions', () => {
       });
 
       it('handles files with content and returns last lines', async () => {
-        mockFs.stat.mockResolvedValue({ size: 50 } as any);
-        
-        const mockFileHandle = {
-          read: vi.fn(),
-          close: vi.fn()
-        } as any;
-        
-        // Simulate reading file content in chunks
-        mockFileHandle.read
-          .mockResolvedValueOnce({ bytesRead: 20, buffer: Buffer.from('line3\nline4\nline5\n') })
-          .mockResolvedValueOnce({ bytesRead: 0 });
-        mockFileHandle.close.mockResolvedValue(undefined);
-        
-        mockFs.open.mockResolvedValue(mockFileHandle);
-        
+        const mockFileHandle = mockTailReadableFile('line1\nline2\nline3\nline4\nline5');
+
         const result = await tailFile('/test/file.txt', 2);
-        
+
+        expect(result).toBe('line4\nline5');
+        expect(mockFileHandle.close).toHaveBeenCalled();
+      });
+
+      it('does not treat a final newline as an empty tail line', async () => {
+        const mockFileHandle = mockTailReadableFile('line1\nline2\nline3\n');
+
+        const result = await tailFile('/test/file.txt', 1);
+
+        expect(result).toBe('line3');
+        expect(mockFileHandle.close).toHaveBeenCalled();
+      });
+
+      it('returns the requested lines when content ends in a newline', async () => {
+        const mockFileHandle = mockTailReadableFile('line1\nline2\nline3\n');
+
+        const result = await tailFile('/test/file.txt', 2);
+
+        expect(result).toBe('line2\nline3');
         expect(mockFileHandle.close).toHaveBeenCalled();
       });
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -274,6 +274,7 @@ export async function tailFile(filePath: string, numLines: number): Promise<stri
     let chunk = Buffer.alloc(CHUNK_SIZE);
     let linesFound = 0;
     let remainingText = '';
+    let isEndChunk = true;
     
     // Read chunks from the end of the file until we have enough lines
     while (position > 0 && linesFound < numLines) {
@@ -289,6 +290,11 @@ export async function tailFile(filePath: string, numLines: number): Promise<stri
       
       // Split by newlines and count
       const chunkLines = normalizeLineEndings(chunkText).split('\n');
+
+      if (isEndChunk && chunkLines[chunkLines.length - 1] === '') {
+        chunkLines.pop();
+      }
+      isEndChunk = false;
       
       // If this isn't the end of the file, the first line is likely incomplete
       // Save it to prepend to the next chunk


### PR DESCRIPTION
## Summary

- Fix `tailFile` so a normal final newline is not returned as an empty trailing line.
- Add regression coverage that asserts `tailFile` content instead of only checking handle cleanup.
- Keep intentional blank lines intact by removing only the split sentinel from the EOF chunk.

## Root Cause

`tailFile` splits the final chunk on `\n`. For text files ending in a newline, `split("\n")` produces a final empty sentinel, which the reverse reader counted as the last line. That made `read_text_file` with `tail: 1` return an empty string for ordinary POSIX-style files like `line1\nline2\nline3\n`.

## Validation

- `npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts`
- `npm run build -w src/filesystem`
