### PR TITLE
fix(filesystem): treat edit replacement text literally

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -416,6 +416,22 @@ describe('Lib Functions', () => {
         );
       });
 
+      it('treats dollar signs in replacement text literally', async () => {
+        const edits = [
+          { oldText: 'line2', newText: '$$100 $& value' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'line1\n$$100 $& value\nline3\n',
+          'utf-8'
+        );
+      });
+
       it('handles dry run mode', async () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -184,7 +184,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
## Summary

- treat filesystem `edit_file` replacement text as literal text by using a replacement callback
- add a regression test covering dollar-sign replacement patterns such as `$$` and `$&`

Fixes #4157.

## Validation

```sh
TMPDIR=$PWD/.tmp npm_config_cache=$PWD/.npm-cache npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts --testNamePattern "dollar signs" --cache false
TMPDIR=$PWD/.tmp npm_config_cache=$PWD/.npm-cache npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts --cache false
npm run build -w src/filesystem
git diff --check
git merge-tree --write-tree origin/main HEAD
```
