### PR TITLE
fix(filesystem): apply search excludes before realpath

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -325,6 +325,40 @@ describe('Lib Functions', () => {
         expect(result).toEqual([expectedResult]);
       });
 
+      it('skips excluded entries before validating their real paths', async () => {
+        const mockEntries = [
+          { name: 'GoogleDrive-lazy', isDirectory: () => true },
+          { name: 'match.txt', isDirectory: () => false }
+        ];
+
+        mockFs.readdir.mockResolvedValueOnce(mockEntries as any);
+
+        const testDir = process.platform === 'win32' ? 'C:\\allowed\\dir' : '/allowed/dir';
+        const allowedDirs = process.platform === 'win32' ? ['C:\\allowed'] : ['/allowed'];
+
+        mockFs.realpath.mockImplementation(async (inputPath: any) => {
+          const pathStr = inputPath.toString();
+          if (pathStr.includes('GoogleDrive-lazy')) {
+            throw new Error('excluded entries should not be realpathed');
+          }
+          return pathStr;
+        });
+
+        const result = await searchFilesWithValidation(
+          testDir,
+          '*',
+          allowedDirs,
+          { excludePatterns: ['GoogleDrive-*'] }
+        );
+
+        const expectedResult = process.platform === 'win32' ? 'C:\\allowed\\dir\\match.txt' : '/allowed/dir/match.txt';
+        expect(result).toEqual([expectedResult]);
+        const validatedExcludedEntry = mockFs.realpath.mock.calls.some(([inputPath]: any[]) =>
+          inputPath.toString().includes('GoogleDrive-lazy')
+        );
+        expect(validatedExcludedEntry).toBe(false);
+      });
+
       it('handles validation errors during search', async () => {
         const mockEntries = [
           { name: 'test.txt', isDirectory: () => false },

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -362,16 +362,15 @@ export async function searchFilesWithValidation(
 
     for (const entry of entries) {
       const fullPath = path.join(currentPath, entry.name);
+      const relativePath = path.relative(rootPath, fullPath);
+      const shouldExclude = excludePatterns.some(excludePattern =>
+        minimatch(relativePath, excludePattern, { dot: true })
+      );
+
+      if (shouldExclude) continue;
 
       try {
         await validatePath(fullPath);
-
-        const relativePath = path.relative(rootPath, fullPath);
-        const shouldExclude = excludePatterns.some(excludePattern =>
-          minimatch(relativePath, excludePattern, { dot: true })
-        );
-
-        if (shouldExclude) continue;
 
         // Use glob matching for the search pattern
         if (minimatch(relativePath, pattern, { dot: true })) {


### PR DESCRIPTION
## Summary
- apply `search_files` exclude patterns before validating each child path
- avoid calling `fs.realpath` on excluded entries, which makes provider-backed directories possible to skip before they can block
- add a regression test that fails if an excluded CloudStorage-like entry is realpathed

Refs #4162

## Testing
- `npm test --workspace @modelcontextprotocol/server-filesystem`
- `npm run build --workspace @modelcontextprotocol/server-filesystem`
- `git diff --check origin/main...HEAD`