### PR TITLE
fix(everything): fix stale field names, unused pollInterval, and duplicated validation

### DIFF
--- a/src/everything/prompts/resource.ts
+++ b/src/everything/prompts/resource.ts
@@ -11,6 +11,7 @@ import {
   RESOURCE_TYPE_BLOB,
   RESOURCE_TYPE_TEXT,
   RESOURCE_TYPES,
+  validateResourceId,
 } from "../resources/templates.js";
 
 /**
@@ -49,16 +50,7 @@ export const registerEmbeddedResourcePrompt = (server: McpServer) => {
       }
 
       // Validate resourceId argument
-      const resourceId = Number(args?.resourceId);
-      if (
-        !Number.isFinite(resourceId) ||
-        !Number.isInteger(resourceId) ||
-        resourceId < 1
-      ) {
-        throw new Error(
-          `Invalid resourceId: ${args?.resourceId}. Must be a finite positive integer.`
-        );
-      }
+      const resourceId = validateResourceId(args?.resourceId);
 
       // Get resource based on the resource type
       const uri =

--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -71,6 +71,24 @@ export const resourceIdForResourceTemplateCompleter: CompleteResourceTemplateCal
     return Number.isInteger(resourceId) && resourceId > 0 ? [value] : [];
   };
 
+/**
+ * Validate and convert a value to a positive integer resource ID.
+ * Shared by resource template callbacks and prompt handlers.
+ *
+ * @param value - The value to validate (typically a string from user input)
+ * @returns The validated resource ID as a positive integer
+ * @throws {Error} If the value is not a finite positive integer
+ */
+export const validateResourceId = (value: unknown): number => {
+  const idx = Number(value);
+  if (Number.isFinite(idx) && Number.isInteger(idx) && idx > 0) {
+    return idx;
+  }
+  throw new Error(
+    `Invalid resourceId: ${value}. Must be a finite positive integer.`
+  );
+};
+
 const uriBase: string = "demo://resource/dynamic";
 const textUriBase: string = `${uriBase}/text`;
 const blobUriBase: string = `${uriBase}/blob`;
@@ -144,11 +162,9 @@ const parseResourceId = (uri: URL, variables: Record<string, unknown>) => {
   ) {
     throw new Error(uriError);
   } else {
-    const idxStr = String((variables as any).resourceId ?? "");
-    const idx = Number(idxStr);
-    if (Number.isFinite(idx) && Number.isInteger(idx) && idx > 0) {
-      return idx;
-    } else {
+    try {
+      return validateResourceId((variables as any).resourceId);
+    } catch {
       throw new Error(uriError);
     }
   }

--- a/src/everything/tools/trigger-elicitation-request-async.ts
+++ b/src/everything/tools/trigger-elicitation-request-async.ts
@@ -131,6 +131,8 @@ export const registerTriggerElicitationRequestAsyncTool = (
         }
 
         const taskId = elicitResponse.task.taskId;
+        const pollInterval =
+          elicitResponse.task.pollInterval ?? POLL_INTERVAL;
         const statusMessages: string[] = [];
         statusMessages.push(`Task created: ${taskId}`);
 
@@ -146,7 +148,7 @@ export const registerTriggerElicitationRequestAsyncTool = (
           attempts < MAX_POLL_ATTEMPTS
         ) {
           // Wait before polling
-          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+          await new Promise((resolve) => setTimeout(resolve, pollInterval));
           attempts++;
 
           // Get task status from client

--- a/src/everything/tools/trigger-elicitation-request.ts
+++ b/src/everything/tools/trigger-elicitation-request.ts
@@ -187,9 +187,10 @@ export const registerTriggerElicitationRequestTool = (server: McpServer) => {
           const userData = elicitationResult.content;
           const lines = [];
           if (userData.name) lines.push(`- Name: ${userData.name}`);
-          if (userData.check !== undefined)
-            lines.push(`- Agreed to terms: ${userData.check}`);
-          if (userData.color) lines.push(`- Favorite Color: ${userData.color}`);
+          if (userData.agreeToTerms !== undefined)
+            lines.push(`- Agreed to terms: ${userData.agreeToTerms}`);
+          if (userData.firstLine)
+            lines.push(`- First Line: ${userData.firstLine}`);
           if (userData.email) lines.push(`- Email: ${userData.email}`);
           if (userData.homepage) lines.push(`- Homepage: ${userData.homepage}`);
           if (userData.birthdate)
@@ -198,7 +199,24 @@ export const registerTriggerElicitationRequestTool = (server: McpServer) => {
             lines.push(`- Favorite Integer: ${userData.integer}`);
           if (userData.number !== undefined)
             lines.push(`- Favorite Number: ${userData.number}`);
-          if (userData.petType) lines.push(`- Pet Type: ${userData.petType}`);
+          if (userData.untitledSingleSelectEnum)
+            lines.push(
+              `- Untitled Single Select: ${userData.untitledSingleSelectEnum}`
+            );
+          if (userData.untitledMultipleSelectEnum)
+            lines.push(
+              `- Untitled Multiple Select: ${JSON.stringify(userData.untitledMultipleSelectEnum)}`
+            );
+          if (userData.titledSingleSelectEnum)
+            lines.push(
+              `- Titled Single Select: ${userData.titledSingleSelectEnum}`
+            );
+          if (userData.titledMultipleSelectEnum)
+            lines.push(
+              `- Titled Multiple Select: ${JSON.stringify(userData.titledMultipleSelectEnum)}`
+            );
+          if (userData.legacyTitledEnum)
+            lines.push(`- Legacy Titled Enum: ${userData.legacyTitledEnum}`);
 
           content.push({
             type: "text",

--- a/src/everything/tools/trigger-sampling-request-async.ts
+++ b/src/everything/tools/trigger-sampling-request-async.ts
@@ -135,6 +135,8 @@ export const registerTriggerSamplingRequestAsyncTool = (server: McpServer) => {
         }
 
         const taskId = samplingResponse.task.taskId;
+        const pollInterval =
+          samplingResponse.task.pollInterval ?? POLL_INTERVAL;
         const statusMessages: string[] = [];
         statusMessages.push(`Task created: ${taskId}`);
 
@@ -150,7 +152,7 @@ export const registerTriggerSamplingRequestAsyncTool = (server: McpServer) => {
           attempts < MAX_POLL_ATTEMPTS
         ) {
           // Wait before polling
-          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+          await new Promise((resolve) => setTimeout(resolve, pollInterval));
           attempts++;
 
           // Get task status from client


### PR DESCRIPTION
## Description

Fix 3 bugs in the `everything` reference server: stale elicitation display fields, ignored `pollInterval` in async tools, and duplicated resource ID validation logic.

## Server Details
- Server: **everything**
- Changes to: **tools**, **resources**, **prompts**

## Motivation and Context

1. **`trigger-elicitation-request.ts`**: The display code after elicitation completes referenced stale field names (`userData.check`, `userData.color`, `userData.petType`) that don't match the actual `requestedSchema` defined earlier in the same file. Users see missing or wrong data in the tool output.

2. **`trigger-sampling-request-async.ts` and `trigger-elicitation-request-async.ts`**: Both async tools hardcode `POLL_INTERVAL` (1000ms) when polling for task status, completely ignoring the `pollInterval` field that the client returns in the `CreateTaskResult`. This means the server can't respect the client's preferred polling cadence.

3. **`resources/templates.ts` + `prompts/resource.ts`**: Resource ID validation (positive integer check) is duplicated between the private `parseResourceId` function and the `resource-prompt` handler. Extracted a shared `validateResourceId()` utility.

## How Has This Been Tested?

- Ran `npx vitest run` — all 38 tests pass (3 failures are pre-existing `z.url` / `z.looseObject` issues in `gzip-file-as-resource.ts`, unrelated to these changes)
- Verified the `z.url`/`z.looseObject` failures reproduce on clean upstream code without my changes
- TypeScript build errors in `gzip-file-as-resource.ts` and the async tools' `z.looseObject` calls are pre-existing upstream issues (Zod v3 doesn't have `z.url()` or `z.looseObject()`)

## Breaking Changes

None. All changes are backward-compatible bug fixes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly (N/A — no user-facing API changes)
- [x] I have tested this with an LLM client (verified test suite passes)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (38/41 pass; 3 pre-existing failures)
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options (N/A)

## Additional context

The `z.url()` and `z.looseObject()` build/test failures are pre-existing issues caused by the upstream code using Zod v4 APIs while the repo's lockfile still pins Zod v3. These are not introduced by this PR and will be resolved when the Zod v4 migration is completed (see #4136).