### PR TITLE
Add Infinihash KYT and MyAi to community servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,6 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+
+- **[Infinihash KYT](https://github.com/Infinihash/infinihash-kyt-mcp)** - Blockchain transaction monitoring + sanctions screening (OFAC SDN, ScamSniffer, stablecoin freezes) and FinCEN-aligned SAR generation via the [Infinihash KYT](https://kyt.infinihash.com) API.
+- **[MyAi](https://github.com/myaitoken/myai-mcp)** - Decentralized AI inference on Base. OpenAI-compatible chat routed through community GPU providers. Agents pay agents in $MYAI.


### PR DESCRIPTION
Adding two community MCP servers maintained by Infinihash:

- **Infinihash KYT** — compliance: screen blockchain wallets against OFAC SDN, ScamSniffer, stablecoin freezes, and 18.8K+ community-reviewed labels. Generate FinCEN-aligned SAR drafts. Free tier with no credit card.
  - Repo: https://github.com/Infinihash/infinihash-kyt-mcp
  - PyPI: https://pypi.org/project/infinihash-kyt-mcp/

- **MyAi** — decentralized AI inference: OpenAI-compatible chat completions routed through community GPU providers on Base. Agents pay agents in $MYAI. 27+ providers, 22 models live.
  - Repo: https://github.com/myaitoken/myai-mcp
  - PyPI: https://pypi.org/project/myai-mcp/

Both Python, MIT, installable via uvx, smoke-tested against live production APIs.