### PR TITLE
Add agent-payment-mcp to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 * **[mcp_sse (Elixir)](https://github.com/kEND/mcp_sse)** An SSE implementation in Elixir for rapidly creating MCP servers.
 * **[mxcp](https://github.com/raw-labs/mxcp)** (Python) - Open-source framework for building enterprise-grade MCP servers using just YAML, SQL, and Python, with built-in auth, monitoring, ETL and policy enforcement.
 * **[Next.js MCP Server Template](https://github.com/vercel-labs/mcp-for-next.js)** (Typescript) - A starter Next.js project that uses the MCP Adapter to allow MCP clients to connect and access resources.
+* **[agent-payment-mcp](https://github.com/evidai/agent-payment-mcp)** (TypeScript) - Give AI agents a USDC wallet with a hard daily spend cap. Pay-per-call billing for MCP servers via `@lemon-cake/mcp-sdk` — adds monetization in 3 lines. [npm](https://www.npmjs.com/package/agent-payment-mcp) · [SDK](https://www.npmjs.com/package/@lemon-cake/mcp-sdk)
 * **[PayMCP](https://github.com/blustAI/paymcp)** (Python & TypeScript) - Lightweight payments layer for MCP servers: turn tools into paid endpoints with a two-line decorator. [PyPI](https://pypi.org/project/paymcp/) · [npm](https://www.npmjs.com/package/paymcp) · [TS repo](https://github.com/blustAI/paymcp-ts)
 * **[Perl SDK](https://github.com/mojolicious/mojo-mcp)** - An SDK for building MCP servers and clients with the Perl programming language.
 * **[Quarkus MCP Server SDK](https://github.com/quarkiverse/quarkus-mcp-server)** (Java)


### PR DESCRIPTION
## Summary

Adds **[agent-payment-mcp](https://github.com/evidai/agent-payment-mcp)** to the Frameworks section, alongside the existing PayMCP entry.

**What it does:**
- Gives AI agents a USDC wallet with a configurable daily spend cap
- Enables pay-per-call billing on any MCP server via `@lemon-cake/mcp-sdk` (3-line integration)
- Transport: HTTP + x402-compatible receipts; Demo Mode when no seller key is set
- Sandbox-safe by default (dry-run flag, cap enforcement before any on-chain tx)

**npm:**
- [`agent-payment-mcp`](https://www.npmjs.com/package/agent-payment-mcp) — the MCP server itself
- [`@lemon-cake/mcp-sdk`](https://www.npmjs.com/package/@lemon-cake/mcp-sdk) — the 3-line billing SDK for server authors

**GitHub:** https://github.com/evidai/agent-payment-mcp