### PR TITLE
everything: harden default CORS to localhost Inspector only

### DIFF
--- a/src/everything/transports/sse.ts
+++ b/src/everything/transports/sse.ts
@@ -5,11 +5,33 @@ import cors from "cors";
 
 console.error("Starting SSE server...");
 
-// Express app with permissive CORS for testing with Inspector direct connect mode
+// CORS is restricted to local Inspector origins by default. Override with
+// MCP_ALLOWED_ORIGINS="https://example.com,..." for additional origins, or
+// MCP_ALLOWED_ORIGINS="*" to opt back into wildcard (dev only). Kept in sync
+// with streamableHttp.ts in this directory.
+const DEFAULT_ALLOWED_ORIGINS = [
+  "http://localhost:6274",
+  "http://127.0.0.1:6274",
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+];
+const corsOriginEnv = process.env.MCP_ALLOWED_ORIGINS;
+const corsOrigin: string | string[] =
+  corsOriginEnv === "*"
+    ? "*"
+    : corsOriginEnv && corsOriginEnv.trim().length > 0
+      ? corsOriginEnv.split(",").map((s) => s.trim()).filter(Boolean)
+      : DEFAULT_ALLOWED_ORIGINS;
+if (corsOrigin === "*") {
+  console.warn(
+    "[mcp-everything] WARNING: MCP_ALLOWED_ORIGINS='*' — wildcard CORS enabled. Use only on a developer workstation; never in any deployed setting.",
+  );
+}
+
 const app = express();
 app.use(
   cors({
-    origin: "*", // use "*" with caution in production
+    origin: corsOrigin,
     methods: "GET,POST",
     preflightContinue: false,
     optionsSuccessStatus: 204,

--- a/src/everything/transports/streamableHttp.ts
+++ b/src/everything/transports/streamableHttp.ts
@@ -38,11 +38,35 @@ class InMemoryEventStore implements EventStore {
 
 console.log("Starting Streamable HTTP server...");
 
-// Express app with permissive CORS for testing with Inspector direct connect mode
+// CORS is restricted to local Inspector origins by default. Override with
+// MCP_ALLOWED_ORIGINS="https://example.com,https://other.example" for extra
+// origins. The previous default of "*" is intentionally NOT supported here:
+// the everything server is the most-forked MCP reference, and a wildcard
+// default propagates into developer-deployed servers exposing real tools.
+// To opt back into a wildcard (development only), set MCP_ALLOWED_ORIGINS="*".
+const DEFAULT_ALLOWED_ORIGINS = [
+  "http://localhost:6274",
+  "http://127.0.0.1:6274",
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+];
+const corsOriginEnv = process.env.MCP_ALLOWED_ORIGINS;
+const corsOrigin: string | string[] =
+  corsOriginEnv === "*"
+    ? "*"
+    : corsOriginEnv && corsOriginEnv.trim().length > 0
+      ? corsOriginEnv.split(",").map((s) => s.trim()).filter(Boolean)
+      : DEFAULT_ALLOWED_ORIGINS;
+if (corsOrigin === "*") {
+  console.warn(
+    "[mcp-everything] WARNING: MCP_ALLOWED_ORIGINS='*' — wildcard CORS enabled. Use only on a developer workstation; never in any deployed setting.",
+  );
+}
+
 const app = express();
 app.use(
   cors({
-    origin: "*", // use "*" with caution in production
+    origin: corsOrigin,
     methods: "GET,POST,DELETE",
     preflightContinue: false,
     optionsSuccessStatus: 204,


### PR DESCRIPTION
## Summary

The `everything` reference server's HTTP transports default to `origin: "*"` with a trailing "use '*' with caution in production" inline comment. Because `everything/` is the most-forked MCP reference, that wildcard default propagates into developer-deployed servers that DO expose real tools.

This PR changes the default to a localhost Inspector allowlist. Override with `MCP_ALLOWED_ORIGINS="..."` (comma-separated) for extra origins, or `MCP_ALLOWED_ORIGINS="*"` to opt back into wildcard (now with a startup warning).

## Changes

- `src/everything/transports/streamableHttp.ts` (line 42 region): default `origin` is now `[http://localhost:6274, http://127.0.0.1:6274, http://localhost:5173, http://127.0.0.1:5173]`
- `src/everything/transports/sse.ts` (line 9 region): same
- Both: read `MCP_ALLOWED_ORIGINS` env, with explicit `"*"` opt-in plus startup warning

## Why

`SECURITY.md` correctly notes the servers are reference implementations not production-ready, and is explicit that the repo is not eligible for security advisories. This PR is **example-code hardening, not a security fix**: it reduces the unsafe-default footgun for downstream forks. The "with caution in production" comment is reliably read as "they thought about it; safe to ship" by hurried developers.

Anchor for the propagation concern: nginx-ui MCP CVE-2026-33032 hit 2,600+ public instances exactly because the auth-absent wildcard pattern propagated from example code.

## Test plan

- [ ] Manually verify `MCP_ALLOWED_ORIGINS` unset → CORS allows only the 4 localhost origins
- [ ] `MCP_ALLOWED_ORIGINS="https://example.com"` → CORS allows that one origin
- [ ] `MCP_ALLOWED_ORIGINS="*"` → CORS allows wildcard, startup prints the warning
- [ ] Inspector direct-connect still works against `localhost:6274` / `:5173` defaults

Happy to revise the default list (port numbers) if Inspector ships from a different port now.

— Calm collective protocol (assisting John Bradley, Calm@rainbowsix.dev)
🤖 Generated with [Claude Code](https://claude.com/claude-code)