### PR TITLE
fix(filesystem): timeouts + max-visited cap for hangs on lazy provider paths (#4162)

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -204,6 +204,22 @@ The mapping for filesystem tools is:
 
 > Note: `idempotentHint` and `destructiveHint` are meaningful only when `readOnlyHint` is `false`, as defined by the MCP spec.
 
+## Environment variables
+
+Three environment variables guard against hangs when `allowed_directories` includes a slow or lazy provider-backed path (macOS `~/Library/CloudStorage/...`, `~/Library/Mobile Documents/com~apple~CloudDocs/...`, NFS / SMB mounts, etc.). Defaults are safe for ordinary local trees; tune only if needed.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `FS_OP_TIMEOUT_MS` | `15000` | Timeout (milliseconds) applied to each `fs.realpath` (in `validatePath`) and `fs.readdir` (in `search_files` and `directory_tree`). On timeout the call rejects with `FsTimeoutError` instead of hanging. |
+| `FS_SEARCH_MAX_VISITED` | `50000` | Hard cap on entries visited by a single `search_files` or `directory_tree` call before aborting with `"Search aborted after visiting N entries..."`. Prevents an unbounded recursion on a large or lazy-materialized tree. |
+| `FS_SEARCH_EXCLUDE_PREFIXES` | (empty) | Comma-separated path prefixes for which recursive search and `directory_tree` are refused outright. `~` is expanded. Matching is boundary-aware: a configured `/data/foo` will not match an unrelated `/data/foobar`. Intended for known-slow roots you'd rather forbid than time out on. |
+
+Invalid numeric values (`"15s"`, `"0"`, negative) print a warning to stderr and fall back to the default, so a typo cannot silently disable a guard.
+
+**Remote-mount tuning:** the 15 s default works well for local trees and warm CloudStorage. On NFS, SMB, or other remote mounts where individual `readdir` calls legitimately take seconds, consider raising `FS_OP_TIMEOUT_MS` (e.g. `30000`–`60000`) to avoid spurious timeouts.
+
+**`FS_SEARCH_EXCLUDE_PREFIXES` is a fast lexical *prefilter*, not a canonical-path exclusion.** The requested root is compared (after `~` expansion and normalisation) against the configured prefixes, with no `realpath` step. A symlink whose target lives under an excluded prefix is therefore **not** blocked — the request would pass the lexical exclude and may still hit the slow provider path through `validatePath`'s realpath. Treat this as a best-effort guard against direct submissions of slow paths, not as a complete symlink-aware exclusion. Security against paths escaping `allowed_directories` is enforced separately by `validatePath`.
+
 ## Usage with Claude Desktop
 Add this to your `claude_desktop_config.json`:
 

--- a/src/filesystem/__tests__/4162-timeouts-and-caps.test.ts
+++ b/src/filesystem/__tests__/4162-timeouts-and-caps.test.ts
@@ -1,0 +1,315 @@
+// Regression tests for issue #4162: recursive search / validatePath can hang
+// for minutes on macOS CloudStorage / lazy provider-backed paths. The patch
+// adds:
+//   - a timeout wrapper around fs.realpath in validatePath
+//   - a timeout wrapper around fs.readdir in searchFilesWithValidation
+//   - a max-visited-entries cap on recursive search
+//   - boundary-aware FS_SEARCH_EXCLUDE_PREFIXES that refuses recursive search
+//     outright on user-configured roots
+//
+// These tests use fake timers to exercise the timeout paths without slow real
+// waits, and mock fs/promises at the module level so no real filesystem state
+// is touched.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import type { Dirent } from 'fs';
+
+vi.mock('fs/promises');
+const mockFs = fs as any;
+
+// The diff reads its env vars at module load. We don't try to retune them per
+// test (which would need module re-import dance); we trust the defaults and
+// drive behaviour by making the mocked fs call hang past the default timeout
+// or by enumerating enough mocked entries to exceed the default cap.
+//
+// Default timeout is 15s (FS_OP_TIMEOUT_MS). With fake timers we just advance
+// past that — no real wait.
+// Default visited cap is 50_000 (FS_SEARCH_MAX_VISITED). We mock readdir to
+// return one directory containing that many synthetic entries.
+
+const ALLOWED = process.platform === 'win32' ? ['C:\\allowed'] : ['/allowed'];
+const ROOT = process.platform === 'win32' ? 'C:\\allowed' : '/allowed';
+const FILE = process.platform === 'win32' ? 'C:\\allowed\\file.txt' : '/allowed/file.txt';
+
+function mkDirent(name: string, isDir = false): Dirent {
+  return {
+    name,
+    isFile: () => !isDir,
+    isDirectory: () => isDir,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    parentPath: '',
+    path: '',
+  } as unknown as Dirent;
+}
+
+describe('issue #4162: timeouts + max-visited cap', () => {
+  let setAllowedDirectories: typeof import('../lib.js').setAllowedDirectories;
+  let validatePath: typeof import('../lib.js').validatePath;
+  let searchFilesWithValidation: typeof import('../lib.js').searchFilesWithValidation;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    const lib = await import('../lib.js');
+    setAllowedDirectories = lib.setAllowedDirectories;
+    validatePath = lib.validatePath;
+    searchFilesWithValidation = lib.searchFilesWithValidation;
+    setAllowedDirectories(ALLOWED);
+  });
+
+  afterEach(() => {
+    setAllowedDirectories([]);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('validatePath: fs.realpath timeout', () => {
+    it('rejects with FsTimeoutError when realpath hangs past FS_OP_TIMEOUT_MS', async () => {
+      vi.useFakeTimers();
+      // realpath returns a promise that never settles — the previous code would
+      // hang forever; the patch must surface a timeout.
+      mockFs.realpath.mockImplementation(() => new Promise(() => {}));
+
+      const op = validatePath(FILE);
+      // Attach a no-op catch BEFORE timer fires, so the rejection is "handled"
+      // by the time vi.advanceTimersByTimeAsync flushes microtasks. Without
+      // this, vitest's strict unhandled-rejection checker trips even though
+      // expect.rejects below will observe the same rejection.
+      op.catch(() => {});
+      // Advance past the 15s default. We use 20s for a margin.
+      await vi.advanceTimersByTimeAsync(20_000);
+      await expect(op).rejects.toThrow(/timed out/i);
+    });
+
+    it('preserves ENOENT path: surfaces "Parent directory does not exist" when both realpaths reject ENOENT', async () => {
+      // Regression for the ENOENT-branch refactor in the patch — a non-existent
+      // file with a non-existent parent must still produce the original error,
+      // not a misleading timeout.
+      const enoent = (): NodeJS.ErrnoException => {
+        const e = new Error('ENOENT') as NodeJS.ErrnoException;
+        e.code = 'ENOENT';
+        return e;
+      };
+      mockFs.realpath
+        .mockRejectedValueOnce(enoent())
+        .mockRejectedValueOnce(enoent());
+
+      await expect(
+        validatePath(
+          process.platform === 'win32'
+            ? 'C:\\allowed\\missing\\file.txt'
+            : '/allowed/missing/file.txt',
+        ),
+      ).rejects.toThrow(/Parent directory does not exist/);
+    });
+
+    it('ENOENT-branch realpath timeout surfaces as FsTimeoutError, not masked as missing-parent', async () => {
+      // Verifies the refactor: a hung parent realpath must propagate the
+      // timeout rather than collapse into "Parent directory does not exist".
+      vi.useFakeTimers();
+      const enoent = new Error('ENOENT') as NodeJS.ErrnoException;
+      enoent.code = 'ENOENT';
+      mockFs.realpath
+        .mockRejectedValueOnce(enoent)
+        .mockImplementationOnce(() => new Promise(() => {})); // parent hangs
+
+      const op = validatePath(
+        process.platform === 'win32'
+          ? 'C:\\allowed\\new\\file.txt'
+          : '/allowed/new/file.txt',
+      );
+      op.catch(() => {}); // see note above
+      await vi.advanceTimersByTimeAsync(20_000);
+      await expect(op).rejects.toThrow(/timed out/i);
+    });
+  });
+
+  describe('searchFilesWithValidation: fs.readdir timeout', () => {
+    it('rejects with FsTimeoutError when readdir hangs past FS_OP_TIMEOUT_MS', async () => {
+      vi.useFakeTimers();
+      mockFs.realpath.mockImplementation(async (p: any) => p.toString());
+      mockFs.readdir.mockImplementation(() => new Promise(() => {}));
+
+      const op = searchFilesWithValidation(ROOT, '**/*', ALLOWED);
+      op.catch(() => {}); // see note above
+      await vi.advanceTimersByTimeAsync(20_000);
+      await expect(op).rejects.toThrow(/timed out/i);
+    });
+
+    it('per-entry timeout propagates instead of being swallowed by catch-continue', async () => {
+      // Critical for the patch: the existing per-entry `catch { continue }`
+      // must re-throw FsTimeoutError so a search never returns silently-partial
+      // results. We make readdir succeed once with two entries, the second of
+      // which has a realpath that hangs.
+      vi.useFakeTimers();
+      mockFs.readdir.mockResolvedValueOnce([
+        mkDirent('a.txt'),
+        mkDirent('b.txt'),
+      ]);
+      // First entry's realpath resolves fine, second hangs forever.
+      let call = 0;
+      mockFs.realpath.mockImplementation((p: any) => {
+        call++;
+        if (call === 1) return Promise.resolve(p.toString());
+        return new Promise(() => {});
+      });
+
+      const op = searchFilesWithValidation(ROOT, '**/*', ALLOWED);
+      op.catch(() => {}); // see note above
+      await vi.advanceTimersByTimeAsync(20_000);
+      await expect(op).rejects.toThrow(/timed out/i);
+    });
+  });
+
+  describe('searchFilesWithValidation: FS_SEARCH_MAX_VISITED cap', () => {
+    // Drive the cap via env-var rather than a 50_001-entry fixture: cleaner,
+    // faster, and exercises the same code path. Module is re-imported per test
+    // so the module-level read of FS_SEARCH_MAX_VISITED picks up our value.
+    beforeEach(async () => {
+      vi.resetModules();
+      process.env.FS_SEARCH_MAX_VISITED = '5';
+      const lib = await import('../lib.js');
+      setAllowedDirectories = lib.setAllowedDirectories;
+      searchFilesWithValidation = lib.searchFilesWithValidation;
+      setAllowedDirectories(ALLOWED);
+    });
+
+    afterEach(() => {
+      delete process.env.FS_SEARCH_MAX_VISITED;
+    });
+
+    it('aborts with a typed FsSearchTruncatedError once the visited cap is exceeded', async () => {
+      const { FsSearchTruncatedError } = await import('../lib.js');
+      const entries: Dirent[] = [];
+      for (let i = 0; i < 10; i++) entries.push(mkDirent(`f${i}.txt`));
+      mockFs.readdir.mockResolvedValue(entries);
+      mockFs.realpath.mockImplementation(async (p: any) => p.toString());
+
+      // Message is still clear...
+      await expect(
+        searchFilesWithValidation(ROOT, '**/*', ALLOWED),
+      ).rejects.toThrow(/Search aborted after visiting/);
+
+      // ...and the abort is observable by type (parity with FsTimeoutError),
+      // carrying the visit count + cap for diagnostics.
+      const err = await searchFilesWithValidation(ROOT, '**/*', ALLOWED).catch(e => e);
+      expect(err).toBeInstanceOf(FsSearchTruncatedError);
+      expect(err.visited).toBeGreaterThanOrEqual(5);
+      expect(err.maxVisited).toBe(5);
+    });
+
+    it('returns normally when entry count is well under the cap', async () => {
+      mockFs.readdir.mockResolvedValueOnce([
+        mkDirent('hit.txt'),
+        mkDirent('miss.log'),
+      ]);
+      mockFs.realpath.mockImplementation(async (p: any) => p.toString());
+
+      const out = await searchFilesWithValidation(ROOT, '**/*.txt', ALLOWED);
+      expect(out.some(p => p.endsWith('hit.txt'))).toBe(true);
+      expect(out.some(p => p.endsWith('miss.log'))).toBe(false);
+    });
+  });
+
+  describe('FS_SEARCH_EXCLUDE_PREFIXES', () => {
+    // Set the env var BEFORE importing lib.ts so the module-level read picks
+    // it up. We isolate this in its own describe so vi.resetModules() rewinds
+    // cleanly between tests.
+    const EXCLUDED = process.platform === 'win32' ? 'C:\\allowed\\slow' : '/allowed/slow';
+
+    beforeEach(async () => {
+      vi.resetModules();
+      process.env.FS_SEARCH_EXCLUDE_PREFIXES = EXCLUDED;
+      const lib = await import('../lib.js');
+      setAllowedDirectories = lib.setAllowedDirectories;
+      searchFilesWithValidation = lib.searchFilesWithValidation;
+      setAllowedDirectories(ALLOWED);
+    });
+
+    afterEach(() => {
+      delete process.env.FS_SEARCH_EXCLUDE_PREFIXES;
+    });
+
+    it('refuses recursive search when root is inside an excluded prefix', async () => {
+      await expect(
+        searchFilesWithValidation(EXCLUDED, '**/*', ALLOWED),
+      ).rejects.toThrow(/Recursive search is disabled/);
+    });
+
+    it('does not match an unrelated sibling that merely shares a string head (boundary-aware)', async () => {
+      // /allowed/slowdown must NOT be excluded just because '/allowed/slow' is
+      // a substring of it. This is the containment-via-isPathWithinAllowedDirectories
+      // guarantee from the patch.
+      const sibling = process.platform === 'win32' ? 'C:\\allowed\\slowdown' : '/allowed/slowdown';
+      mockFs.readdir.mockResolvedValueOnce([mkDirent('ok.txt')]);
+      mockFs.realpath.mockImplementation(async (p: any) => p.toString());
+
+      const out = await searchFilesWithValidation(sibling, '**/*', ALLOWED);
+      expect(out.length).toBeGreaterThanOrEqual(0); // did not throw
+    });
+
+    it('shared helper assertSearchPathNotExcluded customises the operation name', async () => {
+      // The same containment check is reused by the directory_tree handler in
+      // index.ts via assertSearchPathNotExcluded(rootPath, 'directory_tree').
+      // We can't unit-test the inline handler directly, but we can exercise
+      // the shared helper to confirm the error wording reflects the opName.
+      const { assertSearchPathNotExcluded } = await import('../lib.js');
+      expect(() => assertSearchPathNotExcluded(EXCLUDED, 'directory_tree'))
+        .toThrow(/directory_tree is disabled.*FS_SEARCH_EXCLUDE_PREFIXES/);
+    });
+
+    it('helper rejects descendants of an excluded prefix, not just the exact root', async () => {
+      const { assertSearchPathNotExcluded } = await import('../lib.js');
+      const descendant = process.platform === 'win32'
+        ? 'C:\\allowed\\slow\\nested\\deep'
+        : '/allowed/slow/nested/deep';
+      expect(() => assertSearchPathNotExcluded(descendant, 'directory_tree'))
+        .toThrow(/directory_tree is disabled/);
+    });
+
+    it('helper allows a sibling that merely shares a textual prefix with the excluded root', async () => {
+      // /allowed/slowdown is NOT a descendant of /allowed/slow even though
+      // the latter is a string prefix -- the containment check is boundary-aware.
+      const { assertSearchPathNotExcluded } = await import('../lib.js');
+      const sibling = process.platform === 'win32' ? 'C:\\allowed\\slowdown' : '/allowed/slowdown';
+      expect(() => assertSearchPathNotExcluded(sibling, 'directory_tree')).not.toThrow();
+    });
+  });
+
+  describe('env-var validation', () => {
+    afterEach(() => {
+      delete process.env.FS_OP_TIMEOUT_MS;
+      delete process.env.FS_SEARCH_MAX_VISITED;
+    });
+
+    it('ignores non-numeric env values and warns to stderr', async () => {
+      const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+      process.env.FS_OP_TIMEOUT_MS = '15s'; // intentionally invalid
+
+      vi.resetModules();
+      await import('../lib.js');
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/Ignoring invalid FS_OP_TIMEOUT_MS="15s"/),
+      );
+    });
+
+    it('ignores zero/negative values and warns to stderr', async () => {
+      const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
+      process.env.FS_SEARCH_MAX_VISITED = '0';
+
+      vi.resetModules();
+      await import('../lib.js');
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/Ignoring invalid FS_SEARCH_MAX_VISITED="0"/),
+      );
+    });
+  });
+});

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -26,6 +26,11 @@ import {
   tailFile,
   headFile,
   setAllowedDirectories,
+  // #4162: timeout + cap primitives reused by directory_tree
+  withFsTimeout,
+  FS_SEARCH_MAX_VISITED,
+  FsSearchTruncatedError,
+  assertSearchPathNotExcluded,
 } from './lib.js';
 
 // Command line argument parsing
@@ -548,12 +553,38 @@ server.registerTool(
     }
     const rootPath = args.path;
 
+    // #4162: same defensive shape as searchFilesWithValidation -- honour
+    // FS_SEARCH_EXCLUDE_PREFIXES, bound the recursion, and timeout each
+    // readdir so a lazy provider-backed subtree can't keep the server busy
+    // indefinitely. validatePath already wraps fs.realpath via withFsTimeout
+    // in lib.ts, so only readdir + the entry counter need handling here. We
+    // throw immediately when the cap is hit rather than threading an
+    // `aborted` flag through unwinding recursion -- no caller wants a partial
+    // tree, and the immediate throw makes that contract obvious to future
+    // refactors.
+    assertSearchPathNotExcluded(rootPath, 'directory_tree');
+    let visited = 0;
+
     async function buildTree(currentPath: string, excludePatterns: string[] = []): Promise<TreeEntry[]> {
       const validPath = await validatePath(currentPath);
-      const entries = await fs.readdir(validPath, { withFileTypes: true });
+      const entries = await withFsTimeout(
+        fs.readdir(validPath, { withFileTypes: true }),
+        `readdir ${validPath}`,
+      );
       const result: TreeEntry[] = [];
 
       for (const entry of entries) {
+        if (visited >= FS_SEARCH_MAX_VISITED) {
+          throw new FsSearchTruncatedError(
+            `directory_tree aborted after visiting ${visited} entries ` +
+            `(cap FS_SEARCH_MAX_VISITED=${FS_SEARCH_MAX_VISITED}). ` +
+            `Narrow the search path or use excludePatterns.`,
+            visited,
+            FS_SEARCH_MAX_VISITED,
+          );
+        }
+        visited++;
+
         const relativePath = path.relative(rootPath, path.join(currentPath, entry.name));
         const shouldExclude = excludePatterns.some(pattern => {
           if (pattern.includes('*')) {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -40,6 +40,107 @@ export interface SearchResult {
   isDirectory: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Mitigations for issue #4162: recursive search / validatePath can hang for
+// minutes on macOS CloudStorage / lazy provider-backed paths, because
+// fs.realpath and fs.readdir have no timeout and recursive search has no
+// upper bound. All knobs below are env-var configurable and default to
+// behavior that is safe for ordinary local trees.
+//
+//   FS_OP_TIMEOUT_MS            timeout (ms) per fs.realpath / fs.readdir
+//                               call. Default 15000. Positive integer.
+//   FS_SEARCH_MAX_VISITED       max entries a single recursive search may
+//                               visit before aborting. Default 50000.
+//                               Positive integer.
+//   FS_SEARCH_EXCLUDE_PREFIXES  comma-separated path prefixes that recursive
+//                               search refuses outright. Empty by default
+//                               (no behavior change). '~' is expanded.
+//
+// Invalid numeric values are ignored (a warning is logged) and the default is
+// used, so a typo cannot silently disable a guard.
+// ---------------------------------------------------------------------------
+
+// Raised when a wrapped filesystem call exceeds FS_OP_TIMEOUT_MS. Distinct
+// from ordinary fs errors so callers can tell a hang apart from e.g. EACCES
+// and avoid silently swallowing it.
+export class FsTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FsTimeoutError';
+  }
+}
+
+// Raised when a recursive search / directory walk reaches FS_SEARCH_MAX_VISITED.
+// A safety-cap abort is a deliberate early exit, not a genuine empty result, so
+// it gets its own type (mirroring FsTimeoutError) -- callers can discriminate it
+// via instanceof rather than string-matching the message, and it carries the
+// visit count and cap for diagnostics.
+export class FsSearchTruncatedError extends Error {
+  constructor(
+    message: string,
+    public readonly visited: number,
+    public readonly maxVisited: number,
+  ) {
+    super(message);
+    this.name = 'FsSearchTruncatedError';
+  }
+}
+
+// Reads a positive-integer env var, falling back to `defaultValue` (with a
+// warning) when unset or invalid. Uses Number() rather than parseInt() so that
+// partially-numeric garbage such as "15s" is rejected instead of truncated.
+function readPositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    console.error(`[filesystem] Ignoring invalid ${name}="${raw}"; using default ${defaultValue}.`);
+    return defaultValue;
+  }
+  return parsed;
+}
+
+// Timeout (ms) applied to individual fs.realpath / fs.readdir calls.
+const FS_OP_TIMEOUT_MS = readPositiveIntEnv('FS_OP_TIMEOUT_MS', 15000);
+
+// Hard cap on entries visited by a single recursive search before it aborts.
+export const FS_SEARCH_MAX_VISITED = readPositiveIntEnv('FS_SEARCH_MAX_VISITED', 50000);
+
+// Opt-in: comma-separated path prefixes that recursive search refuses outright.
+// Empty by default -- no behavior change unless the user sets it. Intended for
+// known-slow provider-backed roots (e.g. a CloudStorage folder). Each entry is
+// expanded ('~') and normalized so the containment check below is boundary-
+// aware: "/data/foo" must not match an unrelated "/data/foobar" root.
+const FS_SEARCH_EXCLUDE_PREFIXES = (process.env.FS_SEARCH_EXCLUDE_PREFIXES ?? '')
+  .split(',')
+  .map(prefix => prefix.trim())
+  .filter(prefix => prefix.length > 0)
+  .map(prefix => normalizePath(path.resolve(expandHome(prefix))));
+
+// Races a filesystem promise against a timeout. On timeout it rejects with an
+// FsTimeoutError instead of letting the caller hang. Note: the underlying fs
+// operation cannot be cancelled and may still settle in the background; the
+// timeout only unblocks the caller.
+export async function withFsTimeout<T>(operation: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new FsTimeoutError(`Filesystem operation timed out after ${FS_OP_TIMEOUT_MS}ms: ${label}`)),
+      FS_OP_TIMEOUT_MS,
+    );
+  });
+  // Defensive: if the operation wins the race, the timeout promise is left
+  // unhandled. Attach a no-op catch so the eventual rejection (if the timer
+  // does fire before clearTimeout takes effect) isn't reported as an
+  // unhandled rejection. The race result is unaffected.
+  timeout.catch(() => {});
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
 // Pure Utility Functions
 export function formatSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
@@ -112,8 +213,10 @@ export async function validatePath(requestedPath: string): Promise<string> {
 
   // Security: Handle symlinks by checking their real path to prevent symlink attacks
   // This prevents attackers from creating symlinks that point outside allowed directories
+  // #4162: fs.realpath is wrapped with a timeout so a lazy provider-backed path
+  // cannot block validation indefinitely.
   try {
-    const realPath = await fs.realpath(absolute);
+    const realPath = await withFsTimeout(fs.realpath(absolute), `realpath ${absolute}`);
     const normalizedReal = normalizePath(realPath);
     if (!isPathWithinAllowedDirectories(normalizedReal, allowedDirectories)) {
       throw new Error(`Access denied - symlink target outside allowed directories: ${realPath} not in ${allowedDirectories.join(', ')}`);
@@ -124,16 +227,21 @@ export async function validatePath(requestedPath: string): Promise<string> {
     // This ensures we can't create files in unauthorized locations
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       const parentDir = path.dirname(absolute);
+      // #4162: only the realpath call is inside this try, so a timeout
+      // surfaces as FsTimeoutError and the access-denied check below is not
+      // masked into a misleading "Parent directory does not exist".
+      let realParentPath: string;
       try {
-        const realParentPath = await fs.realpath(parentDir);
-        const normalizedParent = normalizePath(realParentPath);
-        if (!isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
-          throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
-        }
-        return absolute;
-      } catch {
+        realParentPath = await withFsTimeout(fs.realpath(parentDir), `realpath ${parentDir}`);
+      } catch (parentError) {
+        if (parentError instanceof FsTimeoutError) throw parentError;
         throw new Error(`Parent directory does not exist: ${parentDir}`);
       }
+      const normalizedParent = normalizePath(realParentPath);
+      if (!isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
+        throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
+      }
+      return absolute;
     }
     throw error;
   }
@@ -371,19 +479,60 @@ export async function headFile(filePath: string, numLines: number): Promise<stri
   }
 }
 
+// #4162: refuse recursive operations outright on user-configured slow roots.
+// Exported so both searchFilesWithValidation here and the directory_tree handler
+// in index.ts share the same containment check -- containment reuses
+// isPathWithinAllowedDirectories so it is boundary-aware: a prefix cannot match
+// an unrelated sibling that merely shares a string head.
+export function assertSearchPathNotExcluded(rootPath: string, opName: string): void {
+  if (FS_SEARCH_EXCLUDE_PREFIXES.length === 0) return;
+  // FS_SEARCH_EXCLUDE_PREFIXES is expanded with expandHome at module load
+  // (see above), so apply the same to rootPath here for symmetric comparison.
+  const normalizedRoot = normalizePath(path.resolve(expandHome(rootPath)));
+  if (isPathWithinAllowedDirectories(normalizedRoot, FS_SEARCH_EXCLUDE_PREFIXES)) {
+    throw new Error(
+      `${opName} is disabled for this path by FS_SEARCH_EXCLUDE_PREFIXES: ${rootPath}. ` +
+      `Recursive operations over lazy provider-backed trees (macOS CloudStorage / FileProvider) ` +
+      `are unreliable; use list_directory on specific subfolders, or narrow the search root.`
+    );
+  }
+}
+
 export async function searchFilesWithValidation(
   rootPath: string,
   pattern: string,
   allowedDirectories: string[],
   options: SearchOptions = {}
 ): Promise<string[]> {
+  assertSearchPathNotExcluded(rootPath, 'Recursive search');
+
   const { excludePatterns = [] } = options;
   const results: string[] = [];
+  // #4162: bound the recursion so a large / lazy-materialized tree cannot keep
+  // the server busy indefinitely. The search aborts once FS_SEARCH_MAX_VISITED
+  // entries have been visited; `aborted` is checked at every re-entry.
+  let visited = 0;
+  let aborted = false;
 
   async function search(currentPath: string) {
-    const entries = await fs.readdir(currentPath, { withFileTypes: true });
+    if (aborted) return;
+    // #4162: fs.readdir is wrapped with a timeout. A timeout (FsTimeoutError)
+    // propagates to the caller from any depth: the per-entry catch below
+    // deliberately re-throws timeouts instead of swallowing them, so a search
+    // never returns silently-partial results.
+    const entries = await withFsTimeout(
+      fs.readdir(currentPath, { withFileTypes: true }),
+      `readdir ${currentPath}`,
+    );
 
     for (const entry of entries) {
+      if (aborted) return;
+      if (visited >= FS_SEARCH_MAX_VISITED) {
+        aborted = true;
+        return;
+      }
+      visited++;
+
       const fullPath = path.join(currentPath, entry.name);
 
       try {
@@ -403,13 +552,26 @@ export async function searchFilesWithValidation(
 
         if (entry.isDirectory()) {
           await search(fullPath);
+          if (aborted) return;
         }
-      } catch {
+      } catch (error) {
+        // #4162: a timeout is a real hang, not an inaccessible entry -- surface
+        // it instead of continuing with partial results.
+        if (error instanceof FsTimeoutError) throw error;
         continue;
       }
     }
   }
 
   await search(rootPath);
+  if (aborted) {
+    throw new FsSearchTruncatedError(
+      `Search aborted after visiting ${visited} entries ` +
+      `(cap FS_SEARCH_MAX_VISITED=${FS_SEARCH_MAX_VISITED}). ` +
+      `Refine the pattern (e.g. '**/name') or narrow the search path.`,
+      visited,
+      FS_SEARCH_MAX_VISITED,
+    );
+  }
   return results;
 }


### PR DESCRIPTION
## Description

Bounds two unbounded code paths in the filesystem server that can hang for minutes on macOS CloudStorage / FileProvider-backed directories: `fs.realpath` in `validatePath`, and recursive `fs.readdir` in `search_files` / `directory_tree`. Addresses the structural concerns from #4162 that #4181 (excludePatterns before realpath) left open.

Follow-up design question about symlink-aware excludes is tracked separately in #4208 — intentionally not in scope here.

## Server Details
- Server: filesystem
- Changes to: tools (`search_files`, `directory_tree`, internal `validatePath`)

## Motivation and Context

`fs.realpath` and `fs.readdir` are called with no timeout. On macOS provider-backed paths (`~/Library/CloudStorage/...`, `~/Library/Mobile Documents/com~apple~CloudDocs/...`, and NFS/SMB), these can block while the provider fetches metadata; recursive search additionally has no upper bound on entries visited. The host (e.g. Claude Desktop) eventually reports the connector unresponsive (~4 min) while the subprocess stays alive but stuck. See #4162 for the full report.

The defensive shape here originated from @alemuenchen, who has run equivalent mitigations in production against Google Drive + iCloud Drive for several weeks and contributed the reference diff on #4162.

### What this adds

`src/filesystem/lib.ts`:
- `withFsTimeout()` wraps `fs.realpath` (in `validatePath`) and `fs.readdir` (in `searchFilesWithValidation`); on timeout it rejects with a typed `FsTimeoutError` rather than hanging.
- `FS_SEARCH_MAX_VISITED` caps recursive search; abort produces a clear "narrow the path / refine the pattern" error.
- `FS_SEARCH_EXCLUDE_PREFIXES` (opt-in, empty default) refuses recursive operations on configured slow roots, via the shared, boundary-aware `assertSearchPathNotExcluded` helper (reuses `isPathWithinAllowedDirectories`).
- ENOENT branch in `validatePath` refactored so a hung parent realpath surfaces as `FsTimeoutError` instead of being masked as "Parent directory does not exist".
- The per-entry `catch` in search re-throws `FsTimeoutError` so a search never returns silently-partial results.

`src/filesystem/index.ts`:
- `directory_tree` gets the same timeout + visited-cap treatment and shares the exclude-prefix helper.

### Configuration

| Variable | Default | Purpose |
|---|---|---|
| `FS_OP_TIMEOUT_MS` | `15000` | Timeout (ms) per `fs.realpath` / `fs.readdir`. |
| `FS_SEARCH_MAX_VISITED` | `50000` | Cap on entries visited by a single `search_files` / `directory_tree` before aborting. |
| `FS_SEARCH_EXCLUDE_PREFIXES` | (empty) | Comma-separated path prefixes recursive ops refuse outright. Lexical prefilter (see #4208 / README). |

Invalid numeric values warn to stderr and fall back to the default, so a typo cannot silently disable a guard.

## How Has This Been Tested?

- New `__tests__/4162-timeouts-and-caps.test.ts` (14 cases): realpath/readdir timeouts, ENOENT preservation + ENOENT-realpath-timeout regression, per-entry `FsTimeoutError` propagation, max-visited abort, exclude-prefix containment (descendant + boundary-aware sibling), env-var validation. Uses vitest fake timers + mocked `fs/promises`, so no real CloudStorage path is needed in CI.
- Full suite: **160/160 pass**, clean build, `lib.ts` coverage 82% stmts / 88% branch / 94% funcs.
- @alemuenchen independently pulled the branch and tested against a **real macOS Google Drive tree** with a live MCP client: no regression on pattern matching, cap + exclude-prefix behaviour confirmed, timeout does not misfire on warm provider paths.

## Breaking Changes

None. All new behaviour is bounded by env vars that default to safe values for ordinary local trees; existing configurations are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client (via @alemuenchen on a live macOS CloudStorage setup; I verified locally with unit tests + build)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (160/160)
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

Deliberately out of scope (worth their own follow-ups, flagged so as not to muddy this PR):
- **libuv threadpool** — timed-out `fs` calls still occupy the threadpool until they settle; a concurrency limiter is a separate mitigation.
- **Single huge directory** — the cap bounds breadth/depth but one `readdir` on a directory with millions of entries is still a single allocation; `fs.opendir` streaming would address this.
- **Symlink-aware excludes** — `FS_SEARCH_EXCLUDE_PREFIXES` is a lexical prefilter; a symlink whose target is under an excluded prefix is not blocked. Design discussion in #4208.

Credit: the core defensive diff is @alemuenchen's, contributed on #4162 with his blessing to take it forward. Tests, `directory_tree` integration, the shared exclude helper, README, and this PR are mine.