### PR TITLE
fix(git): handle input without crashing

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -584,4 +584,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)


### PR DESCRIPTION
## Description

This PR changes `mcp-server-git` to run the stdio server with `raise_exceptions=False` instead of `raise_exceptions=True`.

With `raise_exceptions=True`,  JSON-RPC input can cause exceptions from stdin parsing to propagate into the server task group and terminate the process. With the default behavior, the server reports the error back to the client as a JSON-RPC error and keeps running.

Fixes #4213.

## Publishing Your Server

N/A — this PR modifies an existing reference server and does not add a new server.

## Server Details

- Server: git
- Changes to: stdio error handling

## Motivation and Context

`mcp-server-git` currently differs from reference servers such as `mcp-server-time` and `mcp-server-sqlite`, which use the default `raise_exceptions=False` behavior.

A similar issue was previously fixed for `mcp-server-fetch` in PR #3515. This PR applies the same kind of follow-up cleanup to `mcp-server-git`.

The change prevents malformed or unparseable JSON-RPC input from terminating the server process.

## How Has This Been Tested?

Tested with the reproducer from #4213:

- before the change, a deeply nested JSON-RPC request caused `mcp-server-git` to exit with code 1 and print a `ValidationError: recursion limit exceeded`;
- after the change, the server no longer terminates on that input and reports the malformed input as a JSON-RPC error.

Also verified that normal initialization and tool calls still work.

## Breaking Changes

None. This is a non-breaking robustness fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

This is a one-line change:

```diff
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)