### PR TITLE
fix(filesystem): handle UNC share root allowlists

### DIFF
--- a/src/filesystem/__tests__/path-validation.test.ts
+++ b/src/filesystem/__tests__/path-validation.test.ts
@@ -437,6 +437,10 @@ describe('Path Validation', () => {
         expect(isPathWithinAllowedDirectories('\\\\server\\share\\project\\file', allowed)).toBe(true);
         expect(isPathWithinAllowedDirectories('\\\\server\\share\\other', allowed)).toBe(false);
         expect(isPathWithinAllowedDirectories('\\\\other\\share\\project', allowed)).toBe(false);
+
+        const shareRoot = ['\\\\server\\share\\'];
+        expect(isPathWithinAllowedDirectories('\\\\server\\share\\file.txt', shareRoot)).toBe(true);
+        expect(isPathWithinAllowedDirectories('\\\\server\\share-other\\file.txt', shareRoot)).toBe(false);
       }
     });
   });

--- a/src/filesystem/path-validation.ts
+++ b/src/filesystem/path-validation.ts
@@ -81,6 +81,9 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
       return pathDrive === dirDrive && normalizedPath.startsWith(normalizedDir.replace(/\\?$/, '\\'));
     }
     
-    return normalizedPath.startsWith(normalizedDir + path.sep);
+    const normalizedDirWithSep = normalizedDir.endsWith(path.sep)
+      ? normalizedDir
+      : normalizedDir + path.sep;
+    return normalizedPath.startsWith(normalizedDirWithSep);
   });
 }


### PR DESCRIPTION
Fixes #3756.

UNC share roots keep a trailing separator after Windows path normalization. The allow-list check then appended another separator before the prefix comparison, so a file under `\\server\share\` was compared against `\\server\share\\` and rejected.

This keeps the existing equality check and only adds a separator when the normalized allowed directory does not already end with one.

## To verify

- npm exec -w src/filesystem -- vitest run __tests__/path-validation.test.ts --testNamePattern "UNC paths"
- npm exec -w src/filesystem -- vitest run __tests__/path-validation.test.ts
- npm run build -w src/filesystem
- git diff --check