### PR TITLE
fix(git): resolve server crash on validation errors

### DIFF
--- a/src/git/src/mcp_server_git/__init__.py
+++ b/src/git/src/mcp_server_git/__init__.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from .server import serve
 
+
 @click.command()
 @click.option("--repository", "-r", type=Path, help="Git repository path")
 @click.option("-v", "--verbose", count=True)
@@ -19,6 +20,7 @@ def main(repository: Path | None, verbose: bool) -> None:
 
     logging.basicConfig(level=logging_level, stream=sys.stderr)
     asyncio.run(serve(repository))
+
 
 if __name__ == "__main__":
     main()

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -20,58 +20,68 @@ from pydantic import BaseModel, Field
 # Default number of context lines to show in diff output
 DEFAULT_CONTEXT_LINES = 3
 
+
 class GitStatus(BaseModel):
     repo_path: str
+
 
 class GitDiffUnstaged(BaseModel):
     repo_path: str
     context_lines: int = DEFAULT_CONTEXT_LINES
 
+
 class GitDiffStaged(BaseModel):
     repo_path: str
     context_lines: int = DEFAULT_CONTEXT_LINES
+
 
 class GitDiff(BaseModel):
     repo_path: str
     target: str
     context_lines: int = DEFAULT_CONTEXT_LINES
 
+
 class GitCommit(BaseModel):
     repo_path: str
     message: str
+
 
 class GitAdd(BaseModel):
     repo_path: str
     files: list[str]
 
+
 class GitReset(BaseModel):
     repo_path: str
+
 
 class GitLog(BaseModel):
     repo_path: str
     max_count: int = 10
     start_timestamp: Optional[str] = Field(
         None,
-        description="Start timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')"
+        description="Start timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')",
     )
     end_timestamp: Optional[str] = Field(
         None,
-        description="End timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')"
+        description="End timestamp for filtering commits. Accepts: ISO 8601 format (e.g., '2024-01-15T14:30:25'), relative dates (e.g., '2 weeks ago', 'yesterday'), or absolute dates (e.g., '2024-01-15', 'Jan 15 2024')",
     )
+
 
 class GitCreateBranch(BaseModel):
     repo_path: str
     branch_name: str
     base_branch: str | None = None
 
+
 class GitCheckout(BaseModel):
     repo_path: str
     branch_name: str
 
+
 class GitShow(BaseModel):
     repo_path: str
     revision: str
-
 
 
 class GitBranch(BaseModel):
@@ -108,16 +118,24 @@ class GitTools(str, Enum):
 
     BRANCH = "git_branch"
 
+
 def git_status(repo: git.Repo) -> str:
     return repo.git.status()
 
-def git_diff_unstaged(repo: git.Repo, context_lines: int = DEFAULT_CONTEXT_LINES) -> str:
+
+def git_diff_unstaged(
+    repo: git.Repo, context_lines: int = DEFAULT_CONTEXT_LINES
+) -> str:
     return repo.git.diff(f"--unified={context_lines}")
+
 
 def git_diff_staged(repo: git.Repo, context_lines: int = DEFAULT_CONTEXT_LINES) -> str:
     return repo.git.diff(f"--unified={context_lines}", "--cached")
 
-def git_diff(repo: git.Repo, target: str, context_lines: int = DEFAULT_CONTEXT_LINES) -> str:
+
+def git_diff(
+    repo: git.Repo, target: str, context_lines: int = DEFAULT_CONTEXT_LINES
+) -> str:
     # Defense in depth: reject targets starting with '-' to prevent flag injection,
     # even if a malicious ref with that name exists (e.g. via filesystem manipulation)
     if target.startswith("-"):
@@ -125,9 +143,11 @@ def git_diff(repo: git.Repo, target: str, context_lines: int = DEFAULT_CONTEXT_L
     repo.rev_parse(target)  # Validates target is a real git ref, throws BadName if not
     return repo.git.diff(f"--unified={context_lines}", target)
 
+
 def git_commit(repo: git.Repo, message: str) -> str:
     commit = repo.index.commit(message)
     return f"Changes committed successfully with hash {commit.hexsha}"
+
 
 def git_add(repo: git.Repo, files: list[str]) -> str:
     if files == ["."]:
@@ -152,26 +172,37 @@ def git_add(repo: git.Repo, files: list[str]) -> str:
         repo.git.add("--", *files)
     return "Files staged successfully"
 
+
 def git_reset(repo: git.Repo) -> str:
     repo.index.reset()
     return "All staged changes reset"
 
-def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] = None, end_timestamp: Optional[str] = None) -> list[str]:
+
+def git_log(
+    repo: git.Repo,
+    max_count: int = 10,
+    start_timestamp: Optional[str] = None,
+    end_timestamp: Optional[str] = None,
+) -> list[str]:
     if start_timestamp or end_timestamp:
         # Defense in depth: reject timestamps starting with '-' to prevent flag injection
         if start_timestamp and start_timestamp.startswith("-"):
-            raise ValueError(f"Invalid start_timestamp: '{start_timestamp}' - cannot start with '-'")
+            raise ValueError(
+                f"Invalid start_timestamp: '{start_timestamp}' - cannot start with '-'"
+            )
         if end_timestamp and end_timestamp.startswith("-"):
-            raise ValueError(f"Invalid end_timestamp: '{end_timestamp}' - cannot start with '-'")
+            raise ValueError(
+                f"Invalid end_timestamp: '{end_timestamp}' - cannot start with '-'"
+            )
         # Use git log command with date filtering
         args = []
         if start_timestamp:
-            args.extend(['--since', start_timestamp])
+            args.extend(["--since", start_timestamp])
         if end_timestamp:
-            args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+            args.extend(["--until", end_timestamp])
+        args.extend(["--format=%H%n%an%n%ad%n%s%n"])
 
-        log_output = repo.git.log(*args).split('\n')
+        log_output = repo.git.log(*args).split("\n")
 
         log = []
         # Process commits in groups of 4 (hash, author, date, message)
@@ -197,7 +228,10 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
             )
         return log
 
-def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None = None) -> str:
+
+def git_create_branch(
+    repo: git.Repo, branch_name: str, base_branch: str | None = None
+) -> str:
     # Defense in depth: reject names starting with '-' to prevent flag injection
     if branch_name.startswith("-"):
         raise BadName(f"Invalid branch name: '{branch_name}' - cannot start with '-'")
@@ -211,15 +245,17 @@ def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None 
     repo.create_head(branch_name, base)
     return f"Created branch '{branch_name}' from '{base.name}'"
 
+
 def git_checkout(repo: git.Repo, branch_name: str) -> str:
     # Defense in depth: reject branch names starting with '-' to prevent flag injection,
     # even if a malicious ref with that name exists (e.g. via filesystem manipulation)
     if branch_name.startswith("-"):
         raise BadName(f"Invalid branch name: '{branch_name}' - cannot start with '-'")
-    repo.rev_parse(branch_name)  # Validates branch_name is a real git ref, throws BadName if not
+    repo.rev_parse(
+        branch_name
+    )  # Validates branch_name is a real git ref, throws BadName if not
     repo.git.checkout(branch_name)
     return f"Switched to branch '{branch_name}'"
-
 
 
 def git_show(repo: git.Repo, revision: str) -> str:
@@ -244,10 +280,11 @@ def git_show(repo: git.Repo, revision: str) -> str:
         if d.diff is None:
             continue
         if isinstance(d.diff, bytes):
-            output.append(d.diff.decode('utf-8'))
+            output.append(d.diff.decode("utf-8"))
         else:
             output.append(d.diff)
     return "".join(output)
+
 
 def validate_repo_path(repo_path: Path, allowed_repository: Path | None) -> None:
     """Validate that repo_path is within the allowed repository path."""
@@ -270,12 +307,19 @@ def validate_repo_path(repo_path: Path, allowed_repository: Path | None) -> None
         )
 
 
-def git_branch(repo: git.Repo, branch_type: str, contains: str | None = None, not_contains: str | None = None) -> str:
+def git_branch(
+    repo: git.Repo,
+    branch_type: str,
+    contains: str | None = None,
+    not_contains: str | None = None,
+) -> str:
     # Defense in depth: reject values starting with '-' to prevent flag injection
     if contains and contains.startswith("-"):
         raise BadName(f"Invalid contains value: '{contains}' - cannot start with '-'")
     if not_contains and not_contains.startswith("-"):
-        raise BadName(f"Invalid not_contains value: '{not_contains}' - cannot start with '-'")
+        raise BadName(
+            f"Invalid not_contains value: '{not_contains}' - cannot start with '-'"
+        )
 
     match contains:
         case None:
@@ -290,11 +334,11 @@ def git_branch(repo: git.Repo, branch_type: str, contains: str | None = None, no
             not_contains_sha = ("--no-contains", not_contains)
 
     match branch_type:
-        case 'local':
+        case "local":
             b_type = None
-        case 'remote':
+        case "remote":
             b_type = "-r"
-        case 'all':
+        case "all":
             b_type = "-a"
         case _:
             return f"Invalid branch type: {branch_type}"
@@ -452,20 +496,24 @@ async def serve(repository: Path | None) -> None:
                     idempotentHint=True,
                     openWorldHint=False,
                 ),
-            )
+            ),
         ]
 
     async def list_repos() -> Sequence[str]:
         async def by_roots() -> Sequence[str]:
             if not isinstance(server.request_context.session, ServerSession):
-                raise TypeError("server.request_context.session must be a ServerSession")
+                raise TypeError(
+                    "server.request_context.session must be a ServerSession"
+                )
 
             if not server.request_context.session.check_client_capability(
                 ClientCapabilities(roots=RootsCapability())
             ):
                 return []
 
-            roots_result: ListRootsResult = await server.request_context.session.list_roots()
+            roots_result: ListRootsResult = (
+                await server.request_context.session.list_roots()
+            )
             logger.debug(f"Roots result: {roots_result}")
             repo_paths = []
             for root in roots_result.roots:
@@ -497,52 +545,43 @@ async def serve(repository: Path | None) -> None:
         match name:
             case GitTools.STATUS:
                 status = git_status(repo)
-                return [TextContent(
-                    type="text",
-                    text=f"Repository status:\n{status}"
-                )]
+                return [TextContent(type="text", text=f"Repository status:\n{status}")]
 
             case GitTools.DIFF_UNSTAGED:
-                diff = git_diff_unstaged(repo, arguments.get("context_lines", DEFAULT_CONTEXT_LINES))
-                return [TextContent(
-                    type="text",
-                    text=f"Unstaged changes:\n{diff}"
-                )]
+                diff = git_diff_unstaged(
+                    repo, arguments.get("context_lines", DEFAULT_CONTEXT_LINES)
+                )
+                return [TextContent(type="text", text=f"Unstaged changes:\n{diff}")]
 
             case GitTools.DIFF_STAGED:
-                diff = git_diff_staged(repo, arguments.get("context_lines", DEFAULT_CONTEXT_LINES))
-                return [TextContent(
-                    type="text",
-                    text=f"Staged changes:\n{diff}"
-                )]
+                diff = git_diff_staged(
+                    repo, arguments.get("context_lines", DEFAULT_CONTEXT_LINES)
+                )
+                return [TextContent(type="text", text=f"Staged changes:\n{diff}")]
 
             case GitTools.DIFF:
-                diff = git_diff(repo, arguments["target"], arguments.get("context_lines", DEFAULT_CONTEXT_LINES))
-                return [TextContent(
-                    type="text",
-                    text=f"Diff with {arguments['target']}:\n{diff}"
-                )]
+                diff = git_diff(
+                    repo,
+                    arguments["target"],
+                    arguments.get("context_lines", DEFAULT_CONTEXT_LINES),
+                )
+                return [
+                    TextContent(
+                        type="text", text=f"Diff with {arguments['target']}:\n{diff}"
+                    )
+                ]
 
             case GitTools.COMMIT:
                 result = git_commit(repo, arguments["message"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.ADD:
                 result = git_add(repo, arguments["files"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.RESET:
                 result = git_reset(repo)
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             # Update the LOG case:
             case GitTools.LOG:
@@ -550,49 +589,34 @@ async def serve(repository: Path | None) -> None:
                     repo,
                     arguments.get("max_count", 10),
                     arguments.get("start_timestamp"),
-                    arguments.get("end_timestamp")
+                    arguments.get("end_timestamp"),
                 )
-                return [TextContent(
-                    type="text",
-                    text="Commit history:\n" + "\n".join(log)
-                )]
+                return [
+                    TextContent(type="text", text="Commit history:\n" + "\n".join(log))
+                ]
 
             case GitTools.CREATE_BRANCH:
                 result = git_create_branch(
-                    repo,
-                    arguments["branch_name"],
-                    arguments.get("base_branch")
+                    repo, arguments["branch_name"], arguments.get("base_branch")
                 )
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.CHECKOUT:
                 result = git_checkout(repo, arguments["branch_name"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.SHOW:
                 result = git_show(repo, arguments["revision"])
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case GitTools.BRANCH:
                 result = git_branch(
                     repo,
-                    arguments.get("branch_type", 'local'),
+                    arguments.get("branch_type", "local"),
                     arguments.get("contains", None),
                     arguments.get("not_contains", None),
                 )
-                return [TextContent(
-                    type="text",
-                    text=result
-                )]
+                return [TextContent(type="text", text=result)]
 
             case _:
                 raise ValueError(f"Unknown tool: {name}")

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -599,4 +599,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -19,6 +19,7 @@ from mcp_server_git.server import (
 )
 import shutil
 
+
 @pytest.fixture
 def test_repository(tmp_path: Path):
     repo_path = tmp_path / "temp_test_repo"
@@ -30,7 +31,17 @@ def test_repository(tmp_path: Path):
 
     yield test_repo
 
-    shutil.rmtree(repo_path)
+    test_repo.close()
+
+    def remove_readonly(func, path, excinfo):
+        import stat
+        import os
+
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    shutil.rmtree(repo_path, onerror=remove_readonly)
+
 
 def test_git_checkout_existing_branch(test_repository):
     test_repository.git.branch("test-branch")
@@ -39,31 +50,37 @@ def test_git_checkout_existing_branch(test_repository):
     assert "Switched to branch 'test-branch'" in result
     assert test_repository.active_branch.name == "test-branch"
 
-def test_git_checkout_nonexistent_branch(test_repository):
 
+def test_git_checkout_nonexistent_branch(test_repository):
     with pytest.raises(BadName):
         git_checkout(test_repository, "nonexistent-branch")
+
 
 def test_git_branch_local(test_repository):
     test_repository.git.branch("new-branch-local")
     result = git_branch(test_repository, "local")
     assert "new-branch-local" in result
 
+
 def test_git_branch_remote(test_repository):
     result = git_branch(test_repository, "remote")
     assert "" == result.strip()  # Should be empty if no remote branches
+
 
 def test_git_branch_all(test_repository):
     test_repository.git.branch("new-branch-all")
     result = git_branch(test_repository, "all")
     assert "new-branch-all" in result
 
+
 def test_git_branch_contains(test_repository):
     # Get the default branch name (could be "main" or "master")
     default_branch = test_repository.active_branch.name
     # Create a new branch and commit to it
     test_repository.git.checkout("-b", "feature-branch")
-    Path(test_repository.working_dir / Path("feature.txt")).write_text("feature content")
+    Path(test_repository.working_dir / Path("feature.txt")).write_text(
+        "feature content"
+    )
     test_repository.index.add(["feature.txt"])
     commit = test_repository.index.commit("feature commit")
     test_repository.git.checkout(default_branch)
@@ -72,12 +89,15 @@ def test_git_branch_contains(test_repository):
     assert "feature-branch" in result
     assert default_branch not in result
 
+
 def test_git_branch_not_contains(test_repository):
     # Get the default branch name (could be "main" or "master")
     default_branch = test_repository.active_branch.name
     # Create a new branch and commit to it
     test_repository.git.checkout("-b", "another-feature-branch")
-    Path(test_repository.working_dir / Path("another_feature.txt")).write_text("another feature content")
+    Path(test_repository.working_dir / Path("another_feature.txt")).write_text(
+        "another feature content"
+    )
     test_repository.index.add(["another_feature.txt"])
     commit = test_repository.index.commit("another feature commit")
     test_repository.git.checkout(default_branch)
@@ -85,6 +105,7 @@ def test_git_branch_not_contains(test_repository):
     result = git_branch(test_repository, "local", not_contains=commit.hexsha)
     assert "another-feature-branch" not in result
     assert default_branch in result
+
 
 def test_git_add_all_files(test_repository):
     file_path = Path(test_repository.working_dir) / "all_file.txt"
@@ -95,6 +116,7 @@ def test_git_add_all_files(test_repository):
     staged_files = [item.a_path for item in test_repository.index.diff("HEAD")]
     assert "all_file.txt" in staged_files
     assert result == "Files staged successfully"
+
 
 def test_git_add_specific_files(test_repository):
     file1 = Path(test_repository.working_dir) / "file1.txt"
@@ -141,6 +163,7 @@ def test_git_status(test_repository):
     assert result is not None
     assert "On branch" in result or "branch" in result.lower()
 
+
 def test_git_diff_unstaged(test_repository):
     file_path = Path(test_repository.working_dir) / "test.txt"
     file_path.write_text("modified content")
@@ -150,10 +173,12 @@ def test_git_diff_unstaged(test_repository):
     assert "test.txt" in result
     assert "modified content" in result
 
+
 def test_git_diff_unstaged_empty(test_repository):
     result = git_diff_unstaged(test_repository)
 
     assert result == ""
+
 
 def test_git_diff_staged(test_repository):
     file_path = Path(test_repository.working_dir) / "staged_file.txt"
@@ -165,10 +190,12 @@ def test_git_diff_staged(test_repository):
     assert "staged_file.txt" in result
     assert "staged content" in result
 
+
 def test_git_diff_staged_empty(test_repository):
     result = git_diff_staged(test_repository)
 
     assert result == ""
+
 
 def test_git_diff(test_repository):
     # Get the default branch name (could be "main" or "master")
@@ -184,6 +211,7 @@ def test_git_diff(test_repository):
     assert "test.txt" in result
     assert "feature changes" in result
 
+
 def test_git_commit(test_repository):
     file_path = Path(test_repository.working_dir) / "commit_test.txt"
     file_path.write_text("content to commit")
@@ -195,6 +223,7 @@ def test_git_commit(test_repository):
 
     latest_commit = test_repository.head.commit
     assert latest_commit.message.strip() == "test commit message"
+
 
 def test_git_reset(test_repository):
     file_path = Path(test_repository.working_dir) / "reset_test.txt"
@@ -210,6 +239,7 @@ def test_git_reset(test_repository):
 
     staged_after = [item.a_path for item in test_repository.index.diff("HEAD")]
     assert "reset_test.txt" not in staged_after
+
 
 def test_git_log(test_repository):
     for i in range(3):
@@ -227,12 +257,14 @@ def test_git_log(test_repository):
     assert "Date:" in result[0]
     assert "Message:" in result[0]
 
+
 def test_git_log_default(test_repository):
     result = git_log(test_repository)
 
     assert isinstance(result, list)
     assert len(result) >= 1
     assert "initial commit" in result[0]
+
 
 def test_git_create_branch(test_repository):
     result = git_create_branch(test_repository, "new-feature-branch")
@@ -241,6 +273,7 @@ def test_git_create_branch(test_repository):
 
     branches = [ref.name for ref in test_repository.references]
     assert "new-feature-branch" in branches
+
 
 def test_git_create_branch_from_base(test_repository):
     test_repository.git.checkout("-b", "base-branch")
@@ -252,6 +285,7 @@ def test_git_create_branch_from_base(test_repository):
     result = git_create_branch(test_repository, "derived-branch", "base-branch")
 
     assert "Created branch 'derived-branch' from 'base-branch'" in result
+
 
 def test_git_show(test_repository):
     file_path = Path(test_repository.working_dir) / "show_test.txt"
@@ -268,6 +302,7 @@ def test_git_show(test_repository):
     assert "show test commit" in result
     assert "show_test.txt" in result
 
+
 def test_git_show_initial_commit(test_repository):
     initial_commit = list(test_repository.iter_commits())[-1]
 
@@ -279,6 +314,7 @@ def test_git_show_initial_commit(test_repository):
 
 
 # Tests for validate_repo_path (repository scoping security fix)
+
 
 def test_validate_repo_path_no_restriction():
     """When no repository restriction is configured, any path should be allowed."""
@@ -339,7 +375,10 @@ def test_validate_repo_path_symlink_escape(tmp_path: Path):
     with pytest.raises(ValueError) as exc_info:
         validate_repo_path(symlink, allowed)
     assert "outside the allowed repository" in str(exc_info.value)
+
+
 # Tests for argument injection protection
+
 
 def test_git_diff_rejects_flag_injection(test_repository):
     """git_diff should reject flags that could be used for argument injection."""
@@ -454,6 +493,7 @@ def test_git_checkout_rejects_malicious_refs(test_repository):
 # Tests for argument injection protection in git_show, git_create_branch,
 # git_log, and git_branch — matching the existing guards on git_diff and
 # git_checkout.
+
 
 def test_git_show_rejects_flag_injection(test_repository):
     """git_show should reject revisions starting with '-'."""

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -508,3 +508,39 @@ def test_git_branch_rejects_contains_flag_injection(test_repository):
 
     with pytest.raises(BadName):
         git_branch(test_repository, "local", not_contains="--exec=evil")
+
+
+def test_server_handles_invalid_json_rpc_gracefully(tmp_path):
+    """The server should handle invalid or deeply nested JSON-RPC messages without crashing."""
+    import json
+    import subprocess
+    import sys
+
+    # Initialize a dummy git repository to satisfy the server start requirements
+    repo_path = tmp_path / "test_repo"
+    repo = git.Repo.init(repo_path)
+    repo.close()
+
+    inner = {"leaf": True}
+    for _ in range(200):
+        inner = {"child": inner}
+
+    msgs = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+         "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0.1"}}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 1001, "method": "tools/call",
+         "params": {"name": "git_add", "arguments": inner}},
+    ]
+    payload = ("\n".join(json.dumps(m) for m in msgs) + "\n").encode()
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "mcp_server_git", "-r", str(repo_path)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    out, err = proc.communicate(payload, timeout=10)
+
+    assert proc.returncode == 0
+    assert b"protocolVersion" in out
+    assert b"ValidationError" in err or b"recursion limit" in err


### PR DESCRIPTION
# fix(git): resolve server crash on validation errors

## Description
This PR resolves an issue in `mcp-server-git` where the server process crashes upon encountering input validation errors or malformed JSON-RPC messages (e.g. deeply nested requests that hit Pydantic's core recursion limit) instead of returning a JSON-RPC error response and remaining operational.

Fixes #4213

### The Problem
During initialization of `mcp-server-git`, the stdio server is run with `raise_exceptions=True`:
```python
await server.run(read_stream, write_stream, options, raise_exceptions=True)
```
When this option is enabled, any exceptions raised by the stream reader (such as a `ValidationError` when validating incoming JSON-RPC messages) are re-raised. This causes the internal task group to tear down, resulting in the server process crashing with exit code 1.

Other servers in this repository (e.g. `mcp-server-fetch` and `mcp-server-time`) run with the default `raise_exceptions=False`. Under the default configuration, validation errors on stdin are caught, logged, returned as a JSON-RPC error response where appropriate, and the server process remains active.

### The Solution
1. Modified the `server.run(...)` call in `mcp_server_git/server.py` to use `raise_exceptions=False` to align it with other servers and prevent crashes on invalid/deeply nested JSON-RPC inputs.
2. Added a unit integration test `test_server_handles_invalid_json_rpc_gracefully` in `src/git/tests/test_server.py` that spawns the server, sends a deeply nested JSON-RPC payload triggering a validation error, and asserts that the process exits cleanly (exit code 0) when stdin is closed instead of throwing a traceback and crashing.
