### PR TITLE
fix(filesystem): preserve literal \$ in edit_file newText (closes #4157)

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -440,6 +440,40 @@ describe('Lib Functions', () => {
         );
       });
 
+      it("preserves literal $ characters in newText (regression for #4157)", async () => {
+        // String.prototype.replace interprets $$, $&, $`, $' in the
+        // replacement argument when it is a string. The callback form
+        // disables that interpretation. This test pins the callback form
+        // so the bug can't silently regress.
+        mockFs.readFile.mockResolvedValue("price: PLACEHOLDER\n");
+        const edits = [
+          { oldText: "PLACEHOLDER", newText: "$$100 USD" }
+        ];
+        mockFs.rename.mockResolvedValueOnce(undefined);
+        await applyFileEdits("/test/file.txt", edits, false);
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          "price: $$100 USD\n",
+          "utf-8"
+        );
+      });
+
+      it("preserves $&, $` and $' replacement-pattern tokens in newText (#4157)", async () => {
+        mockFs.readFile.mockResolvedValue("TARGET\n");
+        const edits = [
+          { oldText: "TARGET", newText: "a $& b $` c $' d" }
+        ];
+        mockFs.rename.mockResolvedValueOnce(undefined);
+        await applyFileEdits("/test/file.txt", edits, false);
+        // Without the fix: $& would expand to "TARGET", $` to "" (before-match),
+        // and $' to "" (after-match), corrupting the output.
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          "a $& b $` c $' d\n",
+          "utf-8"
+        );
+      });
+
       it('handles dry run mode', async () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
Fixes #4157.

This is the exact fix the issue reporter proposed (and is consistent with the
bug root-cause in the issue body).

### The bug

`src/filesystem/lib.ts` passes `normalizedNew` as `String.prototype.replace`'s
replacement argument. When that argument is a string, JS interprets these
tokens in it:

| Token | Interpreted as           |
| ----- | ------------------------ |
| `$$` | a literal `$`             |
| `$&` | the matched substring     |
| `$`` | the portion before match |
| `$'` | the portion after match  |
| `$n` | nth capture (regex only) |

So when a caller does `edit_file` with `newText: "$100 USD"`, the `$1` token
gets eaten (replaced with the content of capture group 1, which is undefined
for a plain-string search, so it's dropped).

### The fix

Use the callback form (`() => normalizedNew`). MDN explicitly documents
this as the way to disable replacement-pattern interpretation:

> If replacement is a function, the matched substring is replaced with the
> return value of the function.

One-line diff:

```diff
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
```

### Tests

Two regression tests added to `src/filesystem/__tests__/lib.test.ts`:

1. `$$` preservation (literal `$`)
2. `$&`, `$``, `$'` preservation (replacement-pattern tokens)

Both tests assert that the exact input string is written verbatim. Without
the fix, both tests fail.

### Verification

```
cd src/filesystem && npm test
```

-> **148 / 148** tests pass across 7 test files (the 2 new tests are in there).

### No behavioral regression

The callback always returns a constant (`{n normalizedNew` {n unbound}), so for
inputs that don't contain `$`, the behavior is identical to the string-arg form.
The only change is that `$` characters now survive the replace.

Closes #4157.
