### PR TITLE
Fix filesystem edit_file literal dollar replacements

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -440,6 +440,22 @@ describe('Lib Functions', () => {
         );
       });
 
+      it('treats dollar signs in replacement text literally', async () => {
+        const edits = [
+          { oldText: 'line2', newText: "price=$$; match=$&; before=$`; after=$'" }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          "line1\nprice=$$; match=$&; before=$`; after=$'\nline3\n",
+          'utf-8'
+        );
+      });
+
       it('handles dry run mode', async () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
Fixes #4157

## Summary
- Treat edit_file replacement text literally when using the exact-match replacement path
- Use the callback form of String.prototype.replace so `$`, `$&`, `$\``, and `$'` are not interpreted as replacement patterns
- Add regression coverage for literal dollar replacement content

## Tests
- `cd src/filesystem && npx vitest run __tests__/lib.test.ts`
- `cd src/filesystem && npm run build`
- `git diff --check`