### PR TITLE
fix(filesystem): handle literal $ characters in edit_file

### DIFF
--- a/src/filesystem/__tests__/bug_repro.test.ts
+++ b/src/filesystem/__tests__/bug_repro.test.ts
@@ -1,0 +1,45 @@
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { applyFileEdits } from '../lib.js';
+
+describe('Bug #4157 Reproduction', () => {
+  const testFile = path.join(process.cwd(), 'test_repro.txt');
+
+  beforeEach(async () => {
+    await fs.writeFile(testFile, 'Value: OLD_VALUE\n');
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.unlink(testFile);
+    } catch {}
+  });
+
+  it('should preserve literal $ characters in newText', async () => {
+    const edits = [
+      {
+        oldText: 'OLD_VALUE',
+        newText: '$100'
+      }
+    ];
+
+    await applyFileEdits(testFile, edits, false);
+    const result = await fs.readFile(testFile, 'utf-8');
+    expect(result).toContain('$100');
+  });
+
+  it('should preserve complex $ patterns in newText', async () => {
+    const edits = [
+      {
+        oldText: 'OLD_VALUE',
+        newText: '$& $1 $` $\''
+      }
+    ];
+
+    await applyFileEdits(testFile, edits, false);
+    const result = await fs.readFile(testFile, 'utf-8');
+    expect(result).toContain('$& $1 $` $\'');
+  });
+});

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 

--- a/src/filesystem/reproduce_bug_4157.ts
+++ b/src/filesystem/reproduce_bug_4157.ts
@@ -1,0 +1,37 @@
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { applyFileEdits } from './lib.js';
+
+async function reproduce() {
+  const testFile = path.join(process.cwd(), 'test_dollar.txt');
+  const initialContent = 'Value: OLD_VALUE\n';
+  await fs.writeFile(testFile, initialContent);
+
+  console.log('Initial content:', initialContent);
+
+  const edits = [
+    {
+      oldText: 'OLD_VALUE',
+      newText: '$100'
+    }
+  ];
+
+  try {
+    await applyFileEdits(testFile, edits, false);
+    const result = await fs.readFile(testFile, 'utf-8');
+    console.log('Resulting content:', result);
+    
+    if (result.includes('$100')) {
+      console.log('SUCCESS: $100 preserved');
+    } else {
+      console.log('FAILURE: $100 corrupted. Found:', result);
+    }
+  } catch (error) {
+    console.error('Error during reproduction:', error);
+  } finally {
+    await fs.unlink(testFile);
+  }
+}
+
+reproduce();


### PR DESCRIPTION
This PR fixes Issue #4157 where literal '$' characters in the `newText` of an `edit_file` operation were being incorrectly interpreted as replacement patterns (e.g., $\&, $1). 

### Technical Change
Switched from using a string replacement pattern in `String.prototype.replace()` to a functional replacement. Using a function ensures that the replacement string is treated as a literal, preserving all special characters.

### Verification
- Added a new test suite `src/filesystem/__tests__/bug_repro.test.ts` which specifically verifies the preservation of single and complex '$' patterns.
- Verified that all existing filesystem tests pass.
