### PR TITLE
docs(time, git): fix invalid JSON in Zed `context_servers` config snippets

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -222,14 +222,14 @@ Add to your Zed settings.json:
 <summary>Using uvx</summary>
 
 ```json
-"context_servers": [
+"context_servers": {
   "mcp-server-git": {
     "command": {
       "path": "uvx",
       "args": ["mcp-server-git"]
     }
   }
-],
+},
 ```
 </details>
 

--- a/src/time/README.md
+++ b/src/time/README.md
@@ -100,12 +100,12 @@ Add to your Zed settings.json:
 <summary>Using uvx</summary>
 
 ```json
-"context_servers": [
+"context_servers": {
   "mcp-server-time": {
     "command": "uvx",
     "args": ["mcp-server-time"]
   }
-],
+},
 ```
 </details>
 


### PR DESCRIPTION
## Summary

The Zed configuration snippets under \`Using uvx\` in \`src/time/README.md\` and \`src/git/README.md\` use an array \`[\` with key-value entries inside, which is not valid JSON:

\`\`\`json
\"context_servers\": [
  \"mcp-server-time\": {
    \"command\": \"uvx\",
    \"args\": [\"mcp-server-time\"]
  }
],
\`\`\`

The adjacent \`Using pip installation\` snippets in the same files correctly use an object \`{\`, so this was an inconsistent typo on the uvx variants.

The practical effect: copy-pasting the snippet straight into \`~/.config/zed/settings.json\` causes Zed to fail parsing the file silently and ignore the MCP server registration. Users who go through the README expecting a working copy-paste configuration land on a broken Zed config.

## Fix

Switch \`[\` to \`{\` and \`],\` to \`},\` on the two affected snippets so the structure matches:
1. Zed's expected \`\"context_servers\": { ... }\` shape, and
2. The pip-installation snippets sitting right next to them in the same READMEs.

## Test plan

Each fixed snippet now parses cleanly when wrapped in the surrounding \`{ }\` braces that an actual \`settings.json\` would supply. Diff is 4 lines changed across 2 files; no other content modified.

Filed under CONTRIBUTING.md's \"Improvements to existing documentation is welcome\" lane.