### PR TITLE
fix(fetch): make Readability.js extraction opt-in

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -26,7 +26,9 @@ The fetch tool will truncate the response, but by using the `start_index` argume
 
 ## Installation
 
-Optionally: Install node.js, this will cause the fetch server to use a different HTML simplifier that is more robust.
+By default, HTML pages are simplified with the Python-only parser from `readabilipy`.
+If Node.js is available and you want to use Readability.js instead, start the
+server with `--use-readability`.
 
 ### Using uv (recommended)
 
@@ -169,6 +171,13 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 ### Customization - Proxy
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
+
+### Customization - HTML extraction
+
+The server uses `readabilipy`'s Python parser by default, so a normal Python
+installation is enough for HTML-to-markdown extraction. To opt into
+Readability.js, install Node.js and add `--use-readability` to the `args` list in
+the configuration.
 
 ## Windows Configuration
 

--- a/src/fetch/src/mcp_server_fetch/__init__.py
+++ b/src/fetch/src/mcp_server_fetch/__init__.py
@@ -16,9 +16,21 @@ def main():
         help="Ignore robots.txt restrictions",
     )
     parser.add_argument("--proxy-url", type=str, help="Proxy URL to use for requests")
+    parser.add_argument(
+        "--use-readability",
+        action="store_true",
+        help="Use Readability.js via Node.js for HTML extraction",
+    )
 
     args = parser.parse_args()
-    asyncio.run(serve(args.user_agent, args.ignore_robots_txt, args.proxy_url))
+    asyncio.run(
+        serve(
+            args.user_agent,
+            args.ignore_robots_txt,
+            args.proxy_url,
+            args.use_readability,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -24,7 +24,7 @@ DEFAULT_USER_AGENT_AUTONOMOUS = "ModelContextProtocol/1.0 (Autonomous; +https://
 DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://github.com/modelcontextprotocol/servers)"
 
 
-def extract_content_from_html(html: str) -> str:
+def extract_content_from_html(html: str, use_readability: bool = False) -> str:
     """Extract and convert HTML content to Markdown format.
 
     Args:
@@ -34,7 +34,7 @@ def extract_content_from_html(html: str) -> str:
         Simplified markdown version of the content
     """
     ret = readabilipy.simple_json.simple_json_from_html_string(
-        html, use_readability=True
+        html, use_readability=use_readability
     )
     if not ret["content"]:
         return "<error>Page failed to be simplified from HTML</error>"
@@ -42,6 +42,8 @@ def extract_content_from_html(html: str) -> str:
         ret["content"],
         heading_style=markdownify.ATX,
     )
+    if not content.strip():
+        return "<error>Page failed to be simplified from HTML</error>"
     return content
 
 
@@ -109,7 +111,11 @@ async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url:
 
 
 async def fetch_url(
-    url: str, user_agent: str, force_raw: bool = False, proxy_url: str | None = None
+    url: str,
+    user_agent: str,
+    force_raw: bool = False,
+    proxy_url: str | None = None,
+    use_readability: bool = False,
 ) -> Tuple[str, str]:
     """
     Fetch the URL and return the content in a form ready for the LLM, as well as a prefix string with status information.
@@ -140,7 +146,7 @@ async def fetch_url(
     )
 
     if is_page_html and not force_raw:
-        return extract_content_from_html(page_raw), ""
+        return extract_content_from_html(page_raw, use_readability=use_readability), ""
 
     return (
         page_raw,
@@ -182,6 +188,7 @@ async def serve(
     custom_user_agent: str | None = None,
     ignore_robots_txt: bool = False,
     proxy_url: str | None = None,
+    use_readability: bool = False,
 ) -> None:
     """Run the fetch MCP server.
 
@@ -189,6 +196,7 @@ async def serve(
         custom_user_agent: Optional custom User-Agent string to use for requests
         ignore_robots_txt: Whether to ignore robots.txt restrictions
         proxy_url: Optional proxy URL to use for requests
+        use_readability: Whether to use Readability.js through Node for HTML extraction
     """
     server = Server("mcp-fetch")
     user_agent_autonomous = custom_user_agent or DEFAULT_USER_AGENT_AUTONOMOUS
@@ -235,7 +243,11 @@ Although originally you did not have internet access, and were advised to refuse
             await check_may_autonomously_fetch_url(url, user_agent_autonomous, proxy_url)
 
         content, prefix = await fetch_url(
-            url, user_agent_autonomous, force_raw=args.raw, proxy_url=proxy_url
+            url,
+            user_agent_autonomous,
+            force_raw=args.raw,
+            proxy_url=proxy_url,
+            use_readability=use_readability,
         )
         original_length = len(content)
         if args.start_index >= original_length:
@@ -262,7 +274,12 @@ Although originally you did not have internet access, and were advised to refuse
         url = arguments["url"]
 
         try:
-            content, prefix = await fetch_url(url, user_agent_manual, proxy_url=proxy_url)
+            content, prefix = await fetch_url(
+                url,
+                user_agent_manual,
+                proxy_url=proxy_url,
+                use_readability=use_readability,
+            )
             # TODO: after SDK bug is addressed, don't catch the exception
         except McpError as e:
             return GetPromptResult(

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -87,6 +87,28 @@ class TestExtractContentFromHtml:
         result = extract_content_from_html(html)
         assert "<error>" in result
 
+    def test_html_extraction_uses_python_mode_by_default(self):
+        html = "<html><body><p>Hello</p></body></html>"
+        with patch(
+            "mcp_server_fetch.server.readabilipy.simple_json.simple_json_from_html_string",
+            return_value={"content": "<p>Hello</p>"},
+        ) as mock_extract:
+            result = extract_content_from_html(html)
+
+        mock_extract.assert_called_once_with(html, use_readability=False)
+        assert "Hello" in result
+
+    def test_html_extraction_can_opt_into_readability(self):
+        html = "<html><body><p>Hello</p></body></html>"
+        with patch(
+            "mcp_server_fetch.server.readabilipy.simple_json.simple_json_from_html_string",
+            return_value={"content": "<p>Hello</p>"},
+        ) as mock_extract:
+            result = extract_content_from_html(html, use_readability=True)
+
+        mock_extract.assert_called_once_with(html, use_readability=True)
+        assert "Hello" in result
+
 
 class TestCheckMayAutonomouslyFetchUrl:
     """Tests for check_may_autonomously_fetch_url function."""
@@ -218,6 +240,35 @@ class TestFetchUrl:
             # HTML is processed, so we check it returns something
             assert isinstance(content, str)
             assert prefix == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_html_page_can_opt_into_readability(self):
+        """Test that fetch_url forwards the readability option."""
+        html_content = "<html><body><h1>Test</h1></body></html>"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = html_content
+        mock_response.headers = {"content-type": "text/html"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            with patch(
+                "mcp_server_fetch.server.extract_content_from_html",
+                return_value="markdown",
+            ) as mock_extract:
+                content, prefix = await fetch_url(
+                    "https://example.com/page",
+                    DEFAULT_USER_AGENT_AUTONOMOUS,
+                    use_readability=True,
+                )
+
+        mock_extract.assert_called_once_with(html_content, use_readability=True)
+        assert content == "markdown"
+        assert prefix == ""
 
     @pytest.mark.asyncio
     async def test_fetch_html_page_raw(self):


### PR DESCRIPTION
﻿## Summary

- default `mcp-server-fetch` HTML extraction to readabilipy's Python parser instead of always enabling Readability.js
- add `--use-readability` for operators who explicitly want the Node-backed Readability.js path
- document the new opt-in and cover both default and opt-in paths in tests

Closes #4199.

## To verify

- `uv run pytest -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src tests`
- `uv run pyright src tests`
- `uv run python -m py_compile src\mcp_server_fetch\server.py src\mcp_server_fetch\__init__.py`
