### PR TITLE
fix: preserve literal dollars in filesystem edits

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -451,6 +451,22 @@ describe('Lib Functions', () => {
         expect(mockFs.writeFile).not.toHaveBeenCalled();
       });
 
+      it('treats dollar signs in replacement text literally', async () => {
+        const edits = [
+          { oldText: 'line2', newText: '$$100 $& value' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'line1\n$$100 $& value\nline3\n',
+          'utf-8'
+        );
+      });
+
       it('applies multiple edits sequentially', async () => {
         const edits = [
           { oldText: 'line1', newText: 'first line' },

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -207,7 +207,7 @@ export async function applyFileEdits(
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {
-      modifiedContent = modifiedContent.replace(normalizedOld, normalizedNew);
+      modifiedContent = modifiedContent.replace(normalizedOld, () => normalizedNew);
       continue;
     }
 


### PR DESCRIPTION
﻿## Summary

`edit_file` currently passes `newText` as the string replacement argument to `String.prototype.replace`. That makes literal `$` sequences behave like replacement patterns, so values such as `$$100` and `$&` are silently rewritten before the file is saved.

This switches the exact-match path to the callback form of `replace`, which preserves the existing first-match semantics while treating the replacement as literal text.

## Changes

- Use `modifiedContent.replace(normalizedOld, () => normalizedNew)` for exact text edits.
- Add a regression test covering `$$` and `$&` in replacement text.

## To verify

- `npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts --testNamePattern "dollar signs"`
- `npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts`
- `npm run build -w src/filesystem`
- `git diff --check origin/main...HEAD`

Fixes #4157
