### PR TITLE
Fix grammar in time server get_current_time description

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -131,7 +131,7 @@ async def serve(local_timezone: str | None = None) -> None:
         return [
             Tool(
                 name=TimeTools.GET_CURRENT_TIME.value,
-                description="Get current time in a specific timezones",
+                description="Get current time in a specific timezone",
                 inputSchema={
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
The `get_current_time` tool description reads "Get current time in a specific timezones", which mixes the singular article "a" with the plural "timezones".

The tool only accepts a single timezone, and the time server README already documents the intended singular wording ("Get current time in a specific timezone or system timezone"), so the plural here is just a typo. Tool descriptions are surfaced to model clients and influence tool selection, so the wording is worth getting right.

Changed it to "Get current time in a specific timezone". No behavior change; the existing test suite still passes.