### PR TITLE
docs: add SafeMCP to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Additional resources on MCP.
 - **[r/mcp](https://www.reddit.com/r/mcp)** – A Reddit community dedicated to MCP by **[Frank Fiegel](https://github.com/punkpeye)**
 - **[MCP.ing](https://mcp.ing/)** - A list of MCP services for discovering MCP servers in the community and providing a convenient search function for MCP services by **[iiiusky](https://github.com/iiiusky)**
 - **[MCP Hunt](https://mcp-hunt.com)** - Realtime platform for discovering trending MCP servers with momentum tracking, upvoting, and community discussions - like Product Hunt meets Reddit for MCP
+- **[SafeMCP](https://safemcp.info)** - A free searchable directory of 28,577+ MCP servers, individually verified by an LLM classifier and sorted into 95 categories with metadata-quality scores by **[Tanvith Reddy](https://github.com/tanvithsreddy-del)**
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**


### PR DESCRIPTION
Adds SafeMCP (https://safemcp.info) to the Resources section.

SafeMCP is a free searchable directory of MCP servers. The scanner pulls candidate repos from GitHub and aggregators, verifies each one actually implements MCP via an LLM classifier, then sorts them into 95 categories with metadata-quality scores 0-100.

Currently indexes 28,577 verified MCP servers. Free, no signup, no ads. Continuous re-scanning so new servers appear within days of release.

Inserted alphabetically between MCP Hunt and Smithery per CONTRIBUTING.md guidance to minimize merge conflicts.