### PR TITLE
fix(git): keep stdio server alive on JSON-RPC parse errors

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -584,4 +584,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)


### PR DESCRIPTION
## Summary
- align mcp-server-git's stdio run mode with fetch/time/sqlite by disabling exception re-raise from malformed input
- prevents deeply malformed JSON-RPC frames from tearing down the git server process

Fixes #4213

## Test Report
- `cd src/git && uv run pytest tests/test_server.py` (41 passed)