### PR TITLE
fix(time): default missing timezones to local timezone

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -58,8 +58,12 @@ def get_zoneinfo(timezone_name: str) -> ZoneInfo:
 
 
 class TimeServer:
-    def get_current_time(self, timezone_name: str) -> TimeResult:
+    def __init__(self, local_timezone: str | None = None):
+        self.local_timezone = str(get_local_tz(local_timezone))
+
+    def get_current_time(self, timezone_name: str | None = None) -> TimeResult:
         """Get current time in specified timezone"""
+        timezone_name = timezone_name or self.local_timezone
         timezone = get_zoneinfo(timezone_name)
         current_time = datetime.now(timezone)
 
@@ -71,9 +75,11 @@ class TimeServer:
         )
 
     def convert_time(
-        self, source_tz: str, time_str: str, target_tz: str
+        self, source_tz: str | None, time_str: str, target_tz: str | None
     ) -> TimeConversionResult:
         """Convert time between timezones"""
+        source_tz = source_tz or self.local_timezone
+        target_tz = target_tz or self.local_timezone
         source_timezone = get_zoneinfo(source_tz)
         target_timezone = get_zoneinfo(target_tz)
 
@@ -122,8 +128,8 @@ class TimeServer:
 
 async def serve(local_timezone: str | None = None) -> None:
     server = Server("mcp-time")
-    time_server = TimeServer()
-    local_tz = str(get_local_tz(local_timezone))
+    time_server = TimeServer(local_timezone)
+    local_tz = time_server.local_timezone
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
@@ -140,7 +146,7 @@ async def serve(local_timezone: str | None = None) -> None:
                             "description": f"IANA timezone name (e.g., 'America/New_York', 'Europe/London'). Use '{local_tz}' as local timezone if no timezone provided by the user.",
                         }
                     },
-                    "required": ["timezone"],
+                    "required": [],
                 },
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -168,7 +174,7 @@ async def serve(local_timezone: str | None = None) -> None:
                             "description": f"Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/San_Francisco'). Use '{local_tz}' as local timezone if no target timezone provided by the user.",
                         },
                     },
-                    "required": ["source_timezone", "time", "target_timezone"],
+                    "required": ["time"],
                 },
                 annotations=ToolAnnotations(
                     readOnlyHint=True,
@@ -188,22 +194,16 @@ async def serve(local_timezone: str | None = None) -> None:
             match name:
                 case TimeTools.GET_CURRENT_TIME.value:
                     timezone = arguments.get("timezone")
-                    if not timezone:
-                        raise ValueError("Missing required argument: timezone")
-
                     result = time_server.get_current_time(timezone)
 
                 case TimeTools.CONVERT_TIME.value:
-                    if not all(
-                        k in arguments
-                        for k in ["source_timezone", "time", "target_timezone"]
-                    ):
-                        raise ValueError("Missing required arguments")
+                    if "time" not in arguments:
+                        raise ValueError("Missing required argument: time")
 
                     result = time_server.convert_time(
-                        arguments["source_timezone"],
+                        arguments.get("source_timezone"),
                         arguments["time"],
-                        arguments["target_timezone"],
+                        arguments.get("target_timezone"),
                     )
                 case _:
                     raise ValueError(f"Unknown tool: {name}")

--- a/src/time/test/time_server_test.py
+++ b/src/time/test/time_server_test.py
@@ -91,6 +91,28 @@ def test_get_current_time_with_invalid_timezone():
         time_server.get_current_time("Invalid/Timezone")
 
 
+def test_get_current_time_defaults_to_configured_local_timezone():
+    with freeze_time("2024-01-01 12:00:00+00:00"):
+        time_server = TimeServer("Europe/London")
+
+        result = time_server.get_current_time()
+
+        assert result.timezone == "Europe/London"
+        assert result.datetime == "2024-01-01T12:00:00+00:00"
+
+
+def test_convert_time_defaults_missing_timezones_to_configured_local_timezone():
+    with freeze_time("2024-01-01 00:00:00+00:00"):
+        time_server = TimeServer("Europe/London")
+
+        result = time_server.convert_time(None, "12:00", "Asia/Tokyo")
+
+        assert result.source.timezone == "Europe/London"
+        assert result.source.datetime == "2024-01-01T12:00:00+00:00"
+        assert result.target.timezone == "Asia/Tokyo"
+        assert result.target.datetime == "2024-01-01T21:00:00+09:00"
+
+
 @pytest.mark.parametrize(
     "source_tz,time_str,target_tz,expected_error",
     [


### PR DESCRIPTION
## Summary
- Let get_current_time use the configured local timezone when timezone is omitted
- Let convert_time default omitted source/target timezones to the configured local timezone while still requiring time
- Update tool schemas and tests to match the documented local-timezone behavior

Fixes #2853.

## Validation
- cd src/time && uv run pytest