### PR TITLE
Add Local Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Additional resources on MCP.
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.
 - **[Webrix MCP Gateway](https://github.com/webrix-ai/secure-mcp-gateway)** - Enterprise MCP gateway with SSO, RBAC, audit trails, and token vaults for secure, centralized AI agent access control. Deploy via Helm charts on-premise or in your cloud. [webrix.ai](https://webrix.ai)
+- **[Local Intel](https://github.com/MCFLAMINGO/gsb-swarm)** - Business intelligence for any Florida ZIP. Sector gap analysis, NL market queries, demographics, investment signals, 240k+ businesses. Free tier, no key required. ([MCP endpoint](https://gsb-swarm-production.up.railway.app/api/local-intel/mcp))
 
 
 


### PR DESCRIPTION
Adding Local Intel to the community MCP servers list.

**Local Intel** provides business intelligence for any Florida ZIP code — sector gap analysis, natural language market queries, demographics, investment signals, and 240k+ businesses indexed. Free tier, no API key required.

- Repo: https://github.com/MCFLAMINGO/gsb-swarm
- MCP endpoint: https://gsb-swarm-production.up.railway.app/api/local-intel/mcp