### PR TITLE
Add Ageniti to Frameworks → For servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These are high-level frameworks that make it easier to build MCP servers or clie
 
 ### For servers
 
+* **[Ageniti](https://github.com/Ageniti/ageniti)** (TypeScript) - The action primitive for apps that need to be callable by agents. Define an action once — input/output contract, side effects, permissions — and expose it via CLI, HTTP, MCP, OpenAI / AI SDK tools, React hooks, and a typed client, all sharing the same runtime, streaming events, redaction, and error contract.
 * **[Anubis MCP](https://github.com/zoedsoupe/anubis-mcp)** (Elixir) - A high-performance and high-level Model Context Protocol (MCP) implementation in Elixir. Think like "Live View" for MCP.
 * **[ModelFetch](https://github.com/phuctm97/modelfetch/)** (TypeScript) - Runtime-agnostic SDK to create and deploy MCP servers anywhere TypeScript/JavaScript runs
 * **[EasyMCP](https://github.com/zcaceres/easy-mcp/)** (TypeScript)


### PR DESCRIPTION
Adds [Ageniti](https://github.com/Ageniti/ageniti) to the **Frameworks → For servers** list.

**Ageniti** (MIT, TypeScript) is an action-primitive SDK: you define an action once — input/output contract, side effects, permissions — and the same runtime exposes it as a CLI command, HTTP route, MCP tool, OpenAI / AI SDK tool, React hook, and typed in-process client. Streaming events, redaction, and a unified error contract are shared across all surfaces.

It fits the *For servers* section because building an MCP server is one of its primary outputs — the same action definition that runs locally as a CLI also surfaces as an MCP tool with no additional schema work.

- Repo: https://github.com/Ageniti/ageniti
- npm: https://www.npmjs.com/package/@ageniti/core
- Site: https://ageniti.dev

Entry placed alphabetically at the top of *For servers*.