### PR TITLE
fix(everything): correct blob resource mimeType

### DIFF
--- a/src/everything/__tests__/resources.test.ts
+++ b/src/everything/__tests__/resources.test.ts
@@ -83,7 +83,7 @@ describe('Resource Templates', () => {
       const resource = blobResource(uri, 1);
 
       expect(resource.uri).toBe(uri.toString());
-      expect(resource.mimeType).toBe('text/plain');
+      expect(resource.mimeType).toBe('application/octet-stream');
       expect(resource.blob).toBeDefined();
     });
 

--- a/src/everything/resources/templates.ts
+++ b/src/everything/resources/templates.ts
@@ -105,7 +105,7 @@ export const blobResource = (uri: URL, resourceId: number) => {
   ).toString("base64");
   return {
     uri: uri.toString(),
-    mimeType: "text/plain",
+    mimeType: "application/octet-stream",
     blob: resourceText,
   };
 };


### PR DESCRIPTION
## Description

The `blobResource()` factory in the everything server's `templates.ts` returns `mimeType: "text/plain"` for what is — by construction — a base64-encoded binary blob. The registered Dynamic Blob Resource template at the bottom of the same file already declares `"application/octet-stream"`, so the factory contradicts its own template metadata. Downstream, `get-resource-links.ts` branches on this mimeType to label resources, so every blob `resource_link` was being described as `"plaintext resource"`.

Fix: change the factory to return `"application/octet-stream"` and update the matching test assertion. No behaviour change beyond the mimeType value itself and the now-correct downstream label.

## Server Details

- Server: everything
- Changes to: resources

## Motivation and Context

The everything server is the canonical reference fixture for MCP client developers wiring up resource-link support. A buggy fixture sends client developers chasing phantom bugs in their own code, because the labelling for binary resources contradicts what the registered template advertises.

The fix tightens the internal consistency the registered template at `src/everything/resources/templates.ts:200` already advertises.

## How Has This Been Tested?

- `npm test` in `src/everything/` — 95 passed, 0 failed
- `npm run build` — clean
- Manually traced the call chain through `get-resource-links.ts:74-79` to confirm the description label now correctly distinguishes binary blobs from plaintext resources

## Breaking Changes

None. The mimeType value on blob resources changes from `"text/plain"` to `"application/octet-stream"`. This matches what the registered template metadata already advertised, so any client consuming the registered template was already expecting the new value. Clients that hardcoded `"text/plain"` for the test fixture will need to update — but doing so was already inconsistent with the template registration.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

The fix is a single-line change in the factory plus the corresponding test assertion (which previously pinned the buggy `"text/plain"`). The downstream `get-resource-links.ts:74-79` branch is unchanged — it now produces the correct label for binary resources without any additional code change.