### PR TITLE
fix(filesystem): handle canonical Windows share paths

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -188,6 +188,38 @@ describe('Lib Functions', () => {
         expect(result).toBe(path.resolve(newFilePath));
       });
 
+      it('allows Windows mapped-drive paths that realpath resolves into the allow-list', async () => {
+        if (process.platform !== 'win32') {
+          return;
+        }
+
+        setAllowedDirectories(['\\\\server\\share\\repo']);
+        mockFs.realpath.mockResolvedValueOnce('\\\\server\\share\\repo\\file.txt');
+
+        const result = await validatePath('Y:\\repo\\file.txt');
+
+        expect(result).toBe('\\\\server\\share\\repo\\file.txt');
+      });
+
+      it('allows new files under Windows mapped-drive parents that resolve into the allow-list', async () => {
+        if (process.platform !== 'win32') {
+          return;
+        }
+
+        const enoentError = new Error('ENOENT') as NodeJS.ErrnoException;
+        enoentError.code = 'ENOENT';
+
+        setAllowedDirectories(['\\\\server\\share\\repo']);
+        mockFs.realpath
+          .mockRejectedValueOnce(enoentError)
+          .mockResolvedValueOnce('\\\\server\\share\\repo');
+
+        const newFilePath = 'Y:\\repo\\newfile.txt';
+        const result = await validatePath(newFilePath);
+
+        expect(result).toBe(path.resolve(newFilePath));
+      });
+
       it('rejects when parent directory does not exist', async () => {
         const newFilePath = process.platform === 'win32' ? 'C:\\Users\\test\\nonexistent\\newfile.txt' : '/home/user/nonexistent/newfile.txt';
         

--- a/src/filesystem/__tests__/path-validation.test.ts
+++ b/src/filesystem/__tests__/path-validation.test.ts
@@ -157,6 +157,17 @@ describe('Path Validation', () => {
         expect(isPathWithinAllowedDirectories('C:\\Users\\project2\\', allowed)).toBe(false);
       }
     });
+
+    it('handles Windows UNC share roots with trailing separators', () => {
+      if (path.sep === '\\') {
+        const allowed = ['\\\\server\\share\\'];
+
+        expect(isPathWithinAllowedDirectories('\\\\server\\share\\file.txt', allowed)).toBe(true);
+        expect(isPathWithinAllowedDirectories('\\\\server\\share\\nested\\file.txt', allowed)).toBe(true);
+        expect(isPathWithinAllowedDirectories('\\\\server\\share-other\\file.txt', allowed)).toBe(false);
+        expect(isPathWithinAllowedDirectories('\\\\other\\share\\file.txt', allowed)).toBe(false);
+      }
+    });
   });
 
   describe('Error handling', () => {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -107,6 +107,30 @@ export async function validatePath(requestedPath: string): Promise<string> {
   // Security: Check if path is within allowed directories before any file operations
   const isAllowed = isPathWithinAllowedDirectories(normalizedRequested, allowedDirectories);
   if (!isAllowed) {
+    if (process.platform === 'win32') {
+      // Windows mapped drives can resolve to UNC paths at startup, so the raw
+      // drive-letter path may not string-match the canonical allow-list.
+      try {
+        const realPath = await fs.realpath(absolute);
+        const normalizedReal = normalizePath(realPath);
+        if (isPathWithinAllowedDirectories(normalizedReal, allowedDirectories)) {
+          return realPath;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          const parentDir = path.dirname(absolute);
+          try {
+            const realParentPath = await fs.realpath(parentDir);
+            const normalizedParent = normalizePath(realParentPath);
+            if (isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
+              return absolute;
+            }
+          } catch {
+            // Fall through to the normal access-denied message below.
+          }
+        }
+      }
+    }
     throw new Error(`Access denied - path outside allowed directories: ${absolute} not in ${allowedDirectories.join(', ')}`);
   }
 

--- a/src/filesystem/path-validation.ts
+++ b/src/filesystem/path-validation.ts
@@ -81,6 +81,9 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
       return pathDrive === dirDrive && normalizedPath.startsWith(normalizedDir.replace(/\\?$/, '\\'));
     }
     
-    return normalizedPath.startsWith(normalizedDir + path.sep);
+    const normalizedDirWithSep = normalizedDir.endsWith(path.sep)
+      ? normalizedDir
+      : normalizedDir + path.sep;
+    return normalizedPath.startsWith(normalizedDirWithSep);
   });
 }


### PR DESCRIPTION
﻿## Summary
- allow filesystem requests using Windows mapped-drive paths to pass when realpath resolves inside the configured UNC allow-list
- handle UNC share allow-list entries that already end with a separator without requiring a double separator
- add Windows regression coverage for existing and new files

Fixes #4129.
Fixes #3756.

## To verify
- npm exec -w src/filesystem -- vitest run __tests__/path-validation.test.ts
- npm exec -w src/filesystem -- vitest run __tests__/lib.test.ts
- npm run build -w src/filesystem
- npm test -w src/filesystem
- git diff --check
