### PR TITLE
fix(git): correct field alignment in git_log timestamp filter

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -154,7 +154,7 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
             args.extend(['--since', start_timestamp])
         if end_timestamp:
             args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+        args.extend(['--format=%H%n%an%n%ad%n%s'])
 
         log_output = repo.git.log(*args).split('\n')
 

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -482,3 +482,27 @@ def test_git_branch_rejects_contains_flag_injection(test_repository):
 
     with pytest.raises(BadName):
         git_branch(test_repository, "local", not_contains="--exec=evil")
+
+
+def test_git_log_timestamp_filter_aligns_commit_fields(tmp_path):
+    """git_log with a timestamp filter must not scramble fields across commits."""
+    repo_path = tmp_path / "ts_repo"
+    repo = git.Repo.init(repo_path)
+    author = git.Actor("Tester", "tester@example.com")
+    (repo_path / "f.txt").write_text("a")
+    repo.index.add(["f.txt"])
+    repo.index.commit("first commit", author=author, commit_date="2024-01-10T10:00:00")
+    (repo_path / "f.txt").write_text("b")
+    repo.index.add(["f.txt"])
+    repo.index.commit("second commit", author=author, commit_date="2024-01-20T10:00:00")
+
+    result = git_log(repo, start_timestamp="2024-01-01")
+
+    assert len(result) == 2
+    joined = "\n".join(result)
+    # Both subjects appear in Message fields (none dropped or shifted).
+    assert "Message: second commit" in joined
+    assert "Message: first commit" in joined
+    # Author appears only in Author fields, never shifted into Commit/Date.
+    assert "Commit: Tester" not in joined
+    assert "Author: Tester" in joined


### PR DESCRIPTION
## Summary

In `src/git/src/mcp_server_git/server.py`, the timestamp-filtered branch of `git_log` builds the format string `--format=%H%n%an%n%ad%n%s%n`. The **trailing `%n`** emits a blank line after each commit's subject, so git outputs **5 lines per commit** — but the parser strides by 4 (`for i in range(0, len(log_output), 4)`, "groups of 4 (hash, author, date, message)").

So every commit after the first is shifted by one line: its hash, author, date and subject land in the wrong fields, and the subject of the last in-range commit is dropped. Example output for two commits (filtered):

```
Commit: <hash>     Author: Tester   Date: ...   Message: second commit
Commit:            Author: <hash>   Date: Tester   Message: <date>      <- scrambled; "first commit" lost
```

(The non-timestamp branch is unaffected — it iterates `repo.iter_commits` directly.)

## Fix

Drop the trailing `%n` so each commit is exactly four lines, matching the stride-4 parser:

```python
args.extend(['--format=%H%n%an%n%ad%n%s'])
```

## Test

Added `test_git_log_timestamp_filter_aligns_commit_fields`: two timestamped commits + a `start_timestamp` filter, asserting both subjects appear in `Message:` and the author never shifts into `Commit:`/`Date:`. It fails on the previous code (fields scrambled, one subject dropped) and passes with the fix.

```
pytest src/git/tests/test_server.py   # 42 passed
ruff check                            # clean
```

The existing tests only exercised `git_log` without timestamps, so this branch's output correctness was untested.
