### PR TITLE
test(filesystem): cover encoded Windows root URIs

### DIFF
--- a/src/filesystem/__tests__/roots-utils.test.ts
+++ b/src/filesystem/__tests__/roots-utils.test.ts
@@ -58,6 +58,23 @@ describe('getValidRootDirectories', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toBe(subDir);
     });
+
+    it('should process VS Code Windows file URIs with encoded drive colons', async () => {
+      if (process.platform !== 'win32') {
+        return;
+      }
+
+      const windowsPath = testDir1.replace(/\\/g, '/');
+      const encodedDrivePath = windowsPath.replace(/^([a-zA-Z]):/, (_, drive: string) => `${drive.toLowerCase()}%3A`);
+      const roots: Root[] = [
+        { uri: `file:///${encodedDrivePath}`, name: 'VS Code workspace root' }
+      ];
+
+      const result = await getValidRootDirectories(roots);
+
+      expect(result).toContain(testDir1);
+      expect(result).toHaveLength(1);
+    });
   });
 
   describe('error handling', () => {


### PR DESCRIPTION
## Summary
- add a Windows regression test for VS Code-style MCP roots like `file:///c%3A/...`
- cover the encoded drive-colon shape reported in #3174
- keep this separate from #3353, which covers generic `pathToFileURL` encoding behavior

## Verification
- `npm test --workspace src/filesystem -- roots-utils.test.ts`
- `npm test --workspace src/filesystem`
- `npm run build --workspace src/filesystem`
- Codex review: no actionable findings
