### PR TITLE
fix(deps): bump gitpython and urllib3 to resolve HIGH security alerts

### DIFF
--- a/src/fetch/uv.lock
+++ b/src/fetch/uv.lock
@@ -1293,11 +1293,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/src/git/pyproject.toml
+++ b/src/git/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.7",
-    "gitpython>=3.1.45",
+    "gitpython>=3.1.50",
     "mcp>=1.0.0",
     "pydantic>=2.0.0",
 ]

--- a/src/git/uv.lock
+++ b/src/git/uv.lock
@@ -230,14 +230,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -378,7 +378,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
-    { name = "gitpython", specifier = ">=3.1.45" },
+    { name = "gitpython", specifier = ">=3.1.50" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
## Summary

Resolves two HIGH-severity Dependabot alerts in runtime dependencies.

- **git** (`mcp-server-git`): `gitpython` `>=3.1.45` → `>=3.1.50` (lock `3.1.49` → `3.1.50`)
  - Fixes **GHSA-mv93-w799-cj2w** — newline injection in `config_writer()` bypasses the CVE-2026-42215 patch, enabling RCE via `core.hooksPath`.
- **fetch** (`mcp-server-fetch`): `urllib3` `2.6.3` → `2.7.0` (transitive via `requests`)
  - Fixes **GHSA-qccp-gfcp-xxvc** — sensitive headers forwarded across origins on proxied redirects.
  - Fixes **GHSA-mf9v-mfxr-j63j** — decompression-bomb safeguards bypassed in parts of the streaming API.

Resolves Dependabot alerts #129, #131, #132.

## Changes

- `src/git/pyproject.toml`, `src/git/uv.lock`
- `src/fetch/uv.lock`

Minimal lockfile bumps — only the affected packages changed.

## Testing

- `fetch`: `uv run pytest` → 20 passed.
- `git`: all test bodies pass (including the flag/injection-rejection security tests). The only failures are pre-existing Windows-specific fixture-teardown `PermissionError`s (`shutil.rmtree` cannot delete the temp repo while GitPython holds `.git` handles), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)