### PR TITLE
fix: declare zod runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,7 +3835,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^8.0.3",
         "glob": "^10.5.0",
-        "minimatch": "^10.0.1"
+        "minimatch": "^10.0.1",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-filesystem": "dist/index.js"
@@ -3855,7 +3856,8 @@
       "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-memory": "dist/index.js"
@@ -3875,7 +3877,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
Fixes #4288.

## Summary

`@modelcontextprotocol/server-sequential-thinking` imports `zod` directly from its runtime entrypoint, but the package did not declare `zod` as a dependency. With strict package isolation, consumers can install the server without a local `zod`, then hit `ERR_MODULE_NOT_FOUND` at runtime.

While checking the same dependency boundary, I found two other published server packages with the same direct runtime import:

- `@modelcontextprotocol/server-memory`
- `@modelcontextprotocol/server-filesystem`

This patch declares `zod` in those three packages, using the same `^4.0.0` range already used by `@modelcontextprotocol/server-everything`.

## Validation

- `npm install --package-lock-only --ignore-scripts`
- `npm install --ignore-scripts`
- `npm run build --workspace=@modelcontextprotocol/server-sequential-thinking`
- `npm run build --workspace=@modelcontextprotocol/server-memory`
- `npm run build --workspace=@modelcontextprotocol/server-filesystem`
- `npm test --workspace=@modelcontextprotocol/server-sequential-thinking`
- `npm test --workspace=@modelcontextprotocol/server-memory`
- `npm test --workspace=@modelcontextprotocol/server-filesystem`
- `npm exec prettier -- --check src/filesystem/package.json src/memory/package.json src/sequentialthinking/package.json package-lock.json`
- `git diff --check`
