### PR TITLE
fix: declare zod runtime deps for TS servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3705,6 +3705,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3874,7 +3875,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^8.0.3",
         "glob": "^10.5.0",
-        "minimatch": "^10.0.1"
+        "minimatch": "^10.0.1",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-filesystem": "dist/index.js"
@@ -3965,6 +3967,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "src/filesystem/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "src/gdrive": {
       "name": "@modelcontextprotocol/server-gdrive",
       "version": "0.6.2",
@@ -4048,7 +4059,8 @@
       "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-memory": "dist/index.js"
@@ -4099,6 +4111,15 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "src/memory/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "src/postgres": {
@@ -4162,7 +4183,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"
@@ -4214,6 +4236,15 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "src/sequentialthinking/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "src/slack": {

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- declare zod as a runtime dependency for the filesystem, memory, and sequential-thinking server packages
- sync package-lock.json so strict package managers install zod with each published server package that imports it directly

## Why
src/filesystem/index.ts, src/memory/index.ts, and src/sequentialthinking/index.ts all import zod directly. Without a direct package dependency, strict package managers can omit a co-located zod install for these published packages and the server entrypoints can fail with ERR_MODULE_NOT_FOUND.

## Verification
- 
pm install --package-lock-only --ignore-scripts
- 
pm install --ignore-scripts
- 
pm run build -w src/sequentialthinking
- 
pm run build -w src/memory
- 
pm run build -w src/filesystem
- 
pm run test -w src/sequentialthinking (14 passed)
- 
pm run test -w src/memory (45 passed)
- 
pm run test -w src/filesystem (147 passed; symlink-only cases skipped by test suite on Windows)
- static dependency check: every workspace package that directly imports zod now declares dependencies.zod

Fixes #4288