### PR TITLE
feat(memory): expose the knowledge graph as an MCP resource

### DIFF
--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -125,6 +125,13 @@ Example:
     - Relations between requested entities
   - Silently skips non-existent nodes
 
+### Resources
+
+- **`memory://graph`** (`knowledge-graph`)
+  - The full knowledge graph (all entities and relations) as JSON
+  - MIME type: `application/json`
+  - Read-only; lets MCP clients attach the whole graph as context without calling the `read_graph` tool
+
 # Usage with Claude Desktop
 
 ### Setup

--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { KnowledgeGraphManager, Entity, Relation, KnowledgeGraph } from '../index.js';
+import { KnowledgeGraphManager, Entity, Relation, KnowledgeGraph, readGraphResource } from '../index.js';
 
 describe('KnowledgeGraphManager', () => {
   let manager: KnowledgeGraphManager;
@@ -514,5 +514,51 @@ describe('KnowledgeGraphManager', () => {
       expect(result.relations).toHaveLength(1);
       expect(result.relations[0]).not.toHaveProperty('type');
     });
+  });
+});
+
+describe('readGraphResource', () => {
+  let manager: KnowledgeGraphManager;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    testFilePath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      `test-resource-${Date.now()}.jsonl`
+    );
+    manager = new KnowledgeGraphManager(testFilePath);
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.unlink(testFilePath);
+    } catch {
+      // Ignore if the file doesn't exist
+    }
+  });
+
+  it('returns the full graph as a JSON resource', async () => {
+    await manager.createEntities([
+      { name: 'Alice', entityType: 'person', observations: ['likes coffee'] },
+    ]);
+
+    const result = await readGraphResource(manager, 'memory://graph');
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].uri).toBe('memory://graph');
+    expect(result.contents[0].mimeType).toBe('application/json');
+
+    const data = JSON.parse(result.contents[0].text);
+    expect(data.entities).toHaveLength(1);
+    expect(data.entities[0].name).toBe('Alice');
+    expect(data).toHaveProperty('relations');
+  });
+
+  it('returns an empty graph when nothing has been stored', async () => {
+    const result = await readGraphResource(manager);
+
+    const data = JSON.parse(result.contents[0].text);
+    expect(data.entities).toEqual([]);
+    expect(data.relations).toEqual([]);
   });
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -253,6 +253,24 @@ const RelationSchema = z.object({
 });
 
 // The server instance and tools exposed to Claude
+// Build the MCP resource contents for the full knowledge graph.
+// Exported so it can be unit-tested independently of the server transport.
+export async function readGraphResource(
+  manager: KnowledgeGraphManager,
+  uri: string = "memory://graph",
+) {
+  const graph = await manager.readGraph();
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(graph, null, 2),
+      },
+    ],
+  };
+}
+
 const server = new McpServer({
   name: "memory-server",
   version: "0.6.3",
@@ -521,6 +539,20 @@ server.registerTool(
       structuredContent: { ...graph }
     };
   }
+);
+
+// Expose the full knowledge graph as a readable resource (read-only),
+// complementing the `read_graph` tool. Resources are the idiomatic way to
+// surface read-only data so MCP clients can attach it as context.
+server.registerResource(
+  "knowledge-graph",
+  "memory://graph",
+  {
+    title: "Knowledge Graph",
+    description: "The full knowledge graph (all entities and relations) as JSON",
+    mimeType: "application/json",
+  },
+  async (uri) => readGraphResource(knowledgeGraphManager, uri.href),
 );
 
 async function main() {


### PR DESCRIPTION
The `memory` server currently exposes only Tools. This adds **Resources** support — per the contributing guide's invitation to demonstrate under-used protocol features beyond Tools (Resources, Prompts, Roots).

A single read-only resource:

- **`memory://graph`** (`knowledge-graph`, `application/json`) — returns the full knowledge graph (all entities and relations) as JSON. It complements the existing `read_graph` tool: Resources are the idiomatic way to surface read-only data so MCP clients can attach the whole graph as context without invoking a tool.

The resource content is built by an exported `readGraphResource()` helper, so it's unit-tested independently of the server transport (matching the existing manager-level test style). Includes tests and README docs.

Verified locally: `npm run build` (tsc) passes and `npm test` (vitest) is green — 47 tests, including 2 new ones for the resource.