### PR TITLE
fix(memory): honor MEMORY_FILE_PATH relative to cwd and prepare storage dir

### DIFF
--- a/src/memory/__tests__/file-path.test.ts
+++ b/src/memory/__tests__/file-path.test.ts
@@ -56,7 +56,34 @@ describe('ensureMemoryFilePath', () => {
       const result = await ensureMemoryFilePath();
 
       expect(path.isAbsolute(result)).toBe(true);
-      expect(result).toContain('custom-memory.jsonl');
+      expect(result).toBe(path.resolve(process.cwd(), relativePath));
+    });
+
+    it('should create parent directories for custom absolute paths', async () => {
+      const absolutePath = path.join(testDir, 'nested', 'dir', 'memory.jsonl');
+      process.env.MEMORY_FILE_PATH = absolutePath;
+
+      const result = await ensureMemoryFilePath();
+
+      expect(result).toBe(absolutePath);
+      const stat = await fs.stat(path.dirname(absolutePath));
+      expect(stat.isDirectory()).toBe(true);
+
+      await fs.rm(path.join(testDir, 'nested'), { recursive: true, force: true });
+    });
+
+    it('should migrate custom memory.json path to memory.jsonl', async () => {
+      const jsonPath = path.join(testDir, 'custom-memory.json');
+      const jsonlPath = `${jsonPath}l`;
+      process.env.MEMORY_FILE_PATH = jsonPath;
+      await fs.writeFile(jsonPath, '{"type":"entity","name":"a","entityType":"t","observations":[]}');
+
+      const result = await ensureMemoryFilePath();
+
+      expect(result).toBe(jsonlPath);
+      await fs.access(jsonlPath);
+      await fs.rm(jsonPath, { force: true }).catch(() => undefined);
+      await fs.unlink(jsonlPath).catch(() => undefined);
     });
 
     it('should handle Windows absolute paths', async () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -13,34 +13,55 @@ export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.met
 // Handle backward compatibility: migrate memory.json to memory.jsonl if needed
 export async function ensureMemoryFilePath(): Promise<string> {
   if (process.env.MEMORY_FILE_PATH) {
-    // Custom path provided, use it as-is (with absolute path resolution)
-    return path.isAbsolute(process.env.MEMORY_FILE_PATH)
+    const configuredPath = path.isAbsolute(process.env.MEMORY_FILE_PATH)
       ? process.env.MEMORY_FILE_PATH
-      : path.join(path.dirname(fileURLToPath(import.meta.url)), process.env.MEMORY_FILE_PATH);
+      : path.resolve(process.cwd(), process.env.MEMORY_FILE_PATH);
+
+    return normalizeMemoryStoragePath(configuredPath);
   }
-  
-  // No custom path set, check for backward compatibility migration
+
+  // No custom path set, check for backward compatibility migration in package dir
   const oldMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.json');
   const newMemoryPath = defaultMemoryPath;
-  
+
   try {
-    // Check if old file exists and new file doesn't
     await fs.access(oldMemoryPath);
     try {
       await fs.access(newMemoryPath);
-      // Both files exist, use new one (no migration needed)
       return newMemoryPath;
     } catch {
-      // Old file exists, new file doesn't - migrate
       console.error('DETECTED: Found legacy memory.json file, migrating to memory.jsonl for JSONL format compatibility');
       await fs.rename(oldMemoryPath, newMemoryPath);
       console.error('COMPLETED: Successfully migrated memory.json to memory.jsonl');
       return newMemoryPath;
     }
   } catch {
-    // Old file doesn't exist, use new path
     return newMemoryPath;
   }
+}
+
+async function normalizeMemoryStoragePath(memoryPath: string): Promise<string> {
+  await fs.mkdir(path.dirname(memoryPath), { recursive: true });
+
+  if (memoryPath.endsWith('.json') && !memoryPath.endsWith('.jsonl')) {
+    const jsonlPath = `${memoryPath}l`;
+    try {
+      await fs.access(memoryPath);
+      try {
+        await fs.access(jsonlPath);
+        return jsonlPath;
+      } catch {
+        console.error(`DETECTED: Found legacy memory file at ${memoryPath}, migrating to JSONL format`);
+        await fs.rename(memoryPath, jsonlPath);
+        console.error(`COMPLETED: Successfully migrated to ${jsonlPath}`);
+        return jsonlPath;
+      }
+    } catch {
+      return jsonlPath;
+    }
+  }
+
+  return memoryPath;
 }
 
 // Initialize memory file path (will be set during startup)


### PR DESCRIPTION
## Problem

`MEMORY_FILE_PATH` was resolved relative to the installed package directory when a relative path was provided, so MCP clients configuring a workspace-local path still wrote into the npx cache directory (#692).

Custom absolute paths also failed when parent directories did not exist yet.

## Root cause

- Relative env paths joined against `import.meta.url` instead of `process.cwd()`
- No directory creation before first write
- Custom `.json` paths were not migrated to JSONL like the default path

## Fix

- Resolve relative `MEMORY_FILE_PATH` with `path.resolve(process.cwd(), ...)`
- `mkdir` parent directories for custom storage paths
- Migrate legacy custom `memory.json` to `memory.jsonl`
- Tests for cwd resolution, mkdir, and custom-path migration

Fixes #692