### PR TITLE
fix(git): keep stdio validation errors recoverable

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -584,4 +584,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options)

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -1,7 +1,10 @@
+import asyncio
+from contextlib import asynccontextmanager
 import pytest
 from pathlib import Path
 import git
 from git.exc import BadName
+import mcp_server_git.server as server_module
 from mcp_server_git.server import (
     git_checkout,
     git_branch,
@@ -38,6 +41,39 @@ def test_git_checkout_existing_branch(test_repository):
 
     assert "Switched to branch 'test-branch'" in result
     assert test_repository.active_branch.name == "test-branch"
+
+def test_stdio_transport_errors_do_not_abort_server(monkeypatch):
+    captured_run_kwargs = {}
+
+    class FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        def list_roots(self):
+            return lambda fn: fn
+
+        def list_tools(self):
+            return lambda fn: fn
+
+        def call_tool(self):
+            return lambda fn: fn
+
+        def create_initialization_options(self):
+            return object()
+
+        async def run(self, read_stream, write_stream, options, **kwargs):
+            captured_run_kwargs.update(kwargs)
+
+    @asynccontextmanager
+    async def fake_stdio_server():
+        yield object(), object()
+
+    monkeypatch.setattr(server_module, "Server", FakeServer)
+    monkeypatch.setattr(server_module, "stdio_server", fake_stdio_server)
+
+    asyncio.run(server_module.serve(repository=None))
+
+    assert "raise_exceptions" not in captured_run_kwargs
 
 def test_git_checkout_nonexistent_branch(test_repository):
 


### PR DESCRIPTION
## Description

Fixes #4213 by letting the git server use the default `Server.run(...)` behavior, matching the time server. Validation errors from stdin parsing should be returned through the JSON-RPC error path instead of being re-raised into the server task group and terminating the process.

## Server Details
- Server: git
- Changes to: stdio transport error handling

## Motivation and Context

`mcp-server-git` was the outlier among the Python reference servers: it passed `raise_exceptions=True` into `Server.run(...)`. For malformed JSON-RPC input, that makes transport-level validation errors abort the server process instead of keeping the stdio session recoverable.

The change removes that override and adds a focused regression test that verifies the git server no longer opts into exception-raising transport behavior.

## How Has This Been Tested?

- `python -m py_compile src\git\src\mcp_server_git\server.py src\git\tests\test_server.py`
- `python -m pytest src\git\tests\test_server.py::test_stdio_transport_errors_do_not_abort_server -q`
- `python -m ruff check src\git\src\mcp_server_git\server.py src\git\tests\test_server.py`
- `git diff --check`

I also ran the full `python -m pytest src\git\tests\test_server.py -q` on Windows. All test assertions reached pass state, but the existing GitPython temp repository fixture hit Windows file-handle cleanup errors during teardown (`PermissionError` while removing `.git` temp dirs). I did not count that as a clean full-suite pass.

## Breaking Changes

None. This aligns git server transport error behavior with the other Python servers instead of changing tool semantics.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

No README/config changes are needed because this is an internal transport recovery behavior fix.
