### PR TITLE
fix(fetch): accept socks proxy alias

### DIFF
--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "httpx>=0.27",
+    "httpx[socks]>=0.27",
     "markdownify>=0.13.1",
     "mcp>=1.1.3",
     "protego>=0.3.1",

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated, Tuple
 from urllib.parse import urlparse, urlunparse
 
@@ -63,6 +64,37 @@ def get_robots_txt_url(url: str) -> str:
     return robots_url
 
 
+def normalize_proxy_url(proxy_url: str | None) -> str | None:
+    if proxy_url is None:
+        return None
+
+    if proxy_url.lower().startswith("socks://"):
+        return f"socks5://{proxy_url[len('socks://'):]}"
+
+    return proxy_url
+
+
+def proxy_url_for_request(url: str, proxy_url: str | None = None) -> str | None:
+    if proxy_url:
+        return normalize_proxy_url(proxy_url)
+
+    scheme = urlparse(url).scheme.lower()
+    proxy_keys = []
+    if scheme == "https":
+        proxy_keys.extend(("HTTPS_PROXY", "https_proxy"))
+    elif scheme == "http":
+        proxy_keys.extend(("HTTP_PROXY", "http_proxy"))
+    proxy_keys.extend(("ALL_PROXY", "all_proxy"))
+
+    for key in proxy_keys:
+        env_proxy = os.environ.get(key)
+        normalized = normalize_proxy_url(env_proxy)
+        if normalized != env_proxy:
+            return normalized
+
+    return None
+
+
 async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url: str | None = None) -> None:
     """
     Check if the URL can be fetched by the user agent according to the robots.txt file.
@@ -72,7 +104,7 @@ async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url:
 
     robot_txt_url = get_robots_txt_url(url)
 
-    async with AsyncClient(proxy=proxy_url) as client:
+    async with AsyncClient(proxy=proxy_url_for_request(robot_txt_url, proxy_url)) as client:
         try:
             response = await client.get(
                 robot_txt_url,
@@ -116,7 +148,7 @@ async def fetch_url(
     """
     from httpx import AsyncClient, HTTPError
 
-    async with AsyncClient(proxy=proxy_url) as client:
+    async with AsyncClient(proxy=proxy_url_for_request(url, proxy_url)) as client:
         try:
             response = await client.get(
                 url,

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -10,6 +10,7 @@ from mcp_server_fetch.server import (
     check_may_autonomously_fetch_url,
     fetch_url,
     DEFAULT_USER_AGENT_AUTONOMOUS,
+    proxy_url_for_request,
 )
 
 
@@ -324,3 +325,35 @@ class TestFetchUrl:
 
             # Verify AsyncClient was called with proxy
             mock_client_class.assert_called_once_with(proxy="http://proxy.example.com:8080")
+
+    @pytest.mark.asyncio
+    async def test_fetch_accepts_socks_proxy_alias(self):
+        """Test that socks:// proxy URLs are accepted as SOCKS5 proxies."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"data": "test"}'
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await fetch_url(
+                "https://example.com/data",
+                DEFAULT_USER_AGENT_AUTONOMOUS,
+                proxy_url="socks://127.0.0.1:2080/"
+            )
+
+            mock_client_class.assert_called_once_with(proxy="socks5://127.0.0.1:2080/")
+
+    def test_fetch_accepts_socks_proxy_from_environment(self, monkeypatch):
+        """Test that invalid socks:// environment proxies are normalized."""
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:2080/")
+
+        assert proxy_url_for_request("https://example.com/data") == "socks5://127.0.0.1:2080/"

--- a/src/fetch/uv.lock
+++ b/src/fetch/uv.lock
@@ -349,6 +349,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0", size = 76395, upload-time = "2024-08-27T12:53:59.653Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.0"
@@ -564,7 +569,7 @@ name = "mcp-server-fetch"
 version = "0.6.3"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "markdownify" },
     { name = "mcp" },
     { name = "protego" },
@@ -583,7 +588,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "markdownify", specifier = ">=0.13.1" },
     { name = "mcp", specifier = ">=1.1.3" },
     { name = "protego", specifier = ">=0.3.1" },
@@ -1178,6 +1183,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Accept `socks://` proxy URLs as a SOCKS5 alias in the fetch server.

HTTPX accepts `socks5://...` but raises `Unknown scheme for proxy URL` for the common `socks://...` form. That can happen either when users pass `--proxy-url socks://...` or when the surrounding client process provides `ALL_PROXY=socks://...`.

This keeps the existing proxy behavior for normal `http://`, `https://`, and already-valid SOCKS URLs, but normalizes the invalid alias before creating the HTTPX client.

Fixes #767.

## Publishing Your Server

Not applicable; this changes the existing fetch server.

## Server Details

- Server: fetch
- Changes to: proxy URL handling and fetch server dependencies/tests

## Motivation and Context

Some tools and desktop environments expose local proxy settings as `socks://127.0.0.1:...`. HTTPX does not accept that scheme directly, so fetch fails before it can request the page. Treating `socks://` as `socks5://` matches the practical meaning users expect and avoids requiring each MCP client to rewrite the proxy URL first.

The dependency is also changed to `httpx[socks]` so SOCKS support is installed with the fetch server package.

## How Has This Been Tested?

- `.\.venv\Scripts\python.exe -m pytest tests\test_server.py::TestFetchUrl::test_fetch_with_proxy tests\test_server.py::TestFetchUrl::test_fetch_accepts_socks_proxy_alias tests\test_server.py::TestFetchUrl::test_fetch_accepts_socks_proxy_from_environment -q` -> 3 passed
- `.\.venv\Scripts\python.exe -m ruff check src\mcp_server_fetch\server.py tests\test_server.py` -> passed
- `.\.venv\Scripts\python.exe -m py_compile src\mcp_server_fetch\server.py tests\test_server.py` -> passed
- `.\.venv\Scripts\python.exe -m build` -> passed
- `git diff --check` -> passed
- Secret scan on touched files -> no matches

I also ran `.\.venv\Scripts\python.exe -m pytest tests\test_server.py -q`. It reached 21 passed / 1 failed. The failing test is `TestExtractContentFromHtml.test_empty_content_returns_error`, where the current Windows pure-Python `readabilipy` fallback returns an empty string for empty HTML. That is unrelated to the proxy path changed here.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

The README already documents `--proxy-url`; this patch does not introduce a new option. It only accepts a proxy URL form that users commonly inherit from their environment.
