### PR TITLE
docs(sequentialthinking): correct tool name to sequentialthinking in README

### DIFF
--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -12,7 +12,7 @@ An MCP server implementation that provides a tool for dynamic and reflective pro
 
 ## Tool
 
-### sequential_thinking
+### sequentialthinking
 
 Facilitates a detailed, step-by-step thinking process for problem-solving and analysis.
 
@@ -37,7 +37,7 @@ The Sequential Thinking tool is designed for:
 - Tasks that need to maintain context over multiple steps
 - Situations where irrelevant information needs to be filtered out
 
-In practice, you do not call `sequential_thinking` directly by hand unless your client exposes raw tool calls. Instead, connect the server to an MCP-aware host and ask the model to think through a problem step by step. The host can then decide to call the tool one or more times while it works.
+In practice, you do not call `sequentialthinking` directly by hand unless your client exposes raw tool calls. Instead, connect the server to an MCP-aware host and ask the model to think through a problem step by step. The host can then decide to call the tool one or more times while it works.
 
 ### What it looks like in use
 
@@ -49,7 +49,7 @@ Example prompts that typically benefit from this tool:
 
 ### How to tell it is working
 
-If your host or inspector shows tool activity, you should see repeated calls to `sequential_thinking` with fields such as:
+If your host or inspector shows tool activity, you should see repeated calls to `sequentialthinking` with fields such as:
 
 - `thought`
 - `thoughtNumber`
@@ -63,7 +63,7 @@ When the reasoning changes course, you may also see revision or branching fields
 After installing the server in your MCP host:
 
 1. Restart or reload the host so it reconnects to the server.
-2. Confirm the `sequential_thinking` tool appears in the host's MCP tool list or inspector.
+2. Confirm the `sequentialthinking` tool appears in the host's MCP tool list or inspector.
 3. Ask the host to solve a non-trivial problem in a step-by-step way.
 4. Verify that the host invokes the tool multiple times instead of returning a one-shot answer.
 


### PR DESCRIPTION
The sequentialthinking server README refers to the tool as `sequential_thinking` (with an underscore) in the tool heading and in the usage/verification sections, but the server registers it as `sequentialthinking` (no underscore) in `index.ts` (`server.registerTool("sequentialthinking", ...)`). Anyone following the README to confirm the tool name in their MCP host or to reference it would look for the wrong identifier. This corrects the four tool-name references in `src/sequentialthinking/README.md` to match the registered name. The npm package name (`server-sequential-thinking`), config keys, and Docker image references are intentionally left unchanged since those are correct.