### PR TITLE
fix(memory,sequentialthinking,filesystem): declare zod as an explicit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4048,7 +4048,8 @@
       "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.25 || ^4.0"
       },
       "bin": {
         "mcp-server-memory": "dist/index.js"
@@ -4162,7 +4163,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^3.25 || ^4.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3874,7 +3874,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^8.0.3",
         "glob": "^10.5.0",
-        "minimatch": "^10.0.1"
+        "minimatch": "^10.0.1",
+        "zod": "^3.25 || ^4.0"
       },
       "bin": {
         "mcp-server-filesystem": "dist/index.js"

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary

`@modelcontextprotocol/server-memory`, `@modelcontextprotocol/server-sequential-thinking`, and `@modelcontextprotocol/server-filesystem` all import `zod` at module load (`import { z } from "zod"`) but never declared it in their `package.json` `dependencies`.

Under pnpm's strict, non-flat `node_modules` layout a package can only import the dependencies it declares itself (not transitive ones). So even though `@modelcontextprotocol/sdk` pulls zod in, these servers crash on startup when run standalone:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package "zod" imported from .../dist/index.js
```

Reproduces with `pnpm dlx @modelcontextprotocol/server-memory` / `server-sequential-thinking` / `server-filesystem` (issue #4330 reported the first two; `server-filesystem` has the identical undeclared-zod import and is fixed here too).

## Fix

Declare `zod` explicitly in all three packages using the same range `@modelcontextprotocol/sdk` itself uses (`^3.25 || ^4.0`). This keeps zod deduped to the single instance the SDK already resolves (3.25.x in the current lockfile), avoiding a dual-zod-instance hazard when passing schemas to the SDK. `package-lock.json` is updated to match.

`server-everything` in this repo already declares zod this way, so the combination is known-good.

## Testing

- Confirmed each of the three source files imports `zod` while none declared it.
- Verified the chosen range matches the SDK declaration (`^3.25 || ^4.0`) and the existing hoisted resolution (zod 3.25.76).

Fixes #4330