### PR TITLE
fix: declare zod runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,7 +3835,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^8.0.3",
         "glob": "^10.5.0",
-        "minimatch": "^10.0.1"
+        "minimatch": "^10.0.1",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-filesystem": "dist/index.js"
@@ -3855,7 +3856,8 @@
       "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-memory": "dist/index.js"
@@ -3875,7 +3877,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- add `zod` as a direct runtime dependency for the memory and sequential-thinking servers
- add the same direct dependency for the filesystem server, which also imports `zod` directly
- update the npm lockfile so published package installs include the dependency metadata

Fixes #4330

## Testing
- `npm install`
- `npm run build --workspace src/memory && npm run build --workspace src/sequentialthinking && npm run build --workspace src/filesystem`
- `npm test --workspace src/memory && npm test --workspace src/sequentialthinking && npm test --workspace src/filesystem`
- packed the three affected workspaces and installed the tarballs in a clean temp project
- verified `zod` resolves from each installed package and that short startup smokes no longer hit a missing `zod` module error
- `git diff --check`