### PR TITLE
filesystem: clarify search_files matching scope

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -136,7 +136,7 @@ The server's directory access control follows this flow:
   - Fails if destination exists
 
 - **search_files**
-  - Recursively search for files/directories that match or do not match patterns
+  - Recursively search for files/directories by name or path, not file contents
   - Inputs:
     - `path` (string): Starting directory
     - `pattern` (string): Search pattern

--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -139,6 +139,14 @@ describe('structuredContent schema compliance', () => {
   });
 
   describe('search_files (control - already working)', () => {
+    it('should describe name/path matching rather than content search', async () => {
+      const result = await client.listTools();
+      const searchFiles = result.tools.find((tool) => tool.name === 'search_files');
+
+      expect(searchFiles?.description).toContain('by name or path');
+      expect(searchFiles?.description).toContain('not file contents');
+    });
+
     it('should return structuredContent.content as a string', async () => {
       const result = await client.callTool({
         name: 'search_files',

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -628,8 +628,8 @@ server.registerTool(
   {
     title: "Search Files",
     description:
-      "Recursively search for files and directories matching a pattern. " +
-      "The patterns should be glob-style patterns that match paths relative to the working directory. " +
+      "Recursively search for files and directories by name or path, not file contents. " +
+      "The patterns should be glob-style patterns that match paths relative to the search directory. " +
       "Use pattern like '*.ext' to match files in current directory, and '**/*.ext' to match files in all subdirectories. " +
       "Returns full paths to all matching items. Great for finding files when you don't know their exact location. " +
       "Only searches within allowed directories.",


### PR DESCRIPTION
### What

Clarifies the filesystem server `search_files` tool description so it states up front that it matches file and directory names/paths, not file contents.

Also updates the filesystem README wording and adds a `tools/list` regression check so the exposed tool schema keeps that distinction clear.

### Why

Fixes #896. The current first sentence can be read as grep-style content search, which makes clients choose `search_files` for content lookup and then get misleading empty results.

### Tests

- `npm run build -w @modelcontextprotocol/server-filesystem`
- `npm test -w @modelcontextprotocol/server-filesystem -- --run __tests__/structured-content.test.ts`
- `git diff --check`