### PR TITLE
fix(memory): skip duplicate entities and relations within a single batch

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -59,6 +59,20 @@ describe('KnowledgeGraphManager', () => {
       const newEntities = await manager.createEntities([]);
       expect(newEntities).toHaveLength(0);
     });
+
+    it('should ignore duplicate entity names within a single batch', async () => {
+      const entities: Entity[] = [
+        { name: 'Alice', entityType: 'person', observations: ['first'] },
+        { name: 'Alice', entityType: 'person', observations: ['second'] },
+      ];
+
+      const newEntities = await manager.createEntities(entities);
+      expect(newEntities).toHaveLength(1);
+
+      const graph = await manager.readGraph();
+      expect(graph.entities).toHaveLength(1);
+      expect(graph.entities[0].name).toBe('Alice');
+    });
   });
 
   describe('createRelations', () => {
@@ -102,6 +116,24 @@ describe('KnowledgeGraphManager', () => {
     it('should handle empty relation arrays', async () => {
       const newRelations = await manager.createRelations([]);
       expect(newRelations).toHaveLength(0);
+    });
+
+    it('should skip duplicate relations within a single batch', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: [] },
+        { name: 'Bob', entityType: 'person', observations: [] },
+      ]);
+
+      const relations: Relation[] = [
+        { from: 'Alice', to: 'Bob', relationType: 'knows' },
+        { from: 'Alice', to: 'Bob', relationType: 'knows' },
+      ];
+
+      const newRelations = await manager.createRelations(relations);
+      expect(newRelations).toHaveLength(1);
+
+      const graph = await manager.readGraph();
+      expect(graph.relations).toHaveLength(1);
     });
   });
 

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -118,7 +118,11 @@ export class KnowledgeGraphManager {
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {
     const graph = await this.loadGraph();
-    const newEntities = entities.filter(e => !graph.entities.some(existingEntity => existingEntity.name === e.name));
+    const newEntities = entities.filter((e, index) =>
+      !graph.entities.some(existingEntity => existingEntity.name === e.name) &&
+      // Also skip duplicates appearing earlier in this same batch
+      !entities.slice(0, index).some(earlier => earlier.name === e.name)
+    );
     graph.entities.push(...newEntities);
     await this.saveGraph(graph);
     return newEntities;
@@ -126,11 +130,15 @@ export class KnowledgeGraphManager {
 
   async createRelations(relations: Relation[]): Promise<Relation[]> {
     const graph = await this.loadGraph();
-    const newRelations = relations.filter(r => !graph.relations.some(existingRelation => 
-      existingRelation.from === r.from && 
-      existingRelation.to === r.to && 
-      existingRelation.relationType === r.relationType
-    ));
+    const isSameRelation = (a: Relation, b: Relation) =>
+      a.from === b.from &&
+      a.to === b.to &&
+      a.relationType === b.relationType;
+    const newRelations = relations.filter((r, index) =>
+      !graph.relations.some(existingRelation => isSameRelation(existingRelation, r)) &&
+      // Also skip duplicates appearing earlier in this same batch
+      !relations.slice(0, index).some(earlier => isSameRelation(earlier, r))
+    );
     graph.relations.push(...newRelations);
     await this.saveGraph(graph);
     return newRelations;


### PR DESCRIPTION
## Description

`create_entities` and `create_relations` only de-duplicated against the **existing** graph, never against the items in the incoming request. So passing the same entity name (or an identical relation) twice in a single call persisted duplicate records to `memory.jsonl`.

This contradicts the documented behavior in the README — *"Ignores entities with existing names"* and *"Skips duplicate relations"* — and breaks the implicit name-uniqueness invariant the rest of the manager relies on (`addObservations`/`deleteEntities`/`deleteObservations` all key on `name`, and `find()` only returns the first match).

The fix de-duplicates within the input batch as well, keeping the first occurrence. Cross-call de-duplication is unchanged.

## Server Details
- Server: memory
- Changes to: core logic (`KnowledgeGraphManager.createEntities`, `KnowledgeGraphManager.createRelations`)

## Motivation and Context

Reproduction (before this change):

```jsonc
// create_entities
[{ "name": "Alice", "entityType": "person", "observations": ["a"] },
 { "name": "Alice", "entityType": "person", "observations": ["b"] }]
// -> graph now contains TWO "Alice" entities

// create_relations
[{ "from": "Alice", "to": "Bob", "relationType": "knows" },
 { "from": "Alice", "to": "Bob", "relationType": "knows" }]
// -> graph now contains TWO identical relations
```

After the change each of the above creates a single record, matching the documented "ignores existing names" / "skips duplicate relations" contract.

## How Has This Been Tested?

Added two regression tests to `src/memory/__tests__/knowledge-graph.test.ts` (within-batch duplicate entities, within-batch duplicate relations) and ran the existing vitest suite:

```
$ npx vitest run            # in src/memory
 Test Files  2 passed (2)
      Tests  47 passed (47)
```

Both new tests fail on `main` (the manager returns/persists 2 records) and pass with this change. `npx tsc --noEmit` is clean.

## Breaking Changes

None. Behavior only changes for inputs that were already malformed (duplicate items in one request); valid de-duplicating callers are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly *(no change needed — fix aligns behavior with the existing README description)*
- [ ] I have tested this with an LLM client *(verified via the vitest suite instead)*
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

> Prepared with AI assistance; the diff, tests, and verification were reviewed by me.
