### PR TITLE
Add 墨言安全审计 MCP Server — verifiable agent trust audit with AI payment loop

### DIFF
--- a/servers/moyan-security-audit.json
+++ b/servers/moyan-security-audit.json
@@ -1,0 +1,67 @@
+{
+  "name": "moyan-security-audit",
+  "description": "AI Agent security audit with verifiable PMI trust scores, DecayProof, and 43 defense lines across 7 layers. Supports Alipay/WeChat/ClawTip AI payment loop.",
+  "url": "https://sixu-ai.net.cn",
+  "transport": "http",
+  "tools": [
+    {
+      "name": "security_audit",
+      "description": "Submit code for security audit. Returns PMI 4-dimensional trust score (integrity/compliance/reliability/decay_aware) + violation details across L0/L1/L2 layers.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Code to audit"
+          },
+          "language": {
+            "type": "string",
+            "description": "Programming language (sql, python, bash, etc.)"
+          },
+          "audit_level": {
+            "type": "string",
+            "enum": [
+              "L0",
+              "L1",
+              "L2"
+            ],
+            "default": "L2",
+            "description": "Audit depth: L0=full(43 defenses), L1=runtime+output(31), L2=output only(13)"
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    },
+    {
+      "name": "payment_health",
+      "description": "Check payment service health status (Alipay/WeChat/ClawTip channels)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "kappa_diagnosis",
+      "description": "Get κ_Axiom self-diagnosis with Ω index, complexity/evidence ratio, and L0/L1/L2 violation classification",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ],
+  "pricing": {
+    "free": "100 scans/month (L2 only)",
+    "standard": "¥1,500/month (1,000 scans)",
+    "pro": "¥8,000/month (10,000 scans, L0-L2)"
+  },
+  "homepage": "https://github.com/Liuyanfeng1234/agent-os/discussions/38",
+  "documentation": "https://github.com/Liuyanfeng1234/agent-os/discussions/39",
+  "standards": [
+    "W3C agent-identity (TRAIL+MolTrust+Agent OS convergence)",
+    "A2A Protocol 64/64 TSC compliance",
+    "CompositionRef v1.2 (SHA-256 JCS RFC 8785)",
+    "SIAP independent verification (28/28 PASS)"
+  ]
+}


### PR DESCRIPTION
## 墨言安全审计 MCP Server

A production AI agent security audit service with verifiable trust scores and complete AI payment loop.

### What it does
- **PMI 4-dimensional trust scoring**: integrity, compliance, reliability, decay_aware — not a single scalar
- **DecayProof**: verifiable trust decay curve Γ(t,d) — not a black box
- **κ_Axiom**: self-triggering audit based on Ω index — not scheduled/manual
- **43 defense lines** across 7 layers: L0 input(12) + L1 runtime(18) + L2 output(13)
- **AI payment loop**: Alipay/WeChat/ClawTip — create order → QR → callback → audit activation

### Why this matters
W3C agent-identity recently saw three-way convergence (TRAIL + MolTrust + Agent OS) on a binary-claim + verifier-policy model. This is the first production MCP server implementing that model.

### Quick test
```bash
curl -X POST https://sixu-ai.net.cn/api/security_audit \
  -H "Content-Type: application/json" \
  -d '{"code":"SELECT * FROM users WHERE id = '\'' OR 1=1 --'\''","language":"sql","audit_level":"L1"}'
```

### Links
- Service: https://sixu-ai.net.cn
- Docs: https://github.com/Liuyanfeng1234/agent-os/discussions/39
- Launch: https://github.com/Liuyanfeng1234/agent-os/discussions/38