### PR TITLE
fix(git): correct git_log off-by-one in timestamp-filtered output

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -169,7 +169,7 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
             args.extend(['--since', start_timestamp])
         if end_timestamp:
             args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+        args.extend(['--format=%H%n%an%n%ad%n%s'])
 
         log_output = repo.git.log(*args).split('\n')
 

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -508,3 +508,27 @@ def test_git_branch_rejects_contains_flag_injection(test_repository):
 
     with pytest.raises(BadName):
         git_branch(test_repository, "local", not_contains="--exec=evil")
+
+
+def test_git_log_with_timestamp_filter_parses_each_commit(test_repository):
+    """git_log's timestamp-filtered branch must parse one record per commit.
+
+    A trailing %n in the pretty-format emitted 5 newline-delimited fields per
+    commit while the parser strided by 4, shifting every commit after the first
+    (Author showed the next commit's hash, etc.).
+    """
+    repo_path = Path(test_repository.working_dir)
+    for msg in ("second commit", "third commit"):
+        (repo_path / "test.txt").write_text(msg)
+        test_repository.index.add(["test.txt"])
+        test_repository.index.commit(msg)
+
+    result = git_log(test_repository, start_timestamp="10 years ago")
+
+    assert len(result) == 3
+    messages = [entry.splitlines()[3][len("Message: "):] for entry in result]
+    assert messages == ["third commit", "second commit", "initial commit"]
+    for entry in result:
+        author = entry.splitlines()[1][len("Author: "):]
+        # The bug placed the next commit's 40-char hash in the Author field.
+        assert not (len(author) == 40 and all(c in "0123456789abcdef" for c in author))


### PR DESCRIPTION
## Description

`git_log`'s timestamp-filtered branch uses the pretty-format `%H%n%an%n%ad%n%s%n` — note the **trailing `%n`** after the subject. With git's inter-commit newline, `.split('\n')` then yields **5 fields per commit** (`hash`, `author`, `date`, `subject`, `""`), but the parser strides in groups of **4** (`range(0, len(log_output), 4)`).

So only the first commit parses correctly; every subsequent commit is shifted by one — `Author` shows the next commit's hash, `Date` shows its author, etc. — producing scrambled `git_log` output whenever `start_timestamp` / `end_timestamp` is used on a repo with 2+ matching commits.

The sibling no-timestamp branch (which uses `iter_commits`) parses cleanly, establishing the intended one-record-per-commit contract that this branch violates.

## Fix

Drop the trailing `%n` (`--format=%H%n%an%n%ad%n%s`) so each commit is exactly four newline-delimited fields, matching the groups-of-4 parser.

## Testing

Added `test_git_log_with_timestamp_filter_parses_each_commit` (three commits + a `start_timestamp` filter): before the fix it fails (messages/authors are shifted into each other); after the fix the three commits parse in order. Full `src/git` suite: **44 passed**.
