### PR TITLE
fix(memory): read serverInfo.version from package.json

### DIFF
--- a/src/memory/__tests__/server-version.test.ts
+++ b/src/memory/__tests__/server-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
+
+const packageJson = createRequire(import.meta.url)('../package.json') as { version: string };
+
+describe('server version', () => {
+  it('uses package.json version for serverInfo', () => {
+    expect(SERVER_VERSION).toBe(packageJson.version);
+    expect(resolvePackageVersion()).toBe(packageJson.version);
+  });
+
+  it('resolves package.json from the dist layout', () => {
+    const distDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+    const distVersionPath = path.join(distDir, 'version.js');
+
+    expect(() => createRequire(distVersionPath)('./version.js')).not.toThrow();
+    const distModule = createRequire(distVersionPath)('./version.js') as {
+      SERVER_VERSION: string;
+    };
+    expect(distModule.SERVER_VERSION).toBe(packageJson.version);
+  });
+});

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { SERVER_VERSION } from './version.js';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -253,10 +254,9 @@ const RelationSchema = z.object({
   relationType: z.string().describe("The type of the relation")
 });
 
-// The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: SERVER_VERSION,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";

--- a/src/memory/version.ts
+++ b/src/memory/version.ts
@@ -1,0 +1,27 @@
+import { createRequire } from 'node:module';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export function resolvePackageVersion(): string {
+  const require = createRequire(import.meta.url);
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(moduleDir, 'package.json'),
+    path.join(moduleDir, '..', 'package.json'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const pkg = require(candidate) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // Try the next candidate when running from dist/ or source.
+    }
+  }
+
+  throw new Error('Could not locate package.json for server version');
+}
+
+export const SERVER_VERSION = resolvePackageVersion();


### PR DESCRIPTION
## Description

Read `serverInfo.version` from `package.json` at runtime instead of hardcoding `"0.6.3"` in the memory server.

Fixes #4406

## Server Details
- Server: memory
- Changes to: server initialization / serverInfo version reporting

## Motivation and Context

The published `@modelcontextprotocol/server-memory` calendar versions (e.g. `2026.1.26`) still reported `serverInfo.version` as `"0.6.3"` because the value was hardcoded in source. This made diagnosing MCP startup issues confusing since the reported version did not match the installed package version.

## Changes

- Add `version.ts` with `resolvePackageVersion()` that locates `package.json` from both source (`./package.json`) and dist/Docker/npm layouts (`../package.json`)
- Use the resolved version when constructing `McpServer`
- Add tests covering source and dist version resolution

## How Has This Been Tested?

```bash
cd src/memory
npm run build
npm test
node -e "import('./dist/version.js').then(m => console.log(m.SERVER_VERSION))"
```

Results:
- **52 tests passed** (including new server-version tests)
- Build succeeds
- Dist module resolves version correctly from parent `package.json`

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

The fix is scoped to the memory server only. Other TypeScript servers in this repo still hardcode versions and could be addressed separately.