### PR TITLE
fix(memory, filesystem): dynamic package version + Windows case-insensitive paths

### DIFF
--- a/src/filesystem/path-validation.ts
+++ b/src/filesystem/path-validation.ts
@@ -81,6 +81,11 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
       return pathDrive === dirDrive && normalizedPath.startsWith(normalizedDir.replace(/\\?$/, '\\'));
     }
     
+    // On Windows, file paths are case-insensitive — compare lowercased
+    // so C:\source matches c:\Source\file.txt
+    if (process.platform === 'win32') {
+      return normalizedPath.toLowerCase().startsWith((normalizedDir + path.sep).toLowerCase());
+    }
     return normalizedPath.startsWith(normalizedDir + path.sep);
   });
 }

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs } from 'fs';
+import { promises as fs, readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -253,10 +253,27 @@ const RelationSchema = z.object({
   relationType: z.string().describe("The type of the relation")
 });
 
+// Read version from package.json at runtime to stay in sync with the published release.
+// Works from both source (src/memory/index.ts → ./package.json) and
+// compiled (dist/index.js → ../package.json).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+function loadPackageJson(): { version: string } {
+  const candidates = [
+    path.join(__dirname, 'package.json'),
+    path.join(__dirname, '..', 'package.json'),
+  ];
+  for (const c of candidates) {
+    try { return JSON.parse(readFileSync(c, 'utf-8')); } catch { /* try next */ }
+  }
+  return { version: '0.0.0' };
+}
+const { version: SERVER_VERSION } = loadPackageJson();
+
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: SERVER_VERSION,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";


### PR DESCRIPTION
## Fix 1: Dynamic version from package.json (Closes #4406)

`serverInfo.version` was hardcoded as `"0.6.3"` in server-memory since the package transitioned to calendar versioning. The compiled `dist/index.js` always reported `0.6.3` regardless of the actual package version.

**Fix:** Read version from `package.json` at startup via `loadPackageJson()` that works in both source (dev/test) and compiled contexts.

## Fix 2: Windows case-insensitive path comparison (Closes #470)

On Windows, `C:\source` and `c:\Source` refer to the same directory, but path validation used a case-sensitive `startsWith` comparison. When allowed directories had different casing than the filesystem path, access was incorrectly denied.

**Fix:** On Windows (`process.platform === 'win32'`), compare lowercased paths before `startsWith`. Non-Windows unchanged.

## Testing
- Build: `tsc` clean (both packages)
- Memory tests: 50/50 pass
- Filesystem tests: 147/147 pass