### PR TITLE
Add DDG Agent-Payable Services MCP to Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,15 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+
+## DDG Agent-Payable Services MCP
+
+- [DDG Agent-Payable Services MCP](https://agents.daedalusdevelopmentgroup.com/.well-known/ai) — Payment-aware MCP for AI-agent services: x402 checkout, MCP/security audits, paid model routing, and agent-commerce readiness resources.
+- **Transport:** Streamable HTTP at `https://mcp.daedalusdevelopmentgroup.com/mcp`
+- **PyPI:** `pip install ddg-agent-services-mcp`
+- **Tools:** 15 payment-aware tools including ddg_checkout_conformance, ddg_skill_safety_scan, ddg_quote_payment, ddg_run_paid_model
+- **Payment Rails:** x402 (Base, Polygon, Arbitrum, World Chain, Solana USDC), direct_crypto_auto, direct_crypto_manual
+- **Security:** No shell execution, no file-write tools, no credential relay; paid tools return structured 402 challenges
+- **Discovery:** `/.well-known/ai`, `/openapi.json`, `/llms.txt`, `/.well-known/ddg-agent-status.json`
+- **GitHub:** https://github.com/daedalusdevelopmentgroup/ddg-agent-payable-services
+- **x402scan:** https://www.x402scan.com/server/c3540307-0eb2-455d-90b6-a21f7d5a3792


### PR DESCRIPTION
## Add DDG Agent-Payable Services MCP to Registry

### Server Information
- **Name:** DDG Agent-Payable Services MCP
- **Description:** Payment-aware MCP for DDG Agent-Payable Services: discovery, x402 checkout, MCP/security audits, paid model routing, and agent-commerce readiness resources.
- **Homepage:** https://agents.daedalusdevelopmentgroup.com/.well-known/ai
- **Repository:** https://github.com/daedalusdevelopmentgroup/ddg-agent-payable-services
- **PyPI:** https://pypi.org/project/ddg-agent-services-mcp/0.1.0/
- **MCP Endpoint:** https://mcp.daedalusdevelopmentgroup.com/mcp (Streamable HTTP)
- **License:** MIT

### Transport
- **Type:** Streamable HTTP
- **URL:** https://mcp.daedalusdevelopmentgroup.com/mcp

### Tools (15 total)
- ddg_list_services
- ddg_agent_status
- ddg_checkout_conformance
- ddg_list_models
- ddg_list_local_runtime_options
- ddg_skill_safety_scan
- ddg_security_service_catalog
- ddg_order_status
- ddg_order_artifact
- ddg_receipt_verify_design
- ddg_tx_smoke_test
- ddg_quote_payment
- ddg_submit_order
- ddg_run_paid_model
- ddg_request_ollama_model

### Payment Rails
- x402 (Base, Polygon, Arbitrum, World Chain, Solana USDC)
- direct_crypto_auto
- direct_crypto_manual

### Security Posture
- No arbitrary shell execution tools
- No file-write tools
- No provider credential relay
- Paid tools return structured 402 challenges
- All secrets redacted from public surfaces

### Discovery Endpoints
- AI: https://agents.daedalusdevelopmentgroup.com/.well-known/ai
- OpenAPI: https://agents.daedalusdevelopmentgroup.com/openapi.json
- llms.txt: https://agents.daedalusdevelopmentgroup.com/llms.txt
- Status: https://agents.daedalusdevelopmentgroup.com/.well-known/ddg-agent-status.json
- x402scan: https://www.x402scan.com/server/c3540307-0eb2-455d-90b6-a21f7d5a3792

### Contact
- **Maintainer:** @0xcircuitbreaker (Daedalus Development Group)
- **Email:** 0xcircuitbreaker@protonmail.com

---