### PR TITLE
feat(additional): add Obol pay-per-call MCP server (Finance/Payments)

### DIFF
--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -80,6 +80,7 @@ This is a curated collection of community-built frameworks and resources that si
 - **[Search MCP Server](https://github.com/krzysztofkucmierz/search-mcp-server)** - Recommends the most relevant MCP servers based on the client's query by searching this README file.
 - **[MCPWatch](https://github.com/kapilduraphe/mcp-watch)** - A comprehensive security scanner for Model Context Protocol (MCP) servers that detects vulnerabilities and security issues in your MCP server implementations.
 - **[mkinf](https://mkinf.io)** - An Open Source registry of hosted MCP Servers to accelerate AI agent workflows.
+- **[Obol](https://github.com/superbigroach/obol-arc)** ([npm](https://www.npmjs.com/package/@superbigroach/obol-mcp)) - Pay-per-call API marketplace for AI agents — find, pay for, and call metered services in USDC on Arc testnet. Finance / Payments category.
 - **[Open-Sourced MCP Servers Directory](https://github.com/chatmcp/mcp-directory)** - A curated list of MCP servers by **[mcpso](https://mcp.so)**
 - **[OpenTools](https://opentools.com)** - An open registry for finding, installing, and building with MCP servers by **[opentoolsteam](https://github.com/opentoolsteam)**
 - **[Programmatic MCP Prototype](https://github.com/domdomegg/programmatic-mcp-prototype)** - Experimental agent prototype demonstrating programmatic MCP tool composition, progressive tool discovery, state persistence, and skill building through TypeScript code execution by **[Adam Jones](https://github.com/domdomegg)**

--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -80,7 +80,7 @@ This is a curated collection of community-built frameworks and resources that si
 - **[Search MCP Server](https://github.com/krzysztofkucmierz/search-mcp-server)** - Recommends the most relevant MCP servers based on the client's query by searching this README file.
 - **[MCPWatch](https://github.com/kapilduraphe/mcp-watch)** - A comprehensive security scanner for Model Context Protocol (MCP) servers that detects vulnerabilities and security issues in your MCP server implementations.
 - **[mkinf](https://mkinf.io)** - An Open Source registry of hosted MCP Servers to accelerate AI agent workflows.
-- **[Obol](https://github.com/superbigroach/obol-arc)** ([npm](https://www.npmjs.com/package/@superbigroach/obol-mcp)) - Pay-per-call API marketplace for AI agents — find, pay for, and call metered services in USDC on Arc testnet. Finance / Payments category.
+- **[Obol](https://github.com/superbigroach/obol-mcp)** ([npm](https://www.npmjs.com/package/@superbigroach/obol-mcp)) - Pay-per-call API marketplace for AI agents — find, pay for, and call metered services in USDC on Arc testnet. Finance / Payments category.
 - **[Open-Sourced MCP Servers Directory](https://github.com/chatmcp/mcp-directory)** - A curated list of MCP servers by **[mcpso](https://mcp.so)**
 - **[OpenTools](https://opentools.com)** - An open registry for finding, installing, and building with MCP servers by **[opentoolsteam](https://github.com/opentoolsteam)**
 - **[Programmatic MCP Prototype](https://github.com/domdomegg/programmatic-mcp-prototype)** - Experimental agent prototype demonstrating programmatic MCP tool composition, progressive tool discovery, state persistence, and skill building through TypeScript code execution by **[Adam Jones](https://github.com/domdomegg)**


### PR DESCRIPTION
## Summary

- Adds **[Obol](https://github.com/superbigroach/obol-arc)** to `ADDITIONAL.md` in the Resources section
- Obol is a pay-per-call API marketplace for AI agents: discover, pay for, and call metered API services in USDC on Arc testnet using the x402 protocol and EIP-3009 signed transfers
- Published on npm as [`@superbigroach/obol-mcp`](https://www.npmjs.com/package/@superbigroach/obol-mcp)
- Category: Finance / Payments

## Why ADDITIONAL.md

The server is a community-built MCP server in the Finance/Payments space. `ADDITIONAL.md` is the curated community resource list in this repo; placing Obol here follows the pattern of other payment-adjacent entries (e.g. PayMCP under Frameworks).

## Test plan

- [ ] Verify the new line renders correctly in the Markdown preview
- [ ] Confirm the GitHub link (`https://github.com/superbigroach/obol-arc`) and npm link (`https://www.npmjs.com/package/@superbigroach/obol-mcp`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)