### PR TITLE
docs(filesystem): clarify explicit root configuration

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -250,6 +250,11 @@ Note: all directories must be mounted to `/projects` by default.
 }
 ```
 
+Use explicit path arguments when you want the filesystem scope to be reviewable
+from this committed config. Running the server without path arguments is valid
+for clients that provide MCP roots at runtime, but then the access boundary is
+determined by the client session rather than by the JSON configuration.
+
 On Windows, use `cmd /c` to launch `npx`:
 
 ```json
@@ -327,6 +332,11 @@ Note: all directories must be mounted to `/projects` by default.
   }
 }
 ```
+
+Use explicit path arguments when you want the filesystem scope to be reviewable
+from this committed config. Running the server without path arguments is valid
+for clients that provide MCP roots at runtime, but then the access boundary is
+determined by the client session rather than by the JSON configuration.
 
 On Windows, use:
 


### PR DESCRIPTION
## Summary
- clarify that explicit filesystem path arguments make scope reviewable from committed JSON config
- document that argless startup is valid when clients provide MCP roots at runtime
- add the note to the Claude Desktop and VS Code install snippets

## Test plan
- `git diff --check`

Related: https://github.com/modelcontextprotocol/servers/issues/4391