### PR TITLE
docs(filesystem): clarify argless form behavior (Fixes #4423)

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -30,6 +30,11 @@ Roots notified by Client to Server, completely replace any server-side Allowed d
 
 This is the recommended method, as this enables runtime directory updates via `roots/list_changed` notifications without server restart, providing a more flexible and modern integration experience.
 
+> [!NOTE]
+> **Argless Form & Auditing**:
+> Starting the server without path arguments (e.g., `["-y", "@modelcontextprotocol/server-filesystem"]`) is valid, but it delegates the access boundary entirely to the client's roots at runtime. 
+> Because the client dynamically determines what paths are allowed, the access boundary is not self-contained or visible in the MCP configuration file. For an auditable, self-contained configuration where the allowed paths are clearly defined at config-review time, you should specify the directories explicitly as command-line arguments (e.g., `["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]`).
+
 ### How It Works
 
 The server's directory access control follows this flow:


### PR DESCRIPTION
## Description

This pull request updates the `src/filesystem/README.md` documentation to clarify server startup behavior and configuration auditing for directory access control. 

Documentation improvements:
* Added a note explaining that starting the server without path arguments delegates directory access control to the client at runtime, which can hinder auditability. It recommends specifying allowed directories as command-line arguments for a self-contained and auditable configuration.

*(Note: Left the registry publishing note intact as per standard template instructions)*

## Server Details
- Server: filesystem
- Changes to: documentation (`README.md`)

## Motivation and Context
Fixes #4423.

When the filesystem server is launched without path arguments, it correctly relies on the client's roots protocol for scope verification at runtime. However, this behavior makes the access boundary invisible at the config level. This PR adds a note to clarify this behavior and guides users who want an auditable, self-contained config to use explicit path arguments.

## How Has This Been Tested?
N/A - This is purely a documentation update.

## Breaking Changes
None. Users will not need to update their MCP client configurations.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
N/A