### PR TITLE
fix(memory): read version dynamically from package.json (Fixes #4406)

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,6 +7,11 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
+
+const _dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgPath = path.join(_dirname, path.basename(_dirname) === 'dist' ? '../package.json' : 'package.json');
+const packageJson = JSON.parse(readFileSync(pkgPath, 'utf-8'));
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -256,7 +261,7 @@ const RelationSchema = z.object({
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: packageJson.version,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";


### PR DESCRIPTION
## Description

This pull request updates the `@modelcontextprotocol/server-memory` server to dynamically read its version from `package.json` instead of using a hardcoded string (`"0.6.3"`).

Improvements:
* Uses `fs.readFileSync` combined with robust path resolution to read the package version at runtime.
* Ensures `package.json` path resolution works correctly across both pre-compiled (`.ts` via Vitest) and post-compiled (`.js` in `dist/`) execution contexts without triggering TypeScript `Node16` import assertion errors.

## Server Details
- Server: memory
- Changes to: `src/memory/index.ts` (McpServer initialization)

## Motivation and Context
Fixes #4406.

Previously, `serverInfo.version` in the memory server was hardcoded to `"0.6.3"`. When new versions were published, the server instance would still report `"0.6.3"`, leading to mismatched version semantics. This PR ensures the reported server version dynamically stays in sync with the package version.

## How Has This Been Tested?
Tested locally by building the workspace and running the existing memory server tests via Vitest:
`npm run build --workspace=@modelcontextprotocol/server-memory`
`npm run test --workspace=@modelcontextprotocol/server-memory`
All unit tests successfully passed using the new runtime path logic.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
The `package.json` file is read using a synchronous `fs.readFileSync` at the top level instead of `import packageJson from "./package.json" assert { type: "json" }`. This maintains compatibility with the repository's `Node16` module resolution configuration (which restricts modern import assertions/attributes) while remaining 100% robust.