### PR TITLE
feat(fetch): add tool annotations for fetch tool

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -9,6 +9,17 @@ A Model Context Protocol server that provides web content fetching capabilities.
 
 The fetch tool will truncate the response, but by using the `start_index` argument, you can specify where to start the content extraction. This lets models read a webpage in chunks, until they find the information they need.
 
+### Tool annotations
+
+This server sets [MCP ToolAnnotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#toolannotations)
+on its tool so clients can apply safety policies (for example, gating outbound network access).
+
+| Tool   | readOnlyHint | idempotentHint | destructiveHint | openWorldHint |
+|--------|--------------|----------------|-----------------|---------------|
+| fetch  | true         | true           | false           | true          |
+
+The `openWorldHint: true` annotation reflects that `fetch` performs outbound HTTP requests to user-supplied URLs.
+
 ### Available Tools
 
 - `fetch` - Fetches a URL from the internet and extracts its contents as markdown.

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -14,6 +14,7 @@ from mcp.types import (
     PromptMessage,
     TextContent,
     Tool,
+    ToolAnnotations,
     INVALID_PARAMS,
     INTERNAL_ERROR,
 )
@@ -203,6 +204,12 @@ async def serve(
 
 Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.""",
                 inputSchema=Fetch.model_json_schema(),
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
             )
         ]
 


### PR DESCRIPTION
## Summary

- Add `ToolAnnotations` to the fetch server's single `fetch` tool: `readOnlyHint=true`, `idempotentHint=true`, `destructiveHint=false`, `openWorldHint=true`.
- Document the annotation table in `src/fetch/README.md`, consistent with the filesystem server README.

Fixes #3572

## Motivation

The fetch reference server was the remaining unannotated server called out in #3572. Accurate annotations (especially `openWorldHint: true`) help MCP clients gate outbound network access in multi-tool setups.

## Approach

Follows the same `ToolAnnotations` pattern already used in `src/git` and `src/time`. Metadata-only change; no runtime behavior change.

## Test plan

- [x] `cd src/fetch && uv run pytest -q` (20 passed)
- [x] `cd src/fetch && uv run ruff check src tests`
