### PR TITLE
fix(memory): report package version in server info

### DIFF
--- a/src/memory/__tests__/server-info.test.ts
+++ b/src/memory/__tests__/server-info.test.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'module';
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
+
+const { MockMcpServer, mockServer } = vi.hoisted(() => {
+  const mockServer = {
+    registerTool: vi.fn(),
+    registerResource: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    server: {
+      sendResourceUpdated: vi.fn(),
+      registerCapabilities: vi.fn(),
+      setRequestHandler: vi.fn(),
+    },
+  };
+
+  return {
+    MockMcpServer: vi.fn(function MockMcpServer() {
+      return mockServer;
+    }),
+    mockServer,
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: MockMcpServer,
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: vi.fn(),
+}));
+
+describe('memory server info', () => {
+  it('uses the package version for MCP server metadata', async () => {
+    vi.resetModules();
+
+    await import('../index.js');
+
+    expect(MockMcpServer).toHaveBeenCalledTimes(1);
+    expect(MockMcpServer).toHaveBeenCalledWith({
+      name: 'memory-server',
+      version: packageJson.version,
+    });
+    expect(mockServer.registerTool).toHaveBeenCalled();
+  });
+});

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,12 +4,19 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs } from 'fs';
+import { promises as fs, readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+const currentDirPath = path.dirname(fileURLToPath(import.meta.url));
+const packageJsonUrl = new URL(
+  path.basename(currentDirPath) === 'dist' ? '../package.json' : './package.json',
+  import.meta.url,
+);
+const packageJson = JSON.parse(readFileSync(packageJsonUrl, 'utf-8')) as { version: string };
+
 // Define memory file path using environment variable with fallback
-export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
+export const defaultMemoryPath = path.join(currentDirPath, 'memory.jsonl');
 
 // Handle backward compatibility: migrate memory.json to memory.jsonl if needed
 export async function ensureMemoryFilePath(): Promise<string> {
@@ -17,11 +24,11 @@ export async function ensureMemoryFilePath(): Promise<string> {
     // Custom path provided, use it as-is (with absolute path resolution)
     return path.isAbsolute(process.env.MEMORY_FILE_PATH)
       ? process.env.MEMORY_FILE_PATH
-      : path.join(path.dirname(fileURLToPath(import.meta.url)), process.env.MEMORY_FILE_PATH);
+      : path.join(currentDirPath, process.env.MEMORY_FILE_PATH);
   }
   
   // No custom path set, check for backward compatibility migration
-  const oldMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.json');
+  const oldMemoryPath = path.join(currentDirPath, 'memory.json');
   const newMemoryPath = defaultMemoryPath;
   
   try {
@@ -256,7 +263,7 @@ const RelationSchema = z.object({
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: packageJson.version,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";


### PR DESCRIPTION
## Description

Fixes the memory server's MCP `serverInfo.version` metadata so it is read from the package manifest instead of duplicating the package version as a hardcoded string in `src/memory/index.ts`.

## Server Details
- Server: memory
- Changes to: server metadata/version reporting

## Motivation and Context

Fixes #4406.

`@modelcontextprotocol/server-memory` currently reports `"0.6.3"` from the `McpServer` constructor. Reading the version from `src/memory/package.json` keeps the reported server version aligned with the published package version.

## How Has This Been Tested?

From `src/memory` with Node 22.22.3 via mise:

- `mise x node@22.22.3 -- npm ci` -> added 177 packages, audited 179 packages, found 0 vulnerabilities
- `mise x node@22.22.3 -- npm test -- __tests__/server-info.test.ts` -> 1 test passed
- `mise x node@22.22.3 -- npm run build` -> passed
- `mise x node@22.22.3 -- npm test` -> 4 test files passed, 51 tests passed

Note: the first local focused-test run failed because my test mock used an arrow function for a constructor mock; I fixed the mock to use a constructable function, then reran the focused test successfully.

## Breaking Changes

None. Users do not need to update MCP client configuration.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

README updates, new environment variables, and new error handling are not applicable for this metadata-only bug fix.

AI assistance disclosure: I used AI assistance to prepare this change and reviewed the diff and local test results before opening the PR.
