### PR TITLE
Add repository links to Python package metadata

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -1,6 +1,7 @@
 # Fetch MCP Server
-
 <!-- mcp-name: io.github.modelcontextprotocol/server-fetch -->
+
+Source: [modelcontextprotocol/servers/src/fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)
 
 A Model Context Protocol server that provides web content fetching capabilities. This server enables LLMs to retrieve and process content from web pages, converting HTML to markdown for easier consumption.
 

--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch"
+Repository = "https://github.com/modelcontextprotocol/servers"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-fetch = "mcp_server_fetch:main"
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -1,6 +1,7 @@
 # mcp-server-git: A git MCP server
-
 <!-- mcp-name: io.github.modelcontextprotocol/server-git -->
+
+Source: [modelcontextprotocol/servers/src/git](https://github.com/modelcontextprotocol/servers/tree/main/src/git)
 
 ## Overview
 

--- a/src/git/pyproject.toml
+++ b/src/git/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers/tree/main/src/git"
+Repository = "https://github.com/modelcontextprotocol/servers"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-git = "mcp_server_git:main"
 

--- a/src/time/README.md
+++ b/src/time/README.md
@@ -1,6 +1,7 @@
 # Time MCP Server
-
 <!-- mcp-name: io.github.modelcontextprotocol/server-time -->
+
+Source: [modelcontextprotocol/servers/src/time](https://github.com/modelcontextprotocol/servers/tree/main/src/time)
 
 A Model Context Protocol server that provides time and timezone conversion capabilities. This server enables LLMs to get current time information and perform timezone conversions using IANA timezone names, with automatic system timezone detection.
 

--- a/src/time/pyproject.toml
+++ b/src/time/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "tzlocal>=5.3.1",
 ]
 
+[project.urls]
+Homepage = "https://github.com/modelcontextprotocol/servers/tree/main/src/time"
+Repository = "https://github.com/modelcontextprotocol/servers"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-time = "mcp_server_time:main"
 


### PR DESCRIPTION
## Summary
- Add `project.urls` metadata to the fetch, git, and time Python packages so PyPI exposes repository, source, and issue links.
- Add source-folder links to each corresponding README so package pages point users back to the relevant repository subdirectory.

Fixes #3336

## Tests
- Parsed `src/fetch/pyproject.toml`, `src/git/pyproject.toml`, and `src/time/pyproject.toml` with Python `tomllib` and verified the new `project.urls` entries.
- Checked each README contains the expected source-folder link.
- `git diff --check`