### PR TITLE
Fix memory search for entities without observations

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -323,6 +323,18 @@ describe('KnowledgeGraphManager', () => {
       expect(result.entities).toHaveLength(0);
       expect(result.relations).toHaveLength(0);
     });
+    it('should handle legacy entities without observations when searching', async () => {
+      await fs.writeFile(
+        testFilePath,
+        JSON.stringify({ type: 'entity', name: 'Legacy Node', entityType: 'person' }),
+      );
+
+      const result = await manager.searchNodes('Legacy');
+      expect(result.entities).toHaveLength(1);
+      expect(result.entities[0].name).toBe('Legacy Node');
+      expect(result.entities[0].observations).toEqual([]);
+    });
+
   });
 
   describe('openNodes', () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -79,7 +79,7 @@ export class KnowledgeGraphManager {
           graph.entities.push({
             name: item.name,
             entityType: item.entityType,
-            observations: item.observations
+            observations: Array.isArray(item.observations) ? item.observations : []
           });
         }
         if (item.type === "relation") {


### PR DESCRIPTION
## Summary
- Normalize missing or non-array `observations` fields to an empty array when loading memory entities.
- Prevent `search_nodes` from crashing on legacy or hand-authored memory records that omit `observations`.
- Add a regression test for a JSONL entity without `observations` and a non-empty search query.

Fixes #1818

## Tests
- `npm run build --workspace @modelcontextprotocol/server-memory`
- `npm test --workspace @modelcontextprotocol/server-memory`
- `git diff --check`