### PR TITLE
Support git show object specs

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -227,7 +227,16 @@ def git_show(repo: git.Repo, revision: str) -> str:
     # even if a malicious ref with that name exists (e.g. via filesystem manipulation)
     if revision.startswith("-"):
         raise BadName(f"Invalid revision: '{revision}' - cannot start with '-'")
-    commit = repo.commit(revision)
+    try:
+        commit = repo.commit(revision)
+    except (BadName, KeyError, ValueError):
+        # Support Git object specs such as "HEAD:path/to/file". GitPython's
+        # repo.commit() appends "^0", which makes valid blob specs fail as
+        # "path/to/file^0". Delegate these object specs to `git show` instead.
+        if ":" in revision:
+            return repo.git.show(revision)
+        raise
+
     output = [
         f"Commit: {commit.hexsha!r}\n"
         f"Author: {commit.author!r}\n"

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -278,6 +278,18 @@ def test_git_show_initial_commit(test_repository):
     assert "test.txt" in result
 
 
+def test_git_show_blob_object_spec(test_repository):
+    file_path = Path(test_repository.working_dir) / "logic" / "position_realtime_infos.py"
+    file_path.parent.mkdir()
+    file_path.write_text('print("hello")\n')
+    test_repository.index.add(["logic/position_realtime_infos.py"])
+    test_repository.index.commit("add nested file")
+
+    result = git_show(test_repository, "HEAD:logic/position_realtime_infos.py")
+
+    assert 'print("hello")' in result
+
+
 # Tests for validate_repo_path (repository scoping security fix)
 
 def test_validate_repo_path_no_restriction():


### PR DESCRIPTION
## Summary
- Support Git object specs such as `HEAD:path/to/file` in `git_show`.
- Preserve the existing formatted commit output for normal commit revisions.
- Add a regression test for showing a nested blob through `HEAD:logic/position_realtime_infos.py`.

Fixes #1682

## Tests
- `python -m pytest tests/test_server.py::test_git_show_blob_object_spec tests/test_server.py::test_git_show tests/test_server.py::test_git_show_initial_commit tests/test_server.py::test_git_show_rejects_flag_injection tests/test_server.py::test_git_show_rejects_malicious_refs -q`
- `python -m pytest tests/test_server.py -q`
- `python -m py_compile src/mcp_server_git/server.py`
- `git diff --check`