### PR TITLE
fix: add zod as explicit dependency for servers that import it directly

### DIFF
--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.25 || ^4.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Description

Fixes #4330.

Three servers (server-memory, server-sequential-thinking, server-filesystem) import 'zod' directly in their source code but do not declare it as a dependency. This causes startup failures with strict package managers (pnpm, npm with `--install-strategy=nested`) because zod is only a peerDependency of @modelcontextprotocol/sdk.

## Changes
- **server-memory**: Added `zod: ^3.25 || ^4.0` to dependencies
- **server-sequential-thinking**: Added `zod: ^3.25 || ^4.0` to dependencies
- **server-filesystem**: Added `zod: ^3.25 || ^4.0` to dependencies

## Related
- #4330 (this fix covers both servers mentioned in the issue, plus filesystem which has the same problem)
- #4444 (my other PR fixing the hardcoded version in server-memory)