### PR TITLE
fix(memory): expand leading ~ in MEMORY_FILE_PATH to the home directory

### DIFF
--- a/src/memory/__tests__/file-path.test.ts
+++ b/src/memory/__tests__/file-path.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
+import os from 'os';
 import { fileURLToPath } from 'url';
-import { ensureMemoryFilePath, defaultMemoryPath } from '../index.js';
+import { ensureMemoryFilePath, defaultMemoryPath, expandHome } from '../index.js';
 
 describe('ensureMemoryFilePath', () => {
   const testDir = path.dirname(fileURLToPath(import.meta.url));
@@ -71,6 +72,15 @@ describe('ensureMemoryFilePath', () => {
       } else {
         expect(path.isAbsolute(result)).toBe(true);
       }
+    });
+
+    it('should expand a leading "~/" to the home directory', async () => {
+      process.env.MEMORY_FILE_PATH = path.join('~', 'custom-memory.jsonl');
+
+      const result = await ensureMemoryFilePath();
+
+      expect(result).toBe(path.join(os.homedir(), 'custom-memory.jsonl'));
+      expect(path.isAbsolute(result)).toBe(true);
     });
   });
 
@@ -152,5 +162,31 @@ describe('ensureMemoryFilePath', () => {
     it('should be an absolute path', () => {
       expect(path.isAbsolute(defaultMemoryPath)).toBe(true);
     });
+  });
+});
+
+describe('expandHome', () => {
+  it('expands a bare "~" to the home directory', () => {
+    expect(expandHome('~')).toBe(os.homedir());
+  });
+
+  it('expands a leading "~/" to the home directory', () => {
+    expect(expandHome('~/notes/memory.jsonl')).toBe(
+      path.join(os.homedir(), 'notes/memory.jsonl')
+    );
+  });
+
+  it('leaves a "~" not followed by a separator unchanged', () => {
+    expect(expandHome('~backup.jsonl')).toBe('~backup.jsonl');
+  });
+
+  it('leaves absolute paths unchanged', () => {
+    expect(expandHome('/var/data/memory.jsonl')).toBe('/var/data/memory.jsonl');
+  });
+
+  it('leaves relative paths unchanged', () => {
+    expect(expandHome(path.join('data', 'memory.jsonl'))).toBe(
+      path.join('data', 'memory.jsonl')
+    );
   });
 });

--- a/src/memory/__tests__/file-path.test.ts
+++ b/src/memory/__tests__/file-path.test.ts
@@ -75,7 +75,7 @@ describe('ensureMemoryFilePath', () => {
     });
 
     it('should expand a leading "~/" to the home directory', async () => {
-      process.env.MEMORY_FILE_PATH = path.join('~', 'custom-memory.jsonl');
+      process.env.MEMORY_FILE_PATH = '~/custom-memory.jsonl';
 
       const result = await ensureMemoryFilePath();
 

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -6,18 +6,33 @@ import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextp
 import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
+import os from 'os';
 import { fileURLToPath } from 'url';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
 
+// Expand a leading "~" to the user's home directory. MCP clients pass
+// MEMORY_FILE_PATH from JSON config, where no shell performs tilde expansion,
+// so an unexpanded "~" would otherwise be treated as a relative path and
+// joined onto the package directory. Mirrors the helper of the same name in
+// the filesystem server (src/filesystem/path-utils.ts).
+export function expandHome(filepath: string): string {
+  if (filepath.startsWith('~/') || filepath === '~') {
+    return path.join(os.homedir(), filepath.slice(1));
+  }
+  return filepath;
+}
+
 // Handle backward compatibility: migrate memory.json to memory.jsonl if needed
 export async function ensureMemoryFilePath(): Promise<string> {
   if (process.env.MEMORY_FILE_PATH) {
-    // Custom path provided, use it as-is (with absolute path resolution)
-    return path.isAbsolute(process.env.MEMORY_FILE_PATH)
-      ? process.env.MEMORY_FILE_PATH
-      : path.join(path.dirname(fileURLToPath(import.meta.url)), process.env.MEMORY_FILE_PATH);
+    // Custom path provided. Expand a leading "~" first, then resolve relative
+    // paths against the package directory (absolute paths are used as-is).
+    const customPath = expandHome(process.env.MEMORY_FILE_PATH);
+    return path.isAbsolute(customPath)
+      ? customPath
+      : path.join(path.dirname(fileURLToPath(import.meta.url)), customPath);
   }
   
   // No custom path set, check for backward compatibility migration


### PR DESCRIPTION
## Summary

`@modelcontextprotocol/server-memory` ignores a `MEMORY_FILE_PATH` that begins with `~` (e.g. `~/memory.jsonl`). MCP clients pass this variable from JSON config (Claude Desktop, Cursor, Roo Cline, VS Code), where no shell performs tilde expansion. Because `path.isAbsolute("~/memory.jsonl")` is `false`, `ensureMemoryFilePath()` joined the value onto the package directory, so the server persisted to a literal `~` folder inside the install instead of the user's intended location.

Addresses #1600.

## Change

- `src/memory/index.ts`: add an `expandHome()` helper and call it in `ensureMemoryFilePath()` before the existing absolute/relative resolution. A leading `~` or `~/` expands to `os.homedir()`; absolute paths, relative paths, and a `~` that is not at the start are unchanged.

The helper mirrors the one already used by the filesystem server (`src/filesystem/path-utils.ts`), keeping tilde handling consistent across the official servers.

## Tests

`src/memory/__tests__/file-path.test.ts`:
- `expandHome` unit tests: bare `~`, `~/…`, a `~` not followed by a separator (unchanged), and absolute/relative passthrough.
- `ensureMemoryFilePath` end-to-end: `~/custom-memory.jsonl` resolves under `os.homedir()`.

Verified locally on this branch: `npm test` → 56/56 passing, `npm run build` (`tsc`) clean.

## Scope

Tilde expansion only. The `${workspaceFolder}` variable substitution discussed in #1846 is a client-side concern, and #1481 is about the JSONL storage format — neither is addressed here.