### PR TITLE
fix(memory): persist the knowledge graph atomically (temp file + rename)

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -417,10 +417,14 @@ describe('KnowledgeGraphManager', () => {
         ]);
 
         // saveGraph writes to a temp file, then atomically renames it into place.
-        expect(renameSpy).toHaveBeenCalledWith(
-          expect.stringMatching(/\.tmp$/),
-          testFilePath
-        );
+        expect(renameSpy).toHaveBeenCalledTimes(1);
+        const [tmpArg, destArg] = renameSpy.mock.calls[0];
+        expect(String(destArg)).toBe(testFilePath);
+        // The temp file must live in the target's own directory so the rename
+        // stays on the same filesystem (and is therefore atomic); guard that
+        // invariant rather than just matching any ".tmp" suffix.
+        expect(String(tmpArg).startsWith(`${testFilePath}.`)).toBe(true);
+        expect(String(tmpArg).endsWith('.tmp')).toBe(true);
       } finally {
         renameSpy.mockRestore();
       }
@@ -429,6 +433,30 @@ describe('KnowledgeGraphManager', () => {
       const graph = await manager.readGraph();
       expect(graph.entities.map(e => e.name)).toContain('Alice');
 
+      const dir = path.dirname(testFilePath);
+      const base = path.basename(testFilePath);
+      const leftovers = (await fs.readdir(dir)).filter(
+        f => f.startsWith(base) && f.endsWith('.tmp')
+      );
+      expect(leftovers).toEqual([]);
+    });
+
+    it('should clean up the temp file if the atomic rename fails', async () => {
+      const renameSpy = vi
+        .spyOn(fs, 'rename')
+        .mockRejectedValueOnce(new Error('simulated rename failure'));
+      try {
+        await expect(
+          manager.createEntities([
+            { name: 'Alice', entityType: 'person', observations: [] },
+          ])
+        ).rejects.toThrow('simulated rename failure');
+      } finally {
+        renameSpy.mockRestore();
+      }
+
+      // The temp file written before the failed rename is unlinked (the catch
+      // branch), so no partial file is left behind.
       const dir = path.dirname(testFilePath);
       const base = path.basename(testFilePath);
       const leftovers = (await fs.readdir(dir)).filter(

--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -407,6 +407,34 @@ describe('KnowledgeGraphManager', () => {
 
       expect(graph.entities).toHaveLength(1);
       expect(graph.entities[0].name).toBe('Alice');
+    });
+
+    it('should persist atomically via a temporary file and rename', async () => {
+      const renameSpy = vi.spyOn(fs, 'rename');
+      try {
+        await manager.createEntities([
+          { name: 'Alice', entityType: 'person', observations: ['atomic'] },
+        ]);
+
+        // saveGraph writes to a temp file, then atomically renames it into place.
+        expect(renameSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/\.tmp$/),
+          testFilePath
+        );
+      } finally {
+        renameSpy.mockRestore();
+      }
+
+      // Data round-trips and no temporary file is left behind.
+      const graph = await manager.readGraph();
+      expect(graph.entities.map(e => e.name)).toContain('Alice');
+
+      const dir = path.dirname(testFilePath);
+      const base = path.basename(testFilePath);
+      const leftovers = (await fs.readdir(dir)).filter(
+        f => f.startsWith(base) && f.endsWith('.tmp')
+      );
+      expect(leftovers).toEqual([]);
     });
 
     it('should handle JSONL format correctly', async () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { randomBytes } from 'crypto';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -114,7 +115,20 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    // Write to a temporary file and atomically rename it into place so an
+    // interrupted or concurrent write cannot leave the memory file truncated
+    // or partially written. Mirrors the atomic-write pattern used by the
+    // filesystem server (src/filesystem/lib.ts).
+    const tmpPath = `${this.memoryFilePath}.${randomBytes(16).toString('hex')}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, lines.join("\n"));
+      await fs.rename(tmpPath, this.memoryFilePath);
+    } catch (error) {
+      try {
+        await fs.unlink(tmpPath);
+      } catch {}
+      throw error;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {


### PR DESCRIPTION
## Summary

`KnowledgeGraphManager.saveGraph` rewrote the whole memory file with a single `fs.writeFile`. An interrupted process, or a concurrent reader observing the file mid-write, could see a truncated or partially written `memory.jsonl` — corrupting the store.

Write to a temporary file in the same directory and atomically `rename` it into place, cleaning up the temp file on error. This mirrors the atomic-write pattern already used by the filesystem server (`src/filesystem/lib.ts`).

Addresses the atomic-write finding (#2) in #4117.

## Change

- `src/memory/index.ts`: `saveGraph` now writes to `${memoryFilePath}.<randomBytes>.tmp` and then `fs.rename`s it over the target, unlinking the temp on failure. Adds `import { randomBytes } from 'crypto'`. File contents are otherwise unchanged (`lines.join("\n")`).

## Tests

`src/memory/__tests__/knowledge-graph.test.ts`:
- asserts the write goes to a temp file in the target's **own directory** and is renamed onto the exact target path (same filesystem → atomic);
- forces the `rename` to fail and asserts the temp file is cleaned up (the error branch);
- the existing round-trip / JSONL tests continue to pass unchanged.

Verified locally: `npm test` → 52/52 passing, `npm run build` (`tsc`) clean.

## Notes

- On the same filesystem, `rename(2)` is atomic, so a reader always sees either the old file or the fully written new one. The temp is created in the target's directory specifically to keep the rename on one filesystem.
- This matches the filesystem server's behavior on Windows: a `rename` can still fail if another process holds the file open without share-delete. In that case the save surfaces a clean error and the existing file is left intact (no corruption). A cross-platform retry-on-lock would be a reasonable follow-up for both servers.