### PR TITLE
Link Python packages to their source directories

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -4,6 +4,8 @@
 
 A Model Context Protocol server that provides web content fetching capabilities. This server enables LLMs to retrieve and process content from web pages, converting HTML to markdown for easier consumption.
 
+Source: https://github.com/modelcontextprotocol/servers/tree/main/src/fetch
+
 > [!CAUTION]
 > This server can access local/internal IP addresses and may represent a security risk. Exercise caution when using this MCP server to ensure this does not expose any sensitive data.
 

--- a/src/fetch/pyproject.toml
+++ b/src/fetch/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "requests>=2.32.3",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-fetch = "mcp_server_fetch:main"
 

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -6,6 +6,8 @@
 
 A Model Context Protocol server for Git repository interaction and automation. This server provides tools to read, search, and manipulate Git repositories via Large Language Models.
 
+Source: https://github.com/modelcontextprotocol/servers/tree/main/src/git
+
 Please note that mcp-server-git is currently in early development. The functionality and available tools are subject to change and expansion as we continue to develop and improve the server.
 
 ### Tools

--- a/src/git/pyproject.toml
+++ b/src/git/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/git"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-git = "mcp_server_git:main"
 

--- a/src/time/README.md
+++ b/src/time/README.md
@@ -4,6 +4,8 @@
 
 A Model Context Protocol server that provides time and timezone conversion capabilities. This server enables LLMs to get current time information and perform timezone conversions using IANA timezone names, with automatic system timezone detection.
 
+Source: https://github.com/modelcontextprotocol/servers/tree/main/src/time
+
 ### Available Tools
 
 - `get_current_time` - Get current time in a specific timezone or system timezone.

--- a/src/time/pyproject.toml
+++ b/src/time/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
     "tzlocal>=5.3.1",
 ]
 
+[project.urls]
+Repository = "https://github.com/modelcontextprotocol/servers/tree/main/src/time"
+Issues = "https://github.com/modelcontextprotocol/servers/issues"
+
 [project.scripts]
 mcp-server-time = "mcp_server_time:main"
 


### PR DESCRIPTION
## Summary
- add PyPI project URLs for the Python MCP server packages
- link each package to its source subdirectory in the repository
- add matching source links near the top of the package READMEs

Fixes #3336

## Verification
- python3 TOML parse/URL assertion for src/git, src/fetch, and src/time pyproject.toml
- git diff --check