### PR TITLE
fix(memory): reject relations with missing entities

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -103,6 +103,36 @@ describe('KnowledgeGraphManager', () => {
       const newRelations = await manager.createRelations([]);
       expect(newRelations).toHaveLength(0);
     });
+
+    it('should reject relations with a missing from entity', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: [] },
+      ]);
+
+      await expect(
+        manager.createRelations([
+          { from: 'Ghost', to: 'Alice', relationType: 'knows' },
+        ])
+      ).rejects.toThrow('Entity with name Ghost not found');
+
+      const graph = await manager.readGraph();
+      expect(graph.relations).toHaveLength(0);
+    });
+
+    it('should reject relations with a missing to entity', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: [] },
+      ]);
+
+      await expect(
+        manager.createRelations([
+          { from: 'Alice', to: 'Ghost', relationType: 'knows' },
+        ])
+      ).rejects.toThrow('Entity with name Ghost not found');
+
+      const graph = await manager.readGraph();
+      expect(graph.relations).toHaveLength(0);
+    });
   });
 
   describe('addObservations', () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -127,6 +127,17 @@ export class KnowledgeGraphManager {
 
   async createRelations(relations: Relation[]): Promise<Relation[]> {
     const graph = await this.loadGraph();
+    const entityNames = new Set(graph.entities.map(e => e.name));
+
+    for (const relation of relations) {
+      if (!entityNames.has(relation.from)) {
+        throw new Error(`Entity with name ${relation.from} not found`);
+      }
+      if (!entityNames.has(relation.to)) {
+        throw new Error(`Entity with name ${relation.to} not found`);
+      }
+    }
+
     const newRelations = relations.filter(r => !graph.relations.some(existingRelation => 
       existingRelation.from === r.from && 
       existingRelation.to === r.to && 


### PR DESCRIPTION
## Summary
- validate that both endpoints exist before creating memory graph relations
- reject missing `from` or `to` entities with the same error style used by `addObservations`
- add regression tests that ensure dangling relations are not persisted

Fixes #4457

## Test Plan
- `cd src/memory && npm test`
- `cd src/memory && npm run build`