### PR TITLE
fix(git): handle JSON-RPC errors gracefully instead of crashing

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -599,4 +599,4 @@ async def serve(repository: Path | None) -> None:
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)


### PR DESCRIPTION
## Problem

`mcp-server-git` passes `raise_exceptions=True` to `server.run()`. A malformed or deeply-nested JSON-RPC message (e.g. `params` nested past pydantic-core's recursion limit) crashes the server process with exit code 1 instead of returning a JSON-RPC error and continuing to serve.

Fixes #4213.

## Root cause

With `raise_exceptions=True`, the low-level SDK server re-raises exceptions from message handling instead of logging them and keeping the stream alive. `git` is the only reference server that sets this flag — `fetch`, `time`, and `sqlite` all use `raise_exceptions=False` (the SDK default).

## Implementation

Flip the single flag in `src/git/src/mcp_server_git/server.py` to `False`. This is the identical fix already merged for `mcp-server-fetch` in #3515.

```diff
-        await server.run(read_stream, write_stream, options, raise_exceptions=True)
+        await server.run(read_stream, write_stream, options, raise_exceptions=False)
```

## Tests

Existing `tests/test_server.py` suite passes (the git helper-function unit tests do not exercise `server.run`, so they are unaffected).

Behavioral reproduction, mirroring #3515's manual test plan — a JSON-RPC request with `params` nested 300 levels deep sent to the server over stdio:

| Version | Exit code | Behavior |
|---|---|---|
| `raise_exceptions=True` (before) | `1` | Process crashes with a pydantic `json_invalid` traceback |
| `raise_exceptions=False` (after) | `0` | Exception is logged (`Received exception from stream: ...`); server keeps serving and shuts down cleanly |

## Edge cases

Any malformed / oversized / deeply-nested payload now yields a graceful, logged error instead of terminating the process. Well-formed requests are unaffected.

## Backward compatibility

Fully backward compatible. No API, tool, or output changes — only the failure mode for invalid input changes (crash → graceful error), which is strictly an improvement and brings `git` in line with the other reference servers.
