### PR TITLE
Clarify filesystem roots access scope

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -28,6 +28,8 @@ Roots notified by Client to Server, completely replace any server-side Allowed d
 
 **Important**: If server starts without command-line arguments AND client doesn't support roots protocol (or provides empty roots), the server will throw an error during initialization.
 
+When configuring this server in an MCP client, omit filesystem path arguments only if you want the client to define the allowed directories through Roots. In that form, the server does not grant access on its own; it waits for the client to provide Roots during initialization and uses those directories as the access scope.
+
 This is the recommended method, as this enables runtime directory updates via `roots/list_changed` notifications without server restart, providing a more flexible and modern integration experience.
 
 ### How It Works


### PR DESCRIPTION
## Summary
- clarify that omitting filesystem path args delegates allowed-directory scope to client-provided Roots
- note that the server waits for Roots during initialization rather than granting access on its own

## Why
This addresses #4423 by making the argless quickstart/config behavior explicit for users configuring the filesystem server in MCP clients.

## Tests
- Not run; documentation-only change
- git diff --check

Fixes #4423