### PR TITLE
ci(release): 4463 / Phase 1 - Switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,9 +2,12 @@ name: Python
 
 on:
   push:
-    branches:
-      - main
   pull_request:
+
+# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-packages:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  release:
-    types: [published]
 
 jobs:
   detect-packages:
@@ -95,27 +93,3 @@ jobs:
         with:
           name: dist-${{ matrix.package }}
           path: src/${{ matrix.package }}/dist/
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [build, detect-packages]
-    if: github.event_name == 'release'
-
-    strategy:
-      matrix:
-        package: ${{ fromJson(needs.detect-packages.outputs.packages) }}
-    name: Publish ${{ matrix.package }}
-
-    environment: release
-    permissions:
-      id-token: write # Required for trusted publishing
-
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: dist-${{ matrix.package }}
-          path: dist/
-
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,10 +4,11 @@ on:
   push:
   pull_request:
 
-# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes)
+# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes),
+# except on main, where every merge keeps its own CI run
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   detect-packages:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,9 @@ jobs:
         package: ${{ fromJson(needs.create-metadata.outputs.npm_packages) }}
     name: Build ${{ matrix.package }}
     environment: release
+    permissions:
+      contents: read
+      id-token: write # Required for npm trusted publishing (OIDC)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -167,6 +170,10 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires npm >= 11.5.1; Node 22 bundles an older npm
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         working-directory: src/${{ matrix.package }}
@@ -186,12 +193,12 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: npm run build
 
+      # Authenticates via OIDC trusted publishing (no token) — each package's
+      # npm trusted publisher is bound to this workflow + the release environment
       - name: Publish package
         working-directory: src/${{ matrix.package }}
         run: |
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: |
           if [ -d "tests" ] || [ -d "test" ]; then
-            uv run pytest
+            uv run --frozen pytest
           else
             echo "No tests directory, skipping"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,15 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: uv run --frozen pyright
 
+      - name: Run tests
+        working-directory: src/${{ matrix.package }}
+        run: |
+          if [ -d "tests" ] || [ -d "test" ]; then
+            uv run pytest
+          else
+            echo "No tests directory, skipping"
+          fi
+
       - name: Build package
         working-directory: src/${{ matrix.package }}
         run: uv build
@@ -188,6 +197,10 @@ jobs:
             exit 1
           fi
           echo "Version $VERSION is new, proceeding with publish"
+
+      - name: Run tests
+        working-directory: src/${{ matrix.package }}
+        run: npm test --if-present
 
       - name: Build package
         working-directory: src/${{ matrix.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-name: Automatic Release Creation
+name: Release
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 10 * * *'
 
 jobs:
   create-metadata:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,9 +171,9 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
-      # Trusted publishing requires npm >= 11.5.1; Node 22 bundles an older npm
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
+      # OIDC trusted publishing requires npm >=11.5.1; Node 22's bundled npm is 10.x.
+      - name: Ensure npm CLI supports OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         working-directory: src/${{ matrix.package }}
@@ -199,6 +199,8 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: |
           npm publish --access public
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
 
   create-release:
     needs: [update-packages, create-metadata, publish-pypi, publish-npm]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: src/${{ matrix.package }}/dist
+          skip-existing: true # re-runs tolerate already-uploaded files
 
   publish-npm:
     needs: [update-packages, create-metadata]

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-  release:
-    types: [published]
 
 jobs:
   detect-packages:
@@ -68,35 +66,3 @@ jobs:
         working-directory: src/${{ matrix.package }}
         run: npm run build
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: [build, detect-packages]
-    if: github.event_name == 'release'
-    environment: release
-
-    strategy:
-      matrix:
-        package: ${{ fromJson(needs.detect-packages.outputs.packages) }}
-    name: Publish ${{ matrix.package }}
-
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        working-directory: src/${{ matrix.package }}
-        run: npm ci
-
-      - name: Publish package
-        working-directory: src/${{ matrix.package }}
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -2,9 +2,12 @@ name: TypeScript
 
 on:
   push:
-    branches:
-      - main
   pull_request:
+
+# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   detect-packages:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -4,10 +4,11 @@ on:
   push:
   pull_request:
 
-# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes)
+# Superseded runs on the same ref are cancelled (e.g. rapid amend-pushes),
+# except on main, where every merge keeps its own CI run
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   detect-packages:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ See [ADDITIONAL.md](ADDITIONAL.md) for a curated list of frameworks and resource
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributing to this repository.
 
+## 📦 Releasing
+
+See [RELEASING.md](RELEASING.md) for how packages are published (OIDC trusted publishing from CI — no registry tokens) and how to retry a failed publish.
+
 ## 🔒 Security
 
 See [SECURITY.md](SECURITY.md) for reporting security vulnerabilities.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing
+
+How the packages in this repository are published, and what to do when a publish fails.
+
+## How publishing works
+
+All packages publish exclusively from the [`release.yml`](.github/workflows/release.yml) GitHub Actions workflow, gated by the `release` environment (a required reviewer must approve each deployment).
+
+**Authentication is OIDC trusted publishing on both registries — there are no registry tokens.**
+
+- **npm** (TypeScript servers): each `@modelcontextprotocol/*` package is registered on npmjs.com with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) bound to this repository, workflow filename `release.yml`, and environment `release`. npm rejects publishes from any other workflow or environment — the binding is case-sensitive. Packages are published with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements) (`NPM_CONFIG_PROVENANCE`).
+- **PyPI** (Python servers): published via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) using `pypa/gh-action-pypi-publish`.
+
+A release run:
+
+1. **Detects changed packages** since the last release tag (a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed — READMEs ship inside the published artifacts).
+2. **Stamps versions and tags** — versions are date-based (CalVer, e.g. `2026.7.4`).
+3. **Publishes each package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another): checkout at the release tag → install → *skip if this version already exists on the registry* → **run the package's tests** → build → publish.
+4. **Creates the GitHub release** with generated notes.
+
+Runs are triggered by a daily schedule or manually via **workflow_dispatch** on `release.yml`.
+
+## When a publish fails
+
+A failed matrix leg means that one package didn't publish; everything else that succeeded stays published (the version-exists guard makes retries idempotent).
+
+**Preferred: re-run the failed jobs on the same run.**
+
+```bash
+gh run rerun <run-id> --failed --repo modelcontextprotocol/servers
+```
+
+- A re-run is still a `release.yml` run in the `release` environment, so it satisfies the trusted-publisher binding.
+- It re-runs only the failed legs, checked out at the original release tag — it publishes exactly the tagged code.
+- It needs a fresh `release` environment approval, and the run must be complete first (approve or reject any pending deployments).
+- GitHub's re-run window is ~30 days from the original run, and re-runs execute the *original* workflow snapshot — workflow fixes on main don't apply to a re-run (secrets and registry-side registrations are read fresh).
+
+**Otherwise: let the next release pick it up.** If the re-run window has closed (or the fix required a workflow change), the failed version simply never exists on that registry — that's benign; npm and PyPI version histories don't need to match. The package publishes at the next version, provided it has a qualifying change since the last tag.
+
+**Never:**
+
+- Publish manually with an npm token or from a laptop — there are no registry tokens, and manual publishes would break the provenance/trust chain.
+- Re-dispatch `release.yml` expecting it to retry a failed version — a fresh run mints a *new* version.
+
+## Environment approvals
+
+The `release` environment's required-reviewer list is configured in the repository settings (Settings → Environments → `release`). Reviewer rights come only from that list — repository admin does not confer deployment approval.
+
+---
+
+The release process is evolving — see [#4463](https://github.com/modelcontextprotocol/servers/issues/4463) for planned changes (manual GitHub-release triggering, semver via changesets for the TypeScript packages). This document describes the process as it works today and will be updated when that lands.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@ All packages publish exclusively from the [`release.yml`](.github/workflows/rele
 A release run:
 
 1. **Detects changed packages** since the last release tag (a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed — READMEs ship inside the published artifacts).
-2. **Stamps versions and tags** — versions are date-based (CalVer, e.g. `2026.7.4`).
+2. **Stamps versions and tags** — versions are currently date-based (CalVer, e.g. `2026.7.4`) for all packages. (Planned: the TypeScript packages move to semver managed by changesets, while Python stays CalVer — see [#4463](https://github.com/modelcontextprotocol/servers/issues/4463).)
 3. **Publishes each package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another): checkout at the release tag → install → *skip if this version already exists on the registry* → **run the package's tests** → build → publish.
 4. **Creates the GitHub release** with generated notes.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ A release run:
 
 1. **Detects changed packages** since the last release tag — a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed (READMEs ship inside the published artifacts).
 2. **Stamps versions and pushes the release tag** — versions are date-based (CalVer, e.g. `2026.7.4`).
-3. **Publishes each changed package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another). Each job: checkout at the release tag → install → abort if this version already exists on the registry (double-publish guard) → **run the package's tests** → build → publish.
+3. **Publishes each changed package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another). Each job: checkout at the release tag → install → double-publish guard → **run the package's tests** (plus `pyright` for Python) → build → publish. The guard differs by registry: the npm job aborts if the version already exists; the PyPI action skips files already uploaded (`skip-existing`).
 4. **Creates the GitHub release** with generated notes.
 
 ## When a publish fails
@@ -38,7 +38,7 @@ gh run rerun <run-id> --failed --repo modelcontextprotocol/servers
 **Never:**
 
 - Publish manually with an npm token or from a laptop — there are no registry tokens, and manual publishes would break the provenance/trust chain.
-- Re-run or re-dispatch `release.yml` expecting a fresh run to retry a failed version — a fresh run mints a *new* version.
+- Dispatch a fresh `release.yml` run expecting it to retry a failed version — versions are date-granular, so a same-day dispatch collides with the existing tag, and a later dispatch mints a *new* version. Neither retries the failed one.
 
 ## Environment approvals
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ A release run:
 
 1. **Detects changed packages** since the last release tag — a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed (READMEs ship inside the published artifacts).
 2. **Stamps versions and pushes the release tag** — versions are date-based (CalVer, e.g. `2026.7.4`).
-3. **Publishes each changed package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another). Each job: checkout at the release tag → install → double-publish guard → **run the package's tests** (plus `pyright` for Python) → build → publish. The guard differs by registry: the npm job aborts if the version already exists; the PyPI action skips files already uploaded (`skip-existing`).
+3. **Publishes each changed package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another). Each job: checkout at the release tag → install → double-publish guard → **run the package's tests** (plus `pyright` for Python) → build → publish. The guard differs by registry: the npm job aborts before tests if the version already exists; for PyPI the skip happens at the publish step itself (`skip-existing` on the upload action).
 4. **Creates the GitHub release** with generated notes.
 
 ## When a publish fails

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,28 +1,34 @@
 # Releasing
 
-How the packages in this repository are published, and what to do when a publish fails.
+How the packages in this repository are versioned and published, and what to do when a publish fails.
+
+> Implementation of this process is tracked in [#4463](https://github.com/modelcontextprotocol/servers/issues/4463).
+
+## Versioning
+
+- **TypeScript packages** use **semver**, managed by [changesets](https://github.com/changesets/changesets). A PR that changes a TypeScript package includes a changeset file declaring the bump (patch/minor/major) and a changelog line — the changeset bot flags PRs that are missing one. A rolling **"Version Packages" PR** accumulates pending changesets; merging it applies the version bumps and updates each package's `CHANGELOG.md`.
+  - patch = fixes · minor = new tools/prompts/resources/options · major = breaking changes (tool removed or renamed, schema changes that break clients, protocol or Node floor bump)
+- **Python packages** use **CalVer** (`YYYY.M.D`). A prepare-release step stamps the date onto Python packages that changed since their last published version and opens a normal PR.
+- **Versions live on `main` and are only changed by pull requests.** No workflow computes a version or pushes a tag.
 
 ## How publishing works
 
-All packages publish exclusively from the [`release.yml`](.github/workflows/release.yml) GitHub Actions workflow, gated by the `release` environment (a required reviewer must approve each deployment).
+Publishing is triggered by **creating a GitHub Release** on the [releases page](https://github.com/modelcontextprotocol/servers/releases) (with auto-generated notes). That fires the [`release.yml`](.github/workflows/release.yml) workflow, which is the **only** publish path:
+
+1. Every package is a matrix job, run independently (`fail-fast: false` — one package's failure never blocks another).
+2. Each job: checkout at the release tag → install → **skip if the package's version already exists on its registry** → run the package's tests → build → publish.
+3. Publish jobs are gated by the `release` environment — a required reviewer must approve the deployment.
+
+Because of the version-exists guard, a release publishes exactly the packages whose versions were bumped since the last release, and re-running is always safe.
 
 **Authentication is OIDC trusted publishing on both registries — there are no registry tokens.**
 
-- **npm** (TypeScript servers): each `@modelcontextprotocol/*` package is registered on npmjs.com with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) bound to this repository, workflow filename `release.yml`, and environment `release`. npm rejects publishes from any other workflow or environment — the binding is case-sensitive. Packages are published with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements) (`NPM_CONFIG_PROVENANCE`).
-- **PyPI** (Python servers): published via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) using `pypa/gh-action-pypi-publish`.
-
-A release run:
-
-1. **Detects changed packages** since the last release tag (a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed — READMEs ship inside the published artifacts).
-2. **Stamps versions and tags** — versions are currently date-based (CalVer, e.g. `2026.7.4`) for all packages. (Planned: the TypeScript packages move to semver managed by changesets, while Python stays CalVer — see [#4463](https://github.com/modelcontextprotocol/servers/issues/4463).)
-3. **Publishes each package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another): checkout at the release tag → install → *skip if this version already exists on the registry* → **run the package's tests** → build → publish.
-4. **Creates the GitHub release** with generated notes.
-
-Runs are triggered by a daily schedule or manually via **workflow_dispatch** on `release.yml`.
+- **npm**: each `@modelcontextprotocol/*` package is registered on npmjs.com with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) bound to this repository, workflow filename `release.yml`, and environment `release` (the binding is case-sensitive). Packages publish with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements).
+- **PyPI**: published via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) using `pypa/gh-action-pypi-publish`.
 
 ## When a publish fails
 
-A failed matrix leg means that one package didn't publish; everything else that succeeded stays published (the version-exists guard makes retries idempotent).
+A failed matrix leg means that one package didn't publish; everything that succeeded stays published.
 
 **Preferred: re-run the failed jobs on the same run.**
 
@@ -31,21 +37,17 @@ gh run rerun <run-id> --failed --repo modelcontextprotocol/servers
 ```
 
 - A re-run is still a `release.yml` run in the `release` environment, so it satisfies the trusted-publisher binding.
-- It re-runs only the failed legs, checked out at the original release tag — it publishes exactly the tagged code.
+- It re-runs only the failed legs, checked out at the release tag — it publishes exactly the tagged code, and the version-exists guard makes it idempotent.
 - It needs a fresh `release` environment approval, and the run must be complete first (approve or reject any pending deployments).
-- GitHub's re-run window is ~30 days from the original run, and re-runs execute the *original* workflow snapshot — workflow fixes on main don't apply to a re-run (secrets and registry-side registrations are read fresh).
+- GitHub's re-run window is ~30 days from the original run, and re-runs execute the *original* workflow snapshot — workflow fixes on `main` don't apply to a re-run.
 
-**Otherwise: let the next release pick it up.** If the re-run window has closed (or the fix required a workflow change), the failed version simply never exists on that registry — that's benign; npm and PyPI version histories don't need to match. The package publishes at the next version, provided it has a qualifying change since the last tag.
+**Otherwise: the next release picks it up.** The unpublished version is still on `main`, so the version-exists guard publishes it on the next release automatically. A version skipped this way simply never exists on that registry — that's benign; npm and PyPI version histories don't need to match.
 
 **Never:**
 
 - Publish manually with an npm token or from a laptop — there are no registry tokens, and manual publishes would break the provenance/trust chain.
-- Re-dispatch `release.yml` expecting it to retry a failed version — a fresh run mints a *new* version.
+- Edit versions outside a reviewed PR to force a publish.
 
 ## Environment approvals
 
 The `release` environment's required-reviewer list is configured in the repository settings (Settings → Environments → `release`). Reviewer rights come only from that list — repository admin does not confer deployment approval.
-
----
-
-The release process is evolving — see [#4463](https://github.com/modelcontextprotocol/servers/issues/4463) for planned changes (manual GitHub-release triggering, semver via changesets for the TypeScript packages). This document describes the process as it works today and will be updated when that lands.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ How the packages in this repository are published, and what to do when a publish
 
 ## How publishing works
 
-All packages publish exclusively from the [`release.yml`](.github/workflows/release.yml) GitHub Actions workflow, gated by the `release` environment (a required reviewer must approve each deployment). Runs are triggered on a daily schedule or manually via **workflow_dispatch**.
+All packages publish exclusively from the [`release.yml`](.github/workflows/release.yml) GitHub Actions workflow, gated by the `release` environment (a required reviewer must approve each deployment). Releases are triggered deliberately by a maintainer via **workflow_dispatch** (Actions → Release → Run workflow, or `gh workflow run release.yml`) — there is no scheduled/automatic release.
 
 **Authentication is OIDC trusted publishing on both registries — there are no registry tokens.**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,30 +1,22 @@
 # Releasing
 
-How the packages in this repository are versioned and published, and what to do when a publish fails.
-
-> Implementation of this process is tracked in [#4463](https://github.com/modelcontextprotocol/servers/issues/4463).
-
-## Versioning
-
-- **TypeScript packages** use **semver**, managed by [changesets](https://github.com/changesets/changesets). A PR that changes a TypeScript package includes a changeset file declaring the bump (patch/minor/major) and a changelog line — the changeset bot flags PRs that are missing one. A rolling **"Version Packages" PR** accumulates pending changesets; merging it applies the version bumps and updates each package's `CHANGELOG.md`.
-  - patch = fixes · minor = new tools/prompts/resources/options · major = breaking changes (tool removed or renamed, schema changes that break clients, protocol or Node floor bump)
-- **Python packages** use **CalVer** (`YYYY.M.D`). A prepare-release step stamps the date onto Python packages that changed since their last published version and opens a normal PR.
-- **Versions live on `main` and are only changed by pull requests.** No workflow computes a version or pushes a tag.
+How the packages in this repository are published, and what to do when a publish fails.
 
 ## How publishing works
 
-Publishing is triggered by **creating a GitHub Release** on the [releases page](https://github.com/modelcontextprotocol/servers/releases) (with auto-generated notes). That fires the [`release.yml`](.github/workflows/release.yml) workflow, which is the **only** publish path:
-
-1. Every package is a matrix job, run independently (`fail-fast: false` — one package's failure never blocks another).
-2. Each job: checkout at the release tag → install → **skip if the package's version already exists on its registry** → run the package's tests → build → publish.
-3. Publish jobs are gated by the `release` environment — a required reviewer must approve the deployment.
-
-Because of the version-exists guard, a release publishes exactly the packages whose versions were bumped since the last release, and re-running is always safe.
+All packages publish exclusively from the [`release.yml`](.github/workflows/release.yml) GitHub Actions workflow, gated by the `release` environment (a required reviewer must approve each deployment). Runs are triggered on a daily schedule or manually via **workflow_dispatch**.
 
 **Authentication is OIDC trusted publishing on both registries — there are no registry tokens.**
 
-- **npm**: each `@modelcontextprotocol/*` package is registered on npmjs.com with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) bound to this repository, workflow filename `release.yml`, and environment `release` (the binding is case-sensitive). Packages publish with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements).
-- **PyPI**: published via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) using `pypa/gh-action-pypi-publish`.
+- **npm** (TypeScript servers): each `@modelcontextprotocol/*` package is registered on npmjs.com with a [trusted publisher](https://docs.npmjs.com/trusted-publishers) bound to this repository, workflow filename `release.yml`, and environment `release` (the binding is case-sensitive). Packages publish with [provenance attestations](https://docs.npmjs.com/generating-provenance-statements).
+- **PyPI** (Python servers): published via [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) using `pypa/gh-action-pypi-publish`.
+
+A release run:
+
+1. **Detects changed packages** since the last release tag — a package counts as changed if any `.py`, `.ts`, or `.md` file in its directory changed (READMEs ship inside the published artifacts).
+2. **Stamps versions and pushes the release tag** — versions are date-based (CalVer, e.g. `2026.7.4`).
+3. **Publishes each changed package as an independent matrix job** (`fail-fast: false` — one package's failure never blocks another). Each job: checkout at the release tag → install → abort if this version already exists on the registry (double-publish guard) → **run the package's tests** → build → publish.
+4. **Creates the GitHub release** with generated notes.
 
 ## When a publish fails
 
@@ -37,17 +29,21 @@ gh run rerun <run-id> --failed --repo modelcontextprotocol/servers
 ```
 
 - A re-run is still a `release.yml` run in the `release` environment, so it satisfies the trusted-publisher binding.
-- It re-runs only the failed legs, checked out at the release tag — it publishes exactly the tagged code, and the version-exists guard makes it idempotent.
+- It re-runs only the failed legs, checked out at the original release tag — it publishes exactly the tagged code, and the double-publish guard keeps already-published packages safe.
 - It needs a fresh `release` environment approval, and the run must be complete first (approve or reject any pending deployments).
 - GitHub's re-run window is ~30 days from the original run, and re-runs execute the *original* workflow snapshot — workflow fixes on `main` don't apply to a re-run.
 
-**Otherwise: the next release picks it up.** The unpublished version is still on `main`, so the version-exists guard publishes it on the next release automatically. A version skipped this way simply never exists on that registry — that's benign; npm and PyPI version histories don't need to match.
+**Otherwise: let the next release pick it up.** If the re-run window has closed (or the fix required a workflow change), the failed version simply never exists on that registry — that's benign; npm and PyPI version histories don't need to match. The package publishes at the next version, provided it has a qualifying change (`.py`, `.ts`, or `.md`) since the last release tag.
 
 **Never:**
 
 - Publish manually with an npm token or from a laptop — there are no registry tokens, and manual publishes would break the provenance/trust chain.
-- Edit versions outside a reviewed PR to force a publish.
+- Re-run or re-dispatch `release.yml` expecting a fresh run to retry a failed version — a fresh run mints a *new* version.
 
 ## Environment approvals
 
 The `release` environment's required-reviewer list is configured in the repository settings (Settings → Environments → `release`). Reviewer rights come only from that list — repository admin does not confer deployment approval.
+
+---
+
+Planned changes to this process — semver via changesets for the TypeScript packages, publishing triggered by manually-created GitHub Releases — are tracked in [#4463](https://github.com/modelcontextprotocol/servers/issues/4463). This document will be updated when that work merges.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -113,7 +113,9 @@ def has_changes(path: Path, git_hash: GitHash) -> bool:
         )
 
         changed_files = [Path(f) for f in output.stdout.splitlines()]
-        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts"]]
+        # .md counts as a change: READMEs ship inside the published package
+        # (npm tarball / PyPI long_description)
+        relevant_files = [f for f in changed_files if f.suffix in [".py", ".ts", ".md"]]
         return len(relevant_files) >= 1
     except subprocess.CalledProcessError:
         return False

--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -134,3 +134,7 @@ npx @modelcontextprotocol/server-everything sse
 ```shell
 npx @modelcontextprotocol/server-everything streamableHttp
 ```
+
+## License
+
+This MCP server is licensed under the MIT License. This means you are free to use, modify, and distribute the software, subject to the terms and conditions of the MIT License. For more details, please see the LICENSE file in the project repository.

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -2,6 +2,8 @@
 
 Node.js server implementing Model Context Protocol (MCP) for filesystem operations.
 
+Published on npm as [`@modelcontextprotocol/server-filesystem`](https://www.npmjs.com/package/@modelcontextprotocol/server-filesystem).
+
 ## Features
 
 - Read/write files

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -2,6 +2,8 @@
 
 A basic implementation of persistent memory using a local knowledge graph. This lets Claude remember information about the user across chats.
 
+Published on npm as [`@modelcontextprotocol/server-memory`](https://www.npmjs.com/package/@modelcontextprotocol/server-memory).
+
 ## Core Concepts
 
 ### Entities

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -2,6 +2,8 @@
 
 An MCP server implementation that provides a tool for dynamic and reflective problem-solving through a structured thinking process.
 
+Published on npm as [`@modelcontextprotocol/server-sequential-thinking`](https://www.npmjs.com/package/@modelcontextprotocol/server-sequential-thinking).
+
 ## Features
 
 - Break down complex problems into manageable steps


### PR DESCRIPTION
## Summary

Phase 1 of #4463: make `release.yml`'s npm publishing work via [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) instead of the dead `NPM_TOKEN`, and nudge all four TypeScript packages into the next release matrix.

Both June release attempts ([26882432128](https://github.com/modelcontextprotocol/servers/actions/runs/26882432128), [27626321345](https://github.com/modelcontextprotocol/servers/actions/runs/27626321345)) published to PyPI but failed every npm leg with a disguised auth error (`E404` on the publish PUT) — the token is expired and non-refreshable. Each `@modelcontextprotocol/*` package's npm trusted publisher is being registered against **this workflow (`release.yml`) + the `release` environment**, so the workflow must authenticate via OIDC.

## Changes

**`.github/workflows/release.yml` (`publish-npm` job)** — mirrors modelcontextprotocol/inspector#1199:
- Add `permissions: id-token: write` (required to mint the OIDC token; `contents: read` added explicitly since setting `permissions` drops defaults)
- Install `npm@^11.5.1` — trusted publishing requires npm ≥ 11.5.1, Node 22 bundles npm 10.x
- Remove `NODE_AUTH_TOKEN` from the publish step
- Set `NPM_CONFIG_PROVENANCE: "true"` so packages get provenance attestations
- Run `npm test --if-present` before build/publish — previously nothing between tagging and publishing ran a test

**`publish-pypi` job:** run `pytest` before build/publish (guarded by the same tests-directory check `python.yml` uses; pyright already ran)

**`scripts/release.py`:** count `.md` changes when building the release matrix — READMEs ship inside the published artifacts, and `.py`/`.ts`-only detection would have ignored this PR's README touches entirely (review finding)

**`publish-pypi` job (cont.):** `skip-existing: true` on the PyPI publish action so re-runs tolerate already-uploaded files (review finding)

**`typescript.yml` / `python.yml`:** removed the `release: [published]` triggers and `publish` jobs — they never fired (releases are created with `GITHUB_TOKEN`, which suppresses workflow triggers), could never succeed under OIDC (wrong workflow in the claims), and `typescript.yml`'s still referenced the deleted `NPM_TOKEN`. Both workflows are now pure CI (review finding). This makes `release.yml` the *only* workflow that publishes, matching the trusted-publisher binding and `RELEASING.md`'s description. CI now also runs on pushes to **any** branch (not just `main`) so same-repo branches get CI before a PR exists; a per-ref `concurrency` group cancels superseded runs on rapid amend-pushes (fork PRs were and remain covered by `pull_request`).

**Daily cron removed** — `release.yml` is now `workflow_dispatch`-only (renamed "Release"): the schedule produced a year of unattended runs stuck awaiting approval, real releases were always dispatched manually, and same-day runs collide on the date-based tag. Phase 2 (#4463) replaces the trigger with `release: [published]`.

**Docs:** new root `RELEASING.md` (publishing mechanics as of this PR + failed-publish retry runbook), linked from README alongside the other maintainer docs

## CI trigger behavior after this PR

`typescript.yml` and `python.yml` are pure CI (`detect-packages` → `test` → `build`, all packages each run) and fire as follows:

| Scenario | CI runs? | Via |
|---|---|---|
| Fork contributor opens a PR | ✅ | `pull_request` |
| Fork contributor pushes more commits to the PR branch | ✅ | `pull_request` (`synchronize`) |
| Same-repo branch pushed, no PR yet | ✅ *(new — was main-only)* | `push` |
| Same-repo branch amended | ✅ — superseded run on the ref is auto-cancelled | `push` + per-ref `concurrency` |
| Same-repo branch with an open PR | ✅ runs under both events (accepted trade-off at this repo's scale) | `push` + `pull_request` |
| Push/merge to `main` | ✅ | `push` |

Fork pushes never fire this repo's `push` trigger (they happen in the fork), which is why `pull_request` remains essential for contributor coverage.

⚠️ **The same environment-case bug inspector hit applies here**: the actual GitHub environment is named `Release` (capital R), while this yaml and the npm trusted-publisher config say `release`. npm compares the OIDC environment claim **case-sensitively**, so the environment must be deleted and recreated as lowercase `release` before the first OIDC publish (exact commands in #4463, Phase 0). Bonus: deleting it automatically fails the 31 stale waiting release runs, clearing that backlog in one stroke. Requires repo admin.

**README touch in each TypeScript server** so `scripts/release.py` includes all four in the next npm matrix (they're stranded on npm at `2026.1.26` while PyPI advanced to `2026.6.16`):
- `everything`: add the License section the other three servers already have
- `filesystem` / `memory` / `sequential-thinking`: link the package's npm page under the intro

## Merging is publish-safe

Merging this PR publishes nothing. Publishing only happens when a `release`-environment deployment is approved on a `release.yml` run (cron runs queue daily but sit awaiting approval). The actual release will be dispatched deliberately once the npm trusted-publisher registrations are complete for all four packages.

If a package's trusted publisher isn't registered by then, its matrix leg fails alone (`fail-fast: false`) and catches up in a later release.

## Prerequisites before dispatching the release (not part of this PR)

- [x] **Rename GitHub environment `Release` → `release`** — done 2026-07-04 (delete + recreate; also auto-failed all 31 stale waiting runs and deleted the dead env-level `NPM_TOKEN` secret)
- [x] npm trusted publisher registered for all four packages: `server-everything`, `server-memory`, `server-filesystem`, `server-sequential-thinking` (workflow `release.yml`, environment `release`) — done 2026-07-04
- [x] No `NPM_TOKEN` secrets remain anywhere; going full OIDC — no tokens will be issued again

Part of #4463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)