### PR TITLE
fix(git): normalize git_log schema across filtered and unfiltered branches

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -157,45 +157,27 @@ def git_reset(repo: git.Repo) -> str:
     return "All staged changes reset"
 
 def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] = None, end_timestamp: Optional[str] = None) -> list[str]:
-    if start_timestamp or end_timestamp:
-        # Defense in depth: reject timestamps starting with '-' to prevent flag injection
-        if start_timestamp and start_timestamp.startswith("-"):
-            raise ValueError(f"Invalid start_timestamp: '{start_timestamp}' - cannot start with '-'")
-        if end_timestamp and end_timestamp.startswith("-"):
-            raise ValueError(f"Invalid end_timestamp: '{end_timestamp}' - cannot start with '-'")
-        # Use git log command with date filtering
-        args = []
-        if start_timestamp:
-            args.extend(['--since', start_timestamp])
-        if end_timestamp:
-            args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+    # Defense in depth: reject timestamps starting with '-' to prevent flag injection
+    if start_timestamp and start_timestamp.startswith("-"):
+        raise ValueError(f"Invalid start_timestamp: '{start_timestamp}' - cannot start with '-'")
+    if end_timestamp and end_timestamp.startswith("-"):
+        raise ValueError(f"Invalid end_timestamp: '{end_timestamp}' - cannot start with '-'")
 
-        log_output = repo.git.log(*args).split('\n')
+    rev_kwargs: dict[str, str] = {}
+    if start_timestamp:
+        rev_kwargs["since"] = start_timestamp
+    if end_timestamp:
+        rev_kwargs["until"] = end_timestamp
 
-        log = []
-        # Process commits in groups of 4 (hash, author, date, message)
-        for i in range(0, len(log_output), 4):
-            if i + 3 < len(log_output) and len(log) < max_count:
-                log.append(
-                    f"Commit: {log_output[i]}\n"
-                    f"Author: {log_output[i+1]}\n"
-                    f"Date: {log_output[i+2]}\n"
-                    f"Message: {log_output[i+3]}\n"
-                )
-        return log
-    else:
-        # Use existing logic for simple log without date filtering
-        commits = list(repo.iter_commits(max_count=max_count))
-        log = []
-        for commit in commits:
-            log.append(
-                f"Commit: {commit.hexsha!r}\n"
-                f"Author: {commit.author!r}\n"
-                f"Date: {commit.authored_datetime}\n"
-                f"Message: {commit.message!r}\n"
-            )
-        return log
+    log = []
+    for commit in repo.iter_commits(max_count=max_count, **rev_kwargs):
+        log.append(
+            f"Commit: {commit.hexsha}\n"
+            f"Author: {commit.author}\n"
+            f"Date: {commit.authored_datetime}\n"
+            f"Message: {commit.message}\n"
+        )
+    return log
 
 def git_create_branch(repo: git.Repo, branch_name: str, base_branch: str | None = None) -> str:
     # Defense in depth: reject names starting with '-' to prevent flag injection

--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Sequence, Optional
+from typing import Any, Sequence, Optional
 from mcp.server import Server
 from mcp.server.session import ServerSession
 from mcp.server.stdio import stdio_server
@@ -163,7 +163,7 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
     if end_timestamp and end_timestamp.startswith("-"):
         raise ValueError(f"Invalid end_timestamp: '{end_timestamp}' - cannot start with '-'")
 
-    rev_kwargs: dict[str, str] = {}
+    rev_kwargs: dict[str, Any] = {}
     if start_timestamp:
         rev_kwargs["since"] = start_timestamp
     if end_timestamp:

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -234,6 +234,28 @@ def test_git_log_default(test_repository):
     assert len(result) >= 1
     assert "initial commit" in result[0]
 
+
+def test_git_log_schema_matches_across_filter_branches(test_repository):
+    """git_log emits the same string schema whether or not timestamp filters are supplied."""
+    for i in range(2):
+        file_path = Path(test_repository.working_dir) / f"schema_test_{i}.txt"
+        file_path.write_text(f"content {i}")
+        test_repository.index.add([f"schema_test_{i}.txt"])
+        test_repository.index.commit(f"schema commit {i}")
+
+    unfiltered = git_log(test_repository, max_count=1)
+    filtered = git_log(test_repository, max_count=1, start_timestamp="1970-01-01")
+
+    assert len(unfiltered) == 1
+    assert len(filtered) == 1
+    # Same keys, same order — parsers that split on "\n" and ":" must not care which branch produced the entry.
+    assert [line.split(":", 1)[0] for line in unfiltered[0].splitlines()] == \
+           [line.split(":", 1)[0] for line in filtered[0].splitlines()]
+    # And no repr() artefacts (leading quotes, angle brackets) that used to appear only in the unfiltered branch.
+    for entry in (unfiltered[0], filtered[0]):
+        commit_line = entry.splitlines()[0]
+        assert not commit_line.startswith("Commit: '"), f"Commit hash should not be repr-quoted: {commit_line!r}"
+
 def test_git_create_branch(test_repository):
     result = git_create_branch(test_repository, "new-feature-branch")
 


### PR DESCRIPTION
## Summary

Closes #4469.

\`git_log\` returned two different string shapes depending on whether \`start_timestamp\`/\`end_timestamp\` was passed:

**Before (unfiltered branch — `server.py:187-197`)**

Used \`commit.hexsha!r\` / \`commit.author!r\`, which produced repr-quoted values:

\`\`\`
Commit: 'a1b2c3d4e5f6...'
Author: <git.Actor \"Name <email>\">
Date: 2026-07-01 12:00:00+00:00
Message: 'subject\n\nbody\n'
\`\`\`

**Before (filtered branch — `server.py:180-185`)**

Used `git log --format=%H%n%an%n%ad%n%s%n` and split, producing raw values but losing the commit body (\`%s\` is subject-only):

\`\`\`
Commit: a1b2c3d4e5f6...
Author: Name
Date: Wed Jul 1 12:00:00 2026 +0000
Message: subject
\`\`\`

Downstream parsers that split on \`\n\` and \`:\` had to special-case which branch produced the entry.

## Fix

Collapse both branches onto a single \`repo.iter_commits(max_count=..., since=..., until=...)\` call, so there is exactly one code path — schema drift is impossible by construction. Also drop the \`!r\` formatting so both filtered and unfiltered entries emit raw values (bare commit hash, plain author \`Name <email>\`, full \`commit.message\` including body).

The flag-injection defense (\`start_timestamp.startswith(\"-\")\`) is preserved and now applies uniformly whether or not the fast path is taken.

## Tests

Added \`test_git_log_schema_matches_across_filter_branches\` that asserts:

- Same key order (\`Commit\`, \`Author\`, \`Date\`, \`Message\`) across both filtered and unfiltered calls
- Neither branch emits repr-quoted commit hashes (guards against the leading-\`'\` regression)

All existing \`git_log\` tests pass; the unrelated \`test_validate_repo_path_symlink_escape\` failure on Windows is pre-existing on upstream (verified via stash).

## Compatibility note

The `Date:` line for the unfiltered branch now uses `commit.authored_datetime` (already the case before), and the filtered branch's format string is gone. If any external consumer was pattern-matching on the raw git-format date (\`Wed Jul 1 12:00:00 2026 +0000\`), they now get the ISO-style datetime for both branches, which is the consistent shape #4469 asks for.