### PR TITLE
fix(memory): reject dangling relations

### DIFF
--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -72,6 +72,7 @@ Example:
       - `to` (string): Target entity name
       - `relationType` (string): Relationship type in active voice
   - Skips duplicate relations
+  - Fails if either the source or target entity doesn't exist
 
 - **add_observations**
   - Add new observations to existing entities

--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -99,6 +99,38 @@ describe('KnowledgeGraphManager', () => {
       expect(graph.relations).toHaveLength(1);
     });
 
+    it('should reject relations from non-existent entities', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: [] },
+      ]);
+
+      await expect(
+        manager.createRelations([
+          { from: 'Ghost', to: 'Alice', relationType: 'knows' },
+        ])
+      ).rejects.toThrow('Entity with name Ghost not found');
+
+      const graph = await manager.readGraph();
+      expect(graph.relations).toHaveLength(0);
+    });
+
+    it('should reject relation batches that reference non-existent target entities', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: [] },
+        { name: 'Bob', entityType: 'person', observations: [] },
+      ]);
+
+      await expect(
+        manager.createRelations([
+          { from: 'Alice', to: 'Bob', relationType: 'knows' },
+          { from: 'Alice', to: 'Ghost', relationType: 'knows' },
+        ])
+      ).rejects.toThrow('Entity with name Ghost not found');
+
+      const graph = await manager.readGraph();
+      expect(graph.relations).toHaveLength(0);
+    });
+
     it('should handle empty relation arrays', async () => {
       const newRelations = await manager.createRelations([]);
       expect(newRelations).toHaveLength(0);

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -127,6 +127,17 @@ export class KnowledgeGraphManager {
 
   async createRelations(relations: Relation[]): Promise<Relation[]> {
     const graph = await this.loadGraph();
+    const entityNames = new Set(graph.entities.map(e => e.name));
+
+    relations.forEach(r => {
+      if (!entityNames.has(r.from)) {
+        throw new Error(`Entity with name ${r.from} not found`);
+      }
+      if (!entityNames.has(r.to)) {
+        throw new Error(`Entity with name ${r.to} not found`);
+      }
+    });
+
     const newRelations = relations.filter(r => !graph.relations.some(existingRelation => 
       existingRelation.from === r.from && 
       existingRelation.to === r.to && 


### PR DESCRIPTION
## Summary

Fixes #4457.

The memory server now rejects `create_relations` requests when either endpoint does not name an existing entity. This prevents the knowledge graph from persisting dangling relations that point at nodes that were never created.

## Changes

`createRelations` previously filtered only duplicate relations before appending new entries to the graph. That allowed a fresh graph to store relations such as `Ghost_A -> Ghost_B` while `entities` remained empty.

This change validates every incoming relation endpoint against the current entity set before saving. If a batch contains an invalid endpoint, the call fails before writing any of the batch, matching the fail-fast behavior already used by `add_observations` for unknown entities.

The memory README now documents that `create_relations` fails when the source or target entity does not exist.

## Risk / Scope

The change is limited to the memory reference server. Existing valid relations and duplicate-relation skipping behavior are unchanged.

The only behavior change is that `create_relations` now fails instead of silently storing a relation whose `from` or `to` endpoint is missing.

## Verification

```sh
npm test --workspace @modelcontextprotocol/server-memory -- __tests__/knowledge-graph.test.ts
npm test --workspace @modelcontextprotocol/server-memory
npm run build --workspace @modelcontextprotocol/server-memory
npm run build --workspaces
npm test --workspaces
```
