### PR TITLE
fix(filesystem): return valid MCP content type from read_media_file (#4029)

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -78,10 +78,12 @@ The server's directory access control follows this flow:
   - Cannot specify both `head` and `tail` simultaneously
 
 - **read_media_file**
-  - Read an image or audio file
+  - Read a file and return it as a base64-encoded content block with its MIME type
   - Inputs:
     - `path` (string)
-  - Streams the file and returns base64 data with the corresponding MIME type
+  - Streams the file and returns base64 data with the corresponding MIME type. Image and
+    audio files are returned as `image`/`audio` content; any other file type is returned as
+    an embedded `resource` (a valid MCP content block for arbitrary binary data)
 
 - **read_multiple_files**
   - Read multiple files simultaneously

--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -184,6 +184,10 @@ describe('structuredContent schema compliance', () => {
       expect(content[0].type).toBe('image');
       expect(content[0].mimeType).toBe('image/png');
       expect(Buffer.from(content[0].data!, 'base64').equals(pngBytes)).toBe(true);
+      // structuredContent must MIRROR content. The SDK validates each field independently
+      // against the outputSchema union (either arm is valid for either field), so schema
+      // validation alone cannot catch the two drifting apart — only this equality can.
+      expect(result.structuredContent).toEqual({ content });
     });
 
     it('returns type "audio" for audio files, round-tripping the bytes', async () => {
@@ -200,6 +204,7 @@ describe('structuredContent schema compliance', () => {
       expect(content[0].type).toBe('audio');
       expect(content[0].mimeType).toBe('audio/mpeg');
       expect(Buffer.from(content[0].data!, 'base64').equals(mp3Bytes)).toBe(true);
+      expect(result.structuredContent).toEqual({ content }); // must mirror content (see image case)
     });
 
     it('returns an embedded resource (never "blob") for non-media binaries, round-tripping the bytes', async () => {
@@ -217,8 +222,10 @@ describe('structuredContent schema compliance', () => {
         resource?: { uri: string; mimeType: string; blob: string };
       }>;
       expect(content).toHaveLength(1);
+      // ("never blob" is enforced upstream of any assertion here: the SDK client's
+      // CallToolResultSchema parse rejects a blob block before content is even inspected,
+      // failing the callTool above — which is exactly how this test fails pre-fix.)
       expect(content[0].type).toBe('resource');
-      expect(content[0].type).not.toBe('blob');
       expect(content[0].resource).toBeDefined();
       expect(content[0].resource!.uri.startsWith('file://')).toBe(true);
       // Decode the uri back to a path and confirm it is the file actually read — guards a
@@ -229,6 +236,7 @@ describe('structuredContent schema compliance', () => {
       // The base64 blob must round-trip to the original bytes (data integrity, not just a valid
       // shape) — this also subsumes a non-empty check.
       expect(Buffer.from(content[0].resource!.blob, 'base64').equals(binBytes)).toBe(true);
+      expect(result.structuredContent).toEqual({ content }); // must mirror content (see image case)
     });
 
     it('percent-encodes spaces and non-ASCII chars in the resource uri (pathToFileURL, not a raw file:// concatenation)', async () => {
@@ -253,6 +261,7 @@ describe('structuredContent schema compliance', () => {
       // vacuous on an NFD runner where the precomposed char never appears — is the load-bearing
       // assertion that distinguishes pathToFileURL from a raw `file://${path}` concatenation.
       expect(uri).toMatch(/%C3%A9|%CC%81/);
+      expect(result.structuredContent).toEqual({ content }); // must mirror content (see image case)
     });
 
     it('advertises the widened outputSchema union via tools/list (both branches serialize)', async () => {

--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
 
 /**
  * Integration tests to verify that tool handlers return structuredContent
@@ -153,6 +154,119 @@ describe('structuredContent schema compliance', () => {
       const structuredContent = result.structuredContent as { content: unknown };
       expect(typeof structuredContent.content).toBe('string');
       expect(Array.isArray(structuredContent.content)).toBe(false);
+    });
+  });
+
+  // read_media_file must return a VALID MCP content block. Previously it emitted
+  // type: "blob" for non-image/audio files, which is not in the MCP content-block
+  // union (text | image | audio | resource_link | resource) and a strict client
+  // rejects on schema validation. See issue #4029.
+  describe('read_media_file (issue #4029)', () => {
+    // Image/audio inputs already returned valid content types before #4029 (only the
+    // non-media fallback was the invalid "blob"), so these two cases are "still-works"
+    // coverage — they round-trip the bytes to catch an encoding regression on the media
+    // paths. The resource + café cases below are the actual #4029 regression guards
+    // (they fail against the pre-fix "blob" build).
+    it('returns type "image" for image files, round-tripping the bytes', async () => {
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const pngPath = path.join(testDir, 'pixel.png');
+      // Contents aren't validated by the tool (MIME is by extension), so arbitrary bytes are fine.
+      await fs.writeFile(pngPath, pngBytes);
+
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: pngPath }
+      });
+
+      const content = result.content as Array<{ type: string; data?: string; mimeType?: string }>;
+      expect(Array.isArray(content)).toBe(true);
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe('image');
+      expect(content[0].mimeType).toBe('image/png');
+      expect(Buffer.from(content[0].data!, 'base64').equals(pngBytes)).toBe(true);
+    });
+
+    it('returns type "audio" for audio files, round-tripping the bytes', async () => {
+      const mp3Bytes = Buffer.from([0x49, 0x44, 0x33, 0x04]);
+      const mp3Path = path.join(testDir, 'clip.mp3');
+      await fs.writeFile(mp3Path, mp3Bytes);
+
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: mp3Path }
+      });
+
+      const content = result.content as Array<{ type: string; data?: string; mimeType?: string }>;
+      expect(content[0].type).toBe('audio');
+      expect(content[0].mimeType).toBe('audio/mpeg');
+      expect(Buffer.from(content[0].data!, 'base64').equals(mp3Bytes)).toBe(true);
+    });
+
+    it('returns an embedded resource (never "blob") for non-media binaries, round-tripping the bytes', async () => {
+      const binBytes = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xff, 0xfe]);
+      const binPath = path.join(testDir, 'data.bin');
+      await fs.writeFile(binPath, binBytes);
+
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: binPath }
+      });
+
+      const content = result.content as Array<{
+        type: string;
+        resource?: { uri: string; mimeType: string; blob: string };
+      }>;
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe('resource');
+      expect(content[0].type).not.toBe('blob');
+      expect(content[0].resource).toBeDefined();
+      expect(content[0].resource!.uri.startsWith('file://')).toBe(true);
+      // Decode the uri back to a path and confirm it is the file actually read — guards a
+      // refactor that builds the uri from the wrong variable while still emitting a
+      // well-formed file:// string. (realpath handles the /tmp -> /private/tmp macOS alias.)
+      expect(fileURLToPath(content[0].resource!.uri)).toBe(await fs.realpath(binPath));
+      expect(content[0].resource!.mimeType).toBe('application/octet-stream');
+      // The base64 blob must round-trip to the original bytes (data integrity, not just a valid
+      // shape) — this also subsumes a non-empty check.
+      expect(Buffer.from(content[0].resource!.blob, 'base64').equals(binBytes)).toBe(true);
+    });
+
+    it('percent-encodes spaces and non-ASCII chars in the resource uri (pathToFileURL, not a raw file:// concatenation)', async () => {
+      const fancyPath = path.join(testDir, 'my café.bin');
+      await fs.writeFile(fancyPath, Buffer.from([0x10, 0x20, 0x30]));
+
+      const result = await client.callTool({
+        name: 'read_media_file',
+        arguments: { path: fancyPath }
+      });
+
+      const content = result.content as Array<{ type: string; resource?: { uri: string } }>;
+      expect(content[0].type).toBe('resource');
+      const uri = content[0].resource!.uri;
+      // pathToFileURL percent-encodes the space (%20) and the non-ASCII "é" (%C3%A9 for NFC,
+      // or the base "e" + %CC%81 for the NFD form some filesystems store); a raw
+      // `file://${validPath}` (as in PR #4044) would leave both literal.
+      expect(uri).toContain('%20');
+      expect(uri).not.toContain(' ');
+      // The non-ASCII "é" must be percent-encoded: %C3%A9 (NFC) or base-"e" + %CC%81 (the NFD
+      // form some filesystems decompose to). This regex — not a `.not.toContain('é')`, which is
+      // vacuous on an NFD runner where the precomposed char never appears — is the load-bearing
+      // assertion that distinguishes pathToFileURL from a raw `file://${path}` concatenation.
+      expect(uri).toMatch(/%C3%A9|%CC%81/);
+    });
+
+    it('advertises the widened outputSchema union via tools/list (both branches serialize)', async () => {
+      const { tools } = await client.listTools();
+      const tool = tools.find((t) => t.name === 'read_media_file');
+      expect(tool).toBeDefined();
+      // The union outputSchema must serialize to JSON Schema — a DIFFERENT SDK path
+      // (toJsonSchemaCompat / tools-list) than the callTool structuredContent validation the
+      // other cases exercise — with BOTH branches present. Guards a nested-union-in-array
+      // serialization quirk that could drop the resource arm from the advertised schema.
+      const schemaStr = JSON.stringify(tool!.outputSchema);
+      expect(schemaStr).toMatch(/resource/);
+      expect(schemaStr).toMatch(/image/);
+      expect(schemaStr).toMatch(/audio/);
     });
   });
 });

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -3,13 +3,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
-  CallToolResult,
   RootsListChangedNotificationSchema,
   type Root,
 } from "@modelcontextprotocol/sdk/types.js";
 import fs from "fs/promises";
 import { createReadStream } from "fs";
 import path from "path";
+import { pathToFileURL } from "url";
 import { z } from "zod";
 import { minimatch } from "minimatch";
 import { normalizePath, expandHome } from './path-utils.js';
@@ -250,17 +250,29 @@ server.registerTool(
   {
     title: "Read Media File",
     description:
-      "Read an image or audio file. Returns the base64 encoded data and MIME type. " +
-      "Only works within allowed directories.",
+      "Read a file and return it as a base64-encoded content block with its MIME type. " +
+      "Image and audio files are returned as image/audio content; any other file type is " +
+      "returned as an embedded resource. Only works within allowed directories.",
     inputSchema: {
       path: z.string()
     },
     outputSchema: {
-      content: z.array(z.object({
-        type: z.enum(["image", "audio", "blob"]),
-        data: z.string(),
-        mimeType: z.string()
-      }))
+      content: z.array(z.union([
+        z.object({
+          type: z.enum(["image", "audio"]),
+          data: z.string(),
+          mimeType: z.string()
+        }),
+        z.object({
+          type: z.literal("resource"),
+          resource: z.object({
+            uri: z.string(),
+            // Optional, matching the SDK's BlobResourceContents shape (the handler always sets it).
+            mimeType: z.string().optional(),
+            blob: z.string()
+          })
+        })
+      ]))
     },
     annotations: { readOnlyHint: true }
   },
@@ -283,17 +295,23 @@ server.registerTool(
     const mimeType = mimeTypes[extension] || "application/octet-stream";
     const data = await readFileAsBase64Stream(validPath);
 
-    const type = mimeType.startsWith("image/")
-      ? "image"
-      : mimeType.startsWith("audio/")
-        ? "audio"
-        // Fallback for other binary types, not officially supported by the spec but has been used for some time
-        : "blob";
-    const contentItem = { type: type as 'image' | 'audio' | 'blob', data, mimeType };
+    // Map the MIME type to a valid MCP content block. The spec only allows
+    // text, image, audio, resource_link, and resource — so non-image/audio
+    // binaries are returned as an embedded resource (NOT type:"blob", which the
+    // SDK content-block union rejects on schema validation).
+    const contentItem =
+      mimeType.startsWith("image/")
+        ? { type: "image" as const, data, mimeType }
+        : mimeType.startsWith("audio/")
+          ? { type: "audio" as const, data, mimeType }
+          : {
+              type: "resource" as const,
+              resource: { uri: pathToFileURL(validPath).href, mimeType, blob: data }
+            };
     return {
       content: [contentItem],
       structuredContent: { content: [contentItem] }
-    } as unknown as CallToolResult;
+    };
   }
 );
 


### PR DESCRIPTION
## Summary

`read_media_file` returns a content block with `type: "blob"` for any file that isn't `image/*` or `audio/*`. `blob` is not a valid MCP content type — the content-block union is `text | image | audio | resource_link | resource` — so a strict client rejects the whole tool result on schema validation (surfaced as `MCP error -32602 invalid_union`; the reference TypeScript SDK raises a Zod parse error on the invalid `content[0]`). The result: for any non-image/non-audio file, this tool is unusable against a strict client.

Closes #4029.

## Fix

Map the MIME type to a valid MCP content block:
- `image/*` → `{ type: "image", data, mimeType }`
- `audio/*` → `{ type: "audio", data, mimeType }`
- anything else → an **embedded resource** `{ type: "resource", resource: { uri, mimeType, blob } }` — the spec-correct carrier for arbitrary binary data — instead of the invalid `type: "blob"`.

Alongside the handler change:
- the tool's `outputSchema` is widened to the matching union (so the server-side `structuredContent` validation accepts both shapes);
- `resource.uri` is built with `pathToFileURL()` so spaces / non-ASCII / Windows paths are correctly percent-encoded;
- the now-unnecessary `as unknown as CallToolResult` cast is dropped, so `tsc` enforces the returned shape;
- the tool description and `README` are updated to note that non-media files are returned as an embedded resource.

## ⚠ Behavior change (worth a release note)

For a file that is neither image nor audio, `read_media_file` previously returned `{ type: "blob", data, mimeType }` and now returns `{ type: "resource", resource: { uri, mimeType, blob } }` — the base64 payload moves from `.data` to `.resource.blob`. Any client that read `.data`/`.mimeType` off a blob-typed result for non-media files will need to read the embedded resource instead. Since `type: "blob"` was never a valid MCP content type (strict clients already rejected it), this is a correctness fix — but it may warrant a `server-filesystem` version bump / changelog entry.

## Alternative considered

If you'd rather keep `read_media_file` strictly image/audio, the alternative is to **reject** non-media files (drop `blob` from the enum and `throw` for unsupported types) — the approach in #4163. That's simpler but removes the ability to return arbitrary bytes. This PR takes the capability-preserving route; happy to switch to the reject approach if you prefer it.

## Tests

Adds a `read_media_file (issue #4029)` suite to `src/filesystem/__tests__/structured-content.test.ts`. These are real `client.callTool()` round-trips through the MCP SDK client, so a schema-invalid result fails the call:
- image / audio return their content type, with a byte round-trip of the base64 `data`;
- a non-media binary returns a `type: "resource"` block (never `"blob"`), the base64 blob round-trips to the original bytes, and the `uri` decodes back to the file that was read;
- a spaced + non-ASCII filename asserts the `uri` is percent-encoded (guards `pathToFileURL` vs a raw `file://` string concatenation);
- `tools/list` advertises the widened `outputSchema` union with both branches present (guards the JSON-Schema serialization path, which is separate from the `callTool` validation the other cases exercise).
- each `callTool` case also asserts `structuredContent` mirrors `content` — the SDK validates the two fields independently against the union, so mirror-equality is the only thing that catches them drifting apart (mutation-verified: a schema-valid drifted `structuredContent` fails exactly these assertions).

`npm run build` + `npm test` pass (152 tests).

## Related

- Fixes #4029.
- #4044 implements the same embedded-resource approach; this PR additionally adds `pathToFileURL` URI-encoding, drops the `as unknown as CallToolResult` cast, updates the README, and adds the `tools/list` serialization + uri-identity tests.
- #4163 implements the alternative (reject non-media) approach described above.
- #4480 adds `openWorldHint: false` to all filesystem tools, touching this same file (including the `read_media_file` block); the two branches auto-merge cleanly in either order (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


