### PR TITLE
fix(time): use McpError for proper JSON-RPC error propagation

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -53,10 +53,8 @@ def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
 def get_zoneinfo(timezone_name: str) -> ZoneInfo:
     try:
         return ZoneInfo(timezone_name)
-    except KeyError:
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Unknown timezone: {timezone_name}"))
     except Exception as e:
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone '{timezone_name}': {e}"))
+        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone: {str(e)}"))
 
 
 class TimeServer:

--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -53,8 +53,10 @@ def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
 def get_zoneinfo(timezone_name: str) -> ZoneInfo:
     try:
         return ZoneInfo(timezone_name)
+    except KeyError:
+        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Unknown timezone: {timezone_name}"))
     except Exception as e:
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone: {str(e)}"))
+        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone '{timezone_name}': {e}"))
 
 
 class TimeServer:
@@ -213,7 +215,7 @@ async def serve(local_timezone: str | None = None) -> None:
             ]
 
         except Exception as e:
-            raise ValueError(f"Error processing mcp-server-time query: {str(e)}")
+            raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Error processing time query: {str(e)}"))
 
     options = server.create_initialization_options()
     async with stdio_server() as (read_stream, write_stream):


### PR DESCRIPTION
## Summary

Two fixes in the time server for proper MCP protocol error handling.

## Problem

1. **`call_tool` handler raised `ValueError` instead of `McpError`** (line 216). The MCP protocol requires errors to be sent as JSON-RPC error responses via `McpError`. A bare `ValueError` gets caught by the SDK as a generic internal error, losing the error code and context.

2. **`get_zoneinfo` caught all exceptions generically** (line 56). `ZoneInfo("invalid")` raises `KeyError` while `ZoneInfo(bad_object)` raises `TypeError` — the function gave the same "Invalid timezone" message for both, making debugging harder.

## Changes

- `src/time/src/mcp_server_time/server.py` (+4/-2):
  - `get_zoneinfo`: separate `KeyError` (unknown timezone name) from generic exceptions (invalid format), with distinct messages
  - `call_tool` handler: `ValueError` → `McpError(ErrorData(code=INVALID_PARAMS, ...))` for correct JSON-RPC error propagation