### PR TITLE
fix(git): git_log date-filtered path misparses every commit after the first

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -169,7 +169,10 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
             args.extend(['--since', start_timestamp])
         if end_timestamp:
             args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+        # No trailing %n: git already separates entries with a newline, so a
+        # trailing %n would emit 5 lines per commit and break the groups-of-4
+        # parsing below for every commit after the first.
+        args.extend(['--format=%H%n%an%n%ad%n%s'])
 
         log_output = repo.git.log(*args).split('\n')
 

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -227,6 +227,25 @@ def test_git_log(test_repository):
     assert "Date:" in result[0]
     assert "Message:" in result[0]
 
+def test_git_log_with_date_filter(test_repository):
+    """Every commit on the date-filtered path parses into aligned fields."""
+    for i in range(3):
+        file_path = Path(test_repository.working_dir) / f"log_filter_{i}.txt"
+        file_path.write_text(f"content {i}")
+        test_repository.index.add([f"log_filter_{i}.txt"])
+        test_repository.index.commit(f"commit {i}")
+
+    result = git_log(test_repository, start_timestamp="2000-01-01")
+
+    # initial commit fixture + 3 above
+    assert len(result) == 4
+    for i, entry in enumerate(reversed(result[:3])):
+        lines = entry.splitlines()
+        assert lines[0].startswith("Commit: ") and len(lines[0]) == len("Commit: ") + 40
+        assert lines[1].startswith("Author: ") and lines[1] != "Author: "
+        assert lines[2].startswith("Date: ")
+        assert lines[3] == f"Message: commit {i}"
+
 def test_git_log_default(test_repository):
     result = git_log(test_repository)
 


### PR DESCRIPTION
## Bug

`git_log` with `start_timestamp`/`end_timestamp` uses `--format=%H%n%an%n%ad%n%s%n`. The trailing `%n`, plus the newline git prints between log entries, makes each commit emit **5 lines**, while the parser walks the output in strides of **4** (`server.py`, `for i in range(0, len(log_output), 4)`). Alignment breaks from the second commit on.

Actual output on a 3-commit repo with `start_timestamp="2000-01-01"`:

```
Commit: 15d3a078...          <- commit 3, correct
...
Commit:                      <- blank: this is the separator line
Author: 36688c31c43d9bb...   <- the hash landed in the author column
Date: T                      <- the author landed in the date column
Message: Wed Jul 8 01:04:18  <- the date landed in the message column
```

## Fix

Drop the trailing `%n` so each commit is exactly 4 lines. One-character change; the non-filtered path is untouched.

## Tests

The date-filtered path had no coverage (`test_git_log`/`test_git_log_default` only exercise the plain path). Added `test_git_log_with_date_filter`, which asserts per-field alignment for every returned entry. Verified it fails on the old format string and passes with the fix. Full suite: 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)