### PR TITLE
fix(everything): block SSRF to internal/metadata IPs in gzip-file-as-resource

### DIFF
--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -1217,5 +1217,40 @@ describe('Tools', () => {
         handler!({ name: 'test.gz', data: 'ftp://example.com/file.txt', outputType: 'resource' })
       ).rejects.toThrow('Unsupported URL protocol');
     });
+
+    // SSRF protection: the tool must refuse to fetch non-public IP addresses.
+    // These use IP literals so no DNS resolution (or network) is required.
+    const blockedHosts: Array<[string, string]> = [
+      ['loopback IPv4', 'http://127.0.0.1/secret'],
+      ['cloud metadata', 'http://169.254.169.254/latest/meta-data/'],
+      ['private 10/8', 'http://10.0.0.1/'],
+      ['private 192.168/16', 'http://192.168.1.1/'],
+      ['private 172.16/12', 'http://172.16.0.1/'],
+      ['unspecified', 'http://0.0.0.0/'],
+      ['IPv6 loopback', 'http://[::1]/'],
+      ['IPv4-mapped IPv6 loopback', 'http://[::ffff:127.0.0.1]/'],
+    ];
+
+    for (const [label, url] of blockedHosts) {
+      it(`should refuse to fetch non-public host (${label})`, async () => {
+        const mockServer = {
+          registerTool: vi.fn(),
+          registerResource: vi.fn(),
+        } as unknown as McpServer;
+
+        let handler: Function | null = null;
+        (mockServer.registerTool as any).mockImplementation(
+          (name: string, config: any, h: Function) => {
+            handler = h;
+          }
+        );
+
+        registerGZipFileAsResourceTool(mockServer);
+
+        await expect(
+          handler!({ name: 'test.gz', data: url, outputType: 'resource' })
+        ).rejects.toThrow(/SSRF protection/);
+      });
+    }
   });
 });

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -1254,5 +1254,47 @@ describe('Tools', () => {
         ).rejects.toThrow(/SSRF protection/);
       });
     }
+
+    it('should re-validate redirects and refuse a public URL that redirects to a blocked IP', async () => {
+      const mockServer = {
+        registerTool: vi.fn(),
+        registerResource: vi.fn(),
+      } as unknown as McpServer;
+
+      let handler: Function | null = null;
+      (mockServer.registerTool as any).mockImplementation(
+        (name: string, config: any, h: Function) => {
+          handler = h;
+        }
+      );
+
+      registerGZipFileAsResourceTool(mockServer);
+
+      // First (public) hop responds with a redirect to the cloud-metadata IP.
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        })
+      );
+
+      try {
+        await expect(
+          handler!({
+            name: 'test.gz',
+            // Public IP literal so the first hop needs no DNS resolution.
+            data: 'http://93.184.216.34/',
+            outputType: 'resource',
+          })
+        ).rejects.toThrow(/SSRF protection/);
+
+        // The blocked redirect target must be rejected before any request is
+        // made to it: only the initial public URL was fetched.
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(String(fetchSpy.mock.calls[0][0])).toBe('http://93.184.216.34/');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
   });
 });

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -20,6 +20,15 @@ import {
 import { registerGetRootsListTool } from '../tools/get-roots-list.js';
 import { registerGZipFileAsResourceTool } from '../tools/gzip-file-as-resource.js';
 import { registerSimulateResearchQueryTool } from '../tools/simulate-research-query.js';
+import { lookup } from 'node:dns/promises';
+
+// Mock DNS resolution so the gzip tool's hostname SSRF path can be exercised
+// without real network lookups. Defaults to the real implementation; tests
+// override per-call with mockResolvedValueOnce.
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>();
+  return { ...actual, lookup: vi.fn(actual.lookup) };
+});
 
 // Helper to capture registered tool handlers
 function createMockServer() {
@@ -1295,6 +1304,65 @@ describe('Tools', () => {
       } finally {
         fetchSpy.mockRestore();
       }
+    });
+
+    it('should refuse a hostname that resolves to a blocked IP', async () => {
+      const mockServer = {
+        registerTool: vi.fn(),
+        registerResource: vi.fn(),
+      } as unknown as McpServer;
+
+      let handler: Function | null = null;
+      (mockServer.registerTool as any).mockImplementation(
+        (name: string, config: any, h: Function) => {
+          handler = h;
+        }
+      );
+
+      registerGZipFileAsResourceTool(mockServer);
+
+      // Hostname (not an IP literal) resolves to the cloud-metadata address.
+      vi.mocked(lookup).mockResolvedValueOnce([
+        { address: '169.254.169.254', family: 4 },
+      ] as any);
+
+      await expect(
+        handler!({
+          name: 'test.gz',
+          data: 'http://metadata.internal.example/',
+          outputType: 'resource',
+        })
+      ).rejects.toThrow(/SSRF protection/);
+    });
+
+    it('should refuse when any of several resolved addresses is blocked', async () => {
+      const mockServer = {
+        registerTool: vi.fn(),
+        registerResource: vi.fn(),
+      } as unknown as McpServer;
+
+      let handler: Function | null = null;
+      (mockServer.registerTool as any).mockImplementation(
+        (name: string, config: any, h: Function) => {
+          handler = h;
+        }
+      );
+
+      registerGZipFileAsResourceTool(mockServer);
+
+      // A public and a private address: the "any blocked" rule must reject.
+      vi.mocked(lookup).mockResolvedValueOnce([
+        { address: '93.184.216.34', family: 4 },
+        { address: '10.0.0.5', family: 4 },
+      ] as any);
+
+      await expect(
+        handler!({
+          name: 'test.gz',
+          data: 'http://mixed.example/',
+          outputType: 'resource',
+        })
+      ).rejects.toThrow(/SSRF protection/);
     });
   });
 });

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -1227,8 +1227,10 @@ describe('Tools', () => {
       ['private 192.168/16', 'http://192.168.1.1/'],
       ['private 172.16/12', 'http://172.16.0.1/'],
       ['unspecified', 'http://0.0.0.0/'],
+      ['carrier-grade NAT 100.64/10', 'http://100.64.0.1/'],
       ['IPv6 loopback', 'http://[::1]/'],
       ['IPv4-mapped IPv6 loopback', 'http://[::ffff:127.0.0.1]/'],
+      ['IPv4-compatible IPv6 loopback', 'http://[::127.0.0.1]/'],
     ];
 
     for (const [label, url] of blockedHosts) {

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -1251,6 +1251,12 @@ describe('Tools', () => {
       ['IPv6 site-local', 'http://[fec0::1]/'],
       ['IPv6 discard-only 100::/64', 'http://[100::1]/'],
       ['IPv6 Teredo 2001::/32', 'http://[2001::1]/'],
+      // Everything outside global unicast (2000::/3) is refused, so reserved
+      // space cannot be reached just because it is not individually listed.
+      ['IPv6 reserved 4000::/3', 'http://[4000::1]/'],
+      ['IPv6 reserved 8000::/2', 'http://[8000::1]/'],
+      ['IPv6 reserved 1000::/4', 'http://[1000::1]/'],
+      ['IPv6 reserved 0200::/7', 'http://[200::1]/'],
     ];
 
     for (const [label, url] of blockedHosts) {

--- a/src/everything/__tests__/tools.test.ts
+++ b/src/everything/__tests__/tools.test.ts
@@ -1240,6 +1240,17 @@ describe('Tools', () => {
       ['IPv6 loopback', 'http://[::1]/'],
       ['IPv4-mapped IPv6 loopback', 'http://[::ffff:127.0.0.1]/'],
       ['IPv4-compatible IPv6 loopback', 'http://[::127.0.0.1]/'],
+      ['IPv4-translated IPv6 loopback', 'http://[::ffff:0:7f00:1]/'],
+      ['NAT64 loopback', 'http://[64:ff9b::7f00:1]/'],
+      ['NAT64 cloud metadata', 'http://[64:ff9b::a9fe:a9fe]/'],
+      ['NAT64 local-use prefix', 'http://[64:ff9b:1::1]/'],
+      ['6to4 loopback', 'http://[2002:7f00:1::]/'],
+      ['6to4 cloud metadata', 'http://[2002:a9fe:a9fe::]/'],
+      ['IPv6 unique-local', 'http://[fc00::1]/'],
+      ['IPv6 link-local', 'http://[fe80::1]/'],
+      ['IPv6 site-local', 'http://[fec0::1]/'],
+      ['IPv6 discard-only 100::/64', 'http://[100::1]/'],
+      ['IPv6 Teredo 2001::/32', 'http://[2001::1]/'],
     ];
 
     for (const [label, url] of blockedHosts) {

--- a/src/everything/docs/instructions.md
+++ b/src/everything/docs/instructions.md
@@ -12,7 +12,7 @@ Follow them to use, extend, and troubleshoot the server safely and effectively.
 
 ## Constraints & Limitations
 
-- `gzip-file-as-resource`: Max fetch size controlled by `GZIP_MAX_FETCH_SIZE` (default 10MB), timeout by `GZIP_MAX_FETCH_TIME_MILLIS` (default 30s), allowed domains by `GZIP_ALLOWED_DOMAINS`
+- `gzip-file-as-resource`: Max fetch size controlled by `GZIP_MAX_FETCH_SIZE` (default 10MB), timeout by `GZIP_MAX_FETCH_TIME_MILLIS` (default 30s), allowed domains by `GZIP_ALLOWED_DOMAINS`. Requests to loopback, private, link-local, and cloud-metadata IP addresses are always blocked (SSRF protection), including across redirects, regardless of the allowlist.
 - Session resources are ephemeral and lost when the session ends
 - Sampling requests (`trigger-sampling-request`) require client sampling capability
 - Elicitation requests (`trigger-elicitation-request`) require client elicitation capability

--- a/src/everything/docs/structure.md
+++ b/src/everything/docs/structure.md
@@ -151,6 +151,7 @@ src/everything
     - `GZIP_MAX_FETCH_SIZE` (bytes, default 10 MiB)
     - `GZIP_MAX_FETCH_TIME_MILLIS` (ms, default 30000)
     - `GZIP_ALLOWED_DOMAINS` (comma-separated allowlist; empty means all domains allowed)
+  - SSRF protection: loopback, private (RFC1918), link-local, and cloud-metadata IP addresses are always refused (and re-validated on every redirect hop), independent of `GZIP_ALLOWED_DOMAINS`.
 - `simulate-research-query.ts`
   - Registers a `simulate-research-query` task-based tool that demonstrates the MCP Tasks feature (SEP-1686). Simulates a multi-stage research operation with progress updates. If the query is marked as ambiguous and the client supports elicitation, it pauses mid-execution to request clarification via `elicitation/create`. Uses `server.experimental.tasks.registerToolTask()` with `execution: { taskSupport: "required" }`.
 - `trigger-elicitation-request.ts`

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -452,6 +452,11 @@ async function fetchWithGuardedRedirects(
       return response;
     }
 
+    // This redirect response is never returned to the caller, so drain its
+    // body to let undici release the socket instead of leaving it pinned
+    // across the redirect chain (a leak under load).
+    await response.body?.cancel();
+
     // Enforce the limit before following (and re-validating) another hop, so
     // we never resolve or fetch a redirect target beyond GZIP_MAX_REDIRECTS.
     if (redirects >= GZIP_MAX_REDIRECTS) {

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -272,14 +272,44 @@ function isBlockedIpv6(ip: string): boolean {
 }
 
 /**
+ * Rejects as soon as `signal` aborts so an awaited operation that does not
+ * itself honor the AbortSignal (e.g. DNS resolution via dns/promises.lookup)
+ * still respects the overall fetch timeout instead of hanging past it.
+ */
+function withAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+  message: string
+): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new Error(message));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error(message));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+/**
  * Resolves a URL's host and throws if any resolved address is a non-public
  * (loopback/private/link-local/metadata) IP, to prevent SSRF. Only http/https
  * URLs are checked; other schemes (e.g. data:) are left to the caller.
  *
  * @param {URL} url The URL whose destination host should be validated.
+ * @param {AbortSignal} [signal] Abort signal that also bounds DNS resolution to
+ *   the caller's timeout.
  * @throws {Error} If the host resolves to a blocked address or cannot be resolved.
  */
-async function assertPublicHost(url: URL): Promise<void> {
+async function assertPublicHost(url: URL, signal?: AbortSignal): Promise<void> {
   // url.hostname keeps brackets around IPv6 literals; strip them.
   const host = url.hostname.replace(/^\[|\]$/g, "");
 
@@ -287,7 +317,11 @@ async function assertPublicHost(url: URL): Promise<void> {
   if (isIP(host)) {
     addresses = [host];
   } else {
-    const resolved = await lookup(host, { all: true });
+    const resolved = await withAbort(
+      lookup(host, { all: true }),
+      signal,
+      `Timed out resolving host ${host} for ${url}.`
+    );
     addresses = resolved.map((r) => r.address);
     if (addresses.length === 0) {
       throw new Error(`Could not resolve host ${host} for ${url}`);
@@ -405,7 +439,7 @@ async function fetchWithGuardedRedirects(
   let current = url;
   for (let hop = 0; hop <= GZIP_MAX_REDIRECTS; hop++) {
     if (current.protocol === "http:" || current.protocol === "https:") {
-      await assertPublicHost(current);
+      await assertPublicHost(current, signal);
     }
 
     const response = await fetch(current, { signal, redirect: "manual" });

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -317,11 +317,20 @@ async function assertPublicHost(url: URL, signal?: AbortSignal): Promise<void> {
   if (isIP(host)) {
     addresses = [host];
   } else {
-    const resolved = await withAbort(
-      lookup(host, { all: true }),
-      signal,
-      `Timed out resolving host ${host} for ${url}.`
-    );
+    let resolved;
+    try {
+      resolved = await withAbort(
+        lookup(host, { all: true }),
+        signal,
+        "DNS resolution timed out"
+      );
+    } catch (error) {
+      // Wrap raw Node lookup errors (ENOTFOUND/EAI_AGAIN, or the timeout
+      // above) so the failure carries host + URL context and matches the
+      // tool's other error messages.
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Could not resolve host ${host} for ${url}: ${message}`);
+    }
     addresses = resolved.map((r) => r.address);
     if (addresses.length === 0) {
       throw new Error(`Could not resolve host ${host} for ${url}`);

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -2,10 +2,15 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult, Resource } from "@modelcontextprotocol/sdk/types.js";
 import { gzipSync } from "node:zlib";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import {
   getSessionResourceURI,
   registerSessionResource,
 } from "../resources/session.js";
+
+// Maximum number of redirect hops to follow (and re-validate) when fetching.
+const GZIP_MAX_REDIRECTS = 20;
 
 // Maximum input file size - 10 MB default
 const GZIP_MAX_FETCH_SIZE = Number(
@@ -168,6 +173,133 @@ function validateDataURI(dataUri: string): URL {
 }
 
 /**
+ * Determines whether an IPv4 address string falls in a range that must not be
+ * fetched (loopback, private, link-local/cloud-metadata, reserved, etc.).
+ */
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) {
+    // Not a well-formed IPv4 address; treat as blocked to fail closed.
+    return true;
+  }
+  const asInt =
+    ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
+  const inRange = (base: string, bits: number): boolean => {
+    const b = base.split(".").map((p) => parseInt(p, 10));
+    const baseInt = ((b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3]) >>> 0;
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (asInt & mask) === (baseInt & mask);
+  };
+  return (
+    inRange("0.0.0.0", 8) || // "this" network / unspecified
+    inRange("10.0.0.0", 8) || // private
+    inRange("100.64.0.0", 10) || // carrier-grade NAT
+    inRange("127.0.0.0", 8) || // loopback
+    inRange("169.254.0.0", 16) || // link-local (incl. cloud metadata 169.254.169.254)
+    inRange("172.16.0.0", 12) || // private
+    inRange("192.0.0.0", 24) || // IETF protocol assignments
+    inRange("192.0.2.0", 24) || // TEST-NET-1
+    inRange("192.168.0.0", 16) || // private
+    inRange("198.18.0.0", 15) || // benchmarking
+    inRange("198.51.100.0", 24) || // TEST-NET-2
+    inRange("203.0.113.0", 24) || // TEST-NET-3
+    inRange("224.0.0.0", 4) || // multicast
+    inRange("240.0.0.0", 4) // reserved (incl. 255.255.255.255)
+  );
+}
+
+/**
+ * Expands an IPv6 address string (possibly using "::" compression and/or a
+ * trailing dotted-quad IPv4 suffix) into its 8 16-bit hextets. Returns null if
+ * the address cannot be parsed.
+ */
+function expandIpv6(addr: string): number[] | null {
+  let s = addr;
+  // Convert a trailing IPv4 dotted-quad (e.g. ::ffff:127.0.0.1) into hextets.
+  const v4match = s.match(/^(.*:)(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4match) {
+    const v4 = v4match[2].split(".").map((p) => parseInt(p, 10));
+    if (v4.length !== 4 || v4.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
+      return null;
+    }
+    const h1 = ((v4[0] << 8) | v4[1]).toString(16);
+    const h2 = ((v4[2] << 8) | v4[3]).toString(16);
+    s = `${v4match[1]}${h1}:${h2}`;
+  }
+
+  const halves = s.split("::");
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(":") : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  if (halves.length === 1) {
+    if (head.length !== 8) return null;
+    return head.map((g) => parseInt(g, 16));
+  }
+  const missing = 8 - head.length - tail.length;
+  if (missing < 0) return null;
+  const groups = [...head, ...Array(missing).fill("0"), ...tail];
+  if (groups.length !== 8) return null;
+  return groups.map((g) => parseInt(g || "0", 16));
+}
+
+/**
+ * Determines whether an IPv6 address string must not be fetched. IPv4-mapped
+ * addresses (in either dotted or hex form) are unwrapped and classified as IPv4.
+ */
+function isBlockedIpv6(ip: string): boolean {
+  const g = expandIpv6(ip.toLowerCase());
+  if (!g || g.some((h) => Number.isNaN(h))) {
+    return true; // fail closed on anything we cannot parse
+  }
+  // IPv4-mapped (::ffff:a.b.c.d): first 80 bits zero, next 16 bits 0xffff.
+  if (g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0xffff) {
+    const v4 = `${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`;
+    return isBlockedIpv4(v4);
+  }
+  if (g.every((h) => h === 0)) return true; // :: unspecified
+  if (g.slice(0, 7).every((h) => h === 0) && g[7] === 1) return true; // ::1 loopback
+  const first = g[0];
+  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
+  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  return false;
+}
+
+/**
+ * Resolves a URL's host and throws if any resolved address is a non-public
+ * (loopback/private/link-local/metadata) IP, to prevent SSRF. Only http/https
+ * URLs are checked; other schemes (e.g. data:) are left to the caller.
+ *
+ * @param {URL} url The URL whose destination host should be validated.
+ * @throws {Error} If the host resolves to a blocked address or cannot be resolved.
+ */
+async function assertPublicHost(url: URL): Promise<void> {
+  // url.hostname keeps brackets around IPv6 literals; strip them.
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+
+  let addresses: string[];
+  if (isIP(host)) {
+    addresses = [host];
+  } else {
+    const resolved = await lookup(host, { all: true });
+    addresses = resolved.map((r) => r.address);
+    if (addresses.length === 0) {
+      throw new Error(`Could not resolve host ${host} for ${url}`);
+    }
+  }
+
+  for (const address of addresses) {
+    const blocked =
+      isIP(address) === 6 ? isBlockedIpv6(address) : isBlockedIpv4(address);
+    if (blocked) {
+      throw new Error(
+        `Refusing to fetch ${url}: host ${host} resolves to non-public address ${address} (SSRF protection).`
+      );
+    }
+  }
+}
+
+/**
  * Fetches data safely from a given URL while ensuring constraints on maximum byte size and timeout duration.
  *
  * @param {URL} url The URL to fetch data from.
@@ -191,8 +323,9 @@ async function fetchSafely(
   );
 
   try {
-    // Fetch the data
-    const response = await fetch(url, { signal: controller.signal });
+    // Fetch the data, following redirects manually so every hop is re-validated
+    // against the SSRF guard (automatic redirects would bypass it).
+    const response = await fetchWithGuardedRedirects(url, controller.signal);
     if (!response.body) {
       throw new Error("No response body");
     }
@@ -245,4 +378,50 @@ async function fetchSafely(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Performs a fetch that follows redirects manually, validating the destination
+ * host against the SSRF guard before every hop. Non-http(s) URLs (e.g. data:)
+ * are fetched without host validation, and redirects to non-http(s) schemes are
+ * refused.
+ *
+ * @param {URL} url The initial URL to fetch.
+ * @param {AbortSignal} signal The abort signal used to enforce the fetch timeout.
+ * @return {Promise<Response>} The final (non-redirect) response.
+ * @throws {Error} If a hop resolves to a blocked host, a redirect targets an
+ *   unsupported scheme, or the redirect limit is exceeded.
+ */
+async function fetchWithGuardedRedirects(
+  url: URL,
+  signal: AbortSignal
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= GZIP_MAX_REDIRECTS; hop++) {
+    if (current.protocol === "http:" || current.protocol === "https:") {
+      await assertPublicHost(current);
+    }
+
+    const response = await fetch(current, { signal, redirect: "manual" });
+
+    const isRedirect =
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.headers.has("location");
+    if (!isRedirect) {
+      return response;
+    }
+
+    const next = new URL(response.headers.get("location")!, current);
+    if (next.protocol !== "http:" && next.protocol !== "https:") {
+      throw new Error(
+        `Refusing to follow redirect from ${current} to unsupported protocol ${next.protocol}`
+      );
+    }
+    current = next;
+  }
+
+  throw new Error(
+    `Too many redirects while fetching ${url} (max ${GZIP_MAX_REDIRECTS}).`
+  );
 }

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -258,6 +258,12 @@ function isBlockedIpv6(ip: string): boolean {
   }
   if (g.every((h) => h === 0)) return true; // :: unspecified
   if (g.slice(0, 7).every((h) => h === 0) && g[7] === 1) return true; // ::1 loopback
+  // IPv4-compatible (deprecated ::a.b.c.d, ::/96): first 96 bits zero. Unwrap
+  // and classify as IPv4 so forms like ::127.0.0.1 are not treated as public.
+  if (g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) {
+    const v4 = `${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`;
+    return isBlockedIpv4(v4);
+  }
   const first = g[0];
   if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
   if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -437,7 +437,7 @@ async function fetchWithGuardedRedirects(
   signal: AbortSignal
 ): Promise<Response> {
   let current = url;
-  for (let hop = 0; hop <= GZIP_MAX_REDIRECTS; hop++) {
+  for (let redirects = 0; ; redirects++) {
     if (current.protocol === "http:" || current.protocol === "https:") {
       await assertPublicHost(current, signal);
     }
@@ -452,6 +452,14 @@ async function fetchWithGuardedRedirects(
       return response;
     }
 
+    // Enforce the limit before following (and re-validating) another hop, so
+    // we never resolve or fetch a redirect target beyond GZIP_MAX_REDIRECTS.
+    if (redirects >= GZIP_MAX_REDIRECTS) {
+      throw new Error(
+        `Too many redirects while fetching ${url} (max ${GZIP_MAX_REDIRECTS}).`
+      );
+    }
+
     const next = new URL(response.headers.get("location")!, current);
     if (next.protocol !== "http:" && next.protocol !== "https:") {
       throw new Error(
@@ -460,8 +468,4 @@ async function fetchWithGuardedRedirects(
     }
     current = next;
   }
-
-  throw new Error(
-    `Too many redirects while fetching ${url} (max ${GZIP_MAX_REDIRECTS}).`
-  );
 }

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -254,7 +254,10 @@ function ipv4FromHextets(hi: number, lo: number): string {
  * Determines whether an IPv6 address string must not be fetched. Addresses that
  * embed an IPv4 address (mapped, translated, IPv4-compatible, NAT64, 6to4) are
  * unwrapped and classified as IPv4, so an internal destination cannot be reached
- * by wrapping it in an IPv6 form that looks globally routable.
+ * by wrapping it in an IPv6 form that looks globally routable. Everything that
+ * survives unwrapping is then checked against global unicast (2000::/3) as an
+ * allow list, so an unlisted prefix fails closed rather than being treated as
+ * public.
  */
 function isBlockedIpv6(ip: string): boolean {
   const g = expandIpv6(ip.toLowerCase());
@@ -288,15 +291,18 @@ function isBlockedIpv6(ip: string): boolean {
   if (g[0] === 0x2002) return isBlockedIpv4(ipv4FromHextets(g[1], g[2]));
 
   const first = g[0];
-  if (first === 0x0064 && g[1] === 0xff9b && g[2] === 0x0001) return true; // 64:ff9b:1::/48 local-use NAT64
-  if (first === 0x0100 && g[1] === 0 && g[2] === 0 && g[3] === 0) return true; // 100::/64 discard-only
+  // Only 2000::/3 is assigned as global unicast. Blocking everything else
+  // covers the ranges that are not publicly routable without having to
+  // enumerate them - unique-local (fc00::/7), link-local (fe80::/10),
+  // site-local (fec0::/10), multicast (ff00::/8), discard-only (100::/64),
+  // local-use NAT64 (64:ff9b:1::/48), SRv6 SIDs (5f00::/16) - and, unlike a
+  // deny list, fails closed on reserved space such as 4000::/3 and on any
+  // prefix IANA assigns in future.
+  if ((first & 0xe000) !== 0x2000) return true;
+
+  // Carve-outs inside global unicast that are still not valid destinations.
   if (first === 0x2001 && (g[1] & 0xfe00) === 0) return true; // 2001::/23 IETF protocol assignments (incl. Teredo)
   if (first === 0x2001 && g[1] === 0x0db8) return true; // 2001:db8::/32 documentation
-  if (first === 0x5f00) return true; // 5f00::/16 SRv6 SIDs
-  if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
-  if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
-  if ((first & 0xffc0) === 0xfec0) return true; // fec0::/10 site-local (deprecated, still internal)
-  if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
   return false;
 }
 

--- a/src/everything/tools/gzip-file-as-resource.ts
+++ b/src/everything/tools/gzip-file-as-resource.ts
@@ -243,30 +243,59 @@ function expandIpv6(addr: string): number[] | null {
 }
 
 /**
- * Determines whether an IPv6 address string must not be fetched. IPv4-mapped
- * addresses (in either dotted or hex form) are unwrapped and classified as IPv4.
+ * Renders the dotted-quad IPv4 address encoded by two 16-bit hextets, used to
+ * unwrap the IPv6 forms that embed an IPv4 address.
+ */
+function ipv4FromHextets(hi: number, lo: number): string {
+  return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+}
+
+/**
+ * Determines whether an IPv6 address string must not be fetched. Addresses that
+ * embed an IPv4 address (mapped, translated, IPv4-compatible, NAT64, 6to4) are
+ * unwrapped and classified as IPv4, so an internal destination cannot be reached
+ * by wrapping it in an IPv6 form that looks globally routable.
  */
 function isBlockedIpv6(ip: string): boolean {
   const g = expandIpv6(ip.toLowerCase());
   if (!g || g.some((h) => Number.isNaN(h))) {
     return true; // fail closed on anything we cannot parse
   }
-  // IPv4-mapped (::ffff:a.b.c.d): first 80 bits zero, next 16 bits 0xffff.
-  if (g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0xffff) {
-    const v4 = `${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`;
-    return isBlockedIpv4(v4);
-  }
+  const zeroThrough = (n: number): boolean => g.slice(0, n).every((h) => h === 0);
+
+  // Forms that carry the IPv4 address in the last 32 bits.
+  const embedsIpv4InSuffix =
+    // IPv4-mapped (::ffff:a.b.c.d): first 80 bits zero, next 16 bits 0xffff.
+    (zeroThrough(5) && g[5] === 0xffff) ||
+    // IPv4-translated (::ffff:0:a.b.c.d, ::ffff:0:0/96).
+    (zeroThrough(4) && g[4] === 0xffff && g[5] === 0) ||
+    // NAT64 well-known prefix (64:ff9b::/96), reachable wherever a NAT64
+    // gateway is deployed, e.g. 64:ff9b::169.254.169.254 -> metadata service.
+    (g[0] === 0x0064 &&
+      g[1] === 0xff9b &&
+      g[2] === 0 &&
+      g[3] === 0 &&
+      g[4] === 0 &&
+      g[5] === 0);
+  if (embedsIpv4InSuffix) return isBlockedIpv4(ipv4FromHextets(g[6], g[7]));
+
   if (g.every((h) => h === 0)) return true; // :: unspecified
-  if (g.slice(0, 7).every((h) => h === 0) && g[7] === 1) return true; // ::1 loopback
+  if (zeroThrough(7) && g[7] === 1) return true; // ::1 loopback
   // IPv4-compatible (deprecated ::a.b.c.d, ::/96): first 96 bits zero. Unwrap
   // and classify as IPv4 so forms like ::127.0.0.1 are not treated as public.
-  if (g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0) {
-    const v4 = `${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`;
-    return isBlockedIpv4(v4);
-  }
+  if (zeroThrough(6)) return isBlockedIpv4(ipv4FromHextets(g[6], g[7]));
+  // 6to4 (2002::/16) carries the IPv4 address in bits 16-48 instead.
+  if (g[0] === 0x2002) return isBlockedIpv4(ipv4FromHextets(g[1], g[2]));
+
   const first = g[0];
+  if (first === 0x0064 && g[1] === 0xff9b && g[2] === 0x0001) return true; // 64:ff9b:1::/48 local-use NAT64
+  if (first === 0x0100 && g[1] === 0 && g[2] === 0 && g[3] === 0) return true; // 100::/64 discard-only
+  if (first === 0x2001 && (g[1] & 0xfe00) === 0) return true; // 2001::/23 IETF protocol assignments (incl. Teredo)
+  if (first === 0x2001 && g[1] === 0x0db8) return true; // 2001:db8::/32 documentation
+  if (first === 0x5f00) return true; // 5f00::/16 SRv6 SIDs
   if ((first & 0xfe00) === 0xfc00) return true; // fc00::/7 unique-local
   if ((first & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((first & 0xffc0) === 0xfec0) return true; // fec0::/10 site-local (deprecated, still internal)
   if ((first & 0xff00) === 0xff00) return true; // ff00::/8 multicast
   return false;
 }


### PR DESCRIPTION
## Description

Adds SSRF protection to the `everything` server's `gzip-file-as-resource` tool. The tool fetched a caller-supplied `http`/`https` URL and returned the (compressed) response as a resource. Its only host restriction was an optional domain allowlist (`GZIP_ALLOWED_DOMAINS`) that is empty by default and treated as "all domains allowed", with no IP-range filtering and automatic redirect following. Because the URL is model-produced and prompt-injection-steerable, the server could be driven to fetch loopback, private, link-local, and cloud-metadata endpoints (e.g. `169.254.169.254`) and return their contents to the caller.

## Server Details
- Server: everything (TypeScript, `@modelcontextprotocol/server-everything`)
- Changes to: tools (`gzip-file-as-resource`)

## Motivation and Context
`validateDataURI` allowed `http`/`https`/`data` and enforced only the domain allowlist (skipped entirely when empty), and `fetchSafely` called `fetch(url)` with default redirect following and no loopback/RFC1918/link-local/metadata checks.

What this PR does:
- Adds `assertPublicHost()` plus IPv4/IPv6 classifiers that resolve the destination host and refuse non-public addresses (loopback, private/RFC1918, link-local/metadata, ULA, multicast, reserved, unspecified), covering IPv4, IPv6, and IPv4-mapped IPv6 (including the hex form the WHATWG URL parser normalizes to).
- Replaces automatic redirect following with `fetchWithGuardedRedirects` (`redirect: "manual"`), re-validating the host on every hop and refusing redirects to non-http(s) schemes.
- The IP guard applies **regardless of `GZIP_ALLOWED_DOMAINS`**. The domain-allowlist semantics are intentionally left unchanged (empty still means "all domains"), so the tool's default demo URL keeps working; the allowlist and the SSRF guard are independent controls.

## How Has This Been Tested?
- New unit tests assert the tool refuses non-public hosts (loopback, `169.254.169.254`, RFC1918 ranges, `0.0.0.0`, IPv6 loopback, IPv4-mapped IPv6) via IP literals (no network required).
- `npm run build` (tsc) passes; full `vitest` suite passes (115 tests, including the 8 new cases).
- Existing `data:` URI and public-URL behavior is unchanged and still covered by tests.

## Breaking Changes
No client configuration changes required. Behavior only changes for requests that targeted non-public IPs, which are now refused (the intended fix). `data:` URIs and public URLs are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context
Docs updated in `docs/instructions.md` and `docs/structure.md` to note that internal/metadata IPs are always blocked (and re-validated across redirects) independent of the allowlist. As with any resolve-then-connect guard, a narrow DNS-rebinding window remains; pinning to the validated IP could be added later.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

## Prior art

The `gzip-file-as-resource` tool and its original `GZIP_ALLOWED_DOMAINS` domain-allowlist SSRF mitigation were added in #2831 (@ochafik). This PR builds on that baseline with an IP-range guard that applies independently of the domain allowlist.
