### PR TITLE
docs: clarify Windows launch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,24 @@ Additional examples of using the Claude Desktop as an MCP client might look like
 }
 ```
 
-On Windows, apply the same wrapper to each `npx`-based entry above by changing `"command"` to `"cmd"` and prepending `"/c", "npx"` to the existing `args`. Leave `uvx` entries unchanged.
+On Windows, apply the same wrapper to each `npx`-based entry above by changing `"command"` to `"cmd"` and prepending `"/c", "npx"` to the existing `args`. Keep `npx` in `args` instead of setting `"command"` to the full `npx.cmd` path; this avoids command-path parsing failures when Node.js is installed under `C:\Program Files\nodejs`.
+
+If you need to use the absolute `npx.cmd` path, quote the executable for `cmd`:
+
+```json
+{
+  "command": "cmd",
+  "args": [
+    "/c",
+    "\"C:\\Program Files\\nodejs\\npx.cmd\"",
+    "-y",
+    "@modelcontextprotocol/server-filesystem",
+    "C:\\Users\\username\\Desktop"
+  ]
+}
+```
+
+Leave interactive `uvx` entries unchanged. If a Windows scheduled task or logon-started client fails to launch a `uvx` server from a WinGet shim path such as `%LOCALAPPDATA%\Microsoft\WinGet\Links\uvx.exe`, point `"command"` at the real `uvx.exe` in the WinGet package directory, or install `uv` with an installer that places a normal executable on `PATH`.
 
 ## 🛠️ Creating Your Own Server
 

--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -255,7 +255,7 @@ Note: all directories must be mounted to `/projects` by default.
 }
 ```
 
-On Windows, use `cmd /c` to launch `npx`:
+On Windows, use `cmd /c` to launch `npx`. Keep `npx` in the `args` list as shown below when Node.js is installed in the default `C:\Program Files\nodejs` directory:
 
 ```json
 {

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -128,6 +128,12 @@ Add this to your `claude_desktop_config.json`:
 <details>
 <summary>Using uvx</summary>
 
+On Windows, if this server is launched by a scheduled task at logon and `uvx`
+was installed by WinGet, avoid pointing the task at the WinGet shim under
+`%LOCALAPPDATA%\Microsoft\WinGet\Links`. Use the real `uvx.exe` in the WinGet
+package directory, or install `uv` with an installer that places a normal
+executable on `PATH`.
+
 ```json
 "mcpServers": {
   "git": {


### PR DESCRIPTION
## Summary
- clarify that Windows `npx` MCP configs should keep `npx` in `args` when Node.js is installed under `C:\Program Files\nodejs`
- add an absolute `npx.cmd` example with the executable quoted for `cmd`
- document the WinGet `uvx` shim scheduled-task failure mode and the real-executable workaround

Fixes #4487
Related to #4488

## Validation
- `git diff --check`

## Notes
This is docs-only because the reported failures come from client launch configuration / Windows startup resolution rather than code in this repository.