### PR TITLE
fix(filesystem): add guidance for failed edit matches

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -516,7 +516,9 @@ describe('Lib Functions', () => {
         ];
         
         await expect(applyFileEdits('/test/file.txt', edits, false))
-          .rejects.toThrow('Could not find exact match for edit');
+          .rejects.toThrow(
+            'Use read_file to inspect the exact current content, then retry with oldText copied from the file'
+          );
       });
 
       it('handles complex multi-line edits with indentation', async () => {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -248,7 +248,11 @@ export async function applyFileEdits(
     }
 
     if (!matchFound) {
-      throw new Error(`Could not find exact match for edit:\n${edit.oldText}`);
+      throw new Error(
+        `Could not find exact match for edit:\n${edit.oldText}\n\n` +
+        `This usually means the requested text differs from the file content in whitespace, indentation, or line endings. ` +
+        `Use read_file to inspect the exact current content, then retry with oldText copied from the file.`
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Improves the filesystem server's `edit_file` failure message when an edit cannot be matched. The error now keeps the original failed `oldText` context and adds a short hint to inspect the current file contents with `read_file` before retrying.

## Server Details

- Server: filesystem
- Changes to: `edit_file` error handling and unit tests

## Motivation and Context

When `oldText` does not match the current file contents, the previous error only reported that no exact match was found. Issue #2034 describes this as difficult to recover from when the mismatch is caused by whitespace, indentation, or line-ending differences.

This keeps the edit behavior unchanged and makes the failure easier to act on.

Refs #2034.

## How Has This Been Tested?

- `npm test --workspace @modelcontextprotocol/server-filesystem -- __tests__/lib.test.ts`
- `npm run build --workspace @modelcontextprotocol/server-filesystem`

## Breaking Changes

No breaking changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

The README and environment-variable checklist items are not applicable because this only changes an existing runtime error message and its test coverage.
