### PR TITLE
fix(everything): clarify resource link ID mapping

### DIFF
--- a/src/everything/docs/features.md
+++ b/src/everything/docs/features.md
@@ -12,7 +12,7 @@
 - `echo` (tools/echo.ts): Echoes the provided `message: string`. Uses Zod to validate inputs.
 - `get-annotated-message` (tools/get-annotated-message.ts): Returns a `text` message annotated with `priority` and `audience` based on `messageType` (`error`, `success`, or `debug`); can optionally include an annotated `image`.
 - `get-env` (tools/get-env.ts): Returns all environment variables from the running process as pretty-printed JSON text.
-- `get-resource-links` (tools/get-resource-links.ts): Returns an intro `text` block followed by multiple `resource_link` items. For a requested `count` (1–10), alternates between dynamic Text and Blob resources using URIs from `resources/templates.ts`.
+- `get-resource-links` (tools/get-resource-links.ts): Returns an intro `text` block followed by multiple `resource_link` items. For a requested `count` (1–10), alternates between dynamic Text and Blob resources using URIs from `resources/templates.ts`; odd resource IDs return Blob links, and even resource IDs return Text links.
 - `get-resource-reference` (tools/get-resource-reference.ts): Accepts `resourceType` (`text` or `blob`) and `resourceId` (positive integer). Returns a concrete `resource` content block (with its `uri`, `mimeType`, and data) with surrounding explanatory `text`.
 - `get-roots-list` (tools/get-roots-list.ts): Returns the last list of roots sent by the client.
 - `gzip-file-as-resource` (tools/gzip-file-as-resource.ts): Accepts a `name` and `data` (URL or data URI), fetches the data subject to size/time/domain constraints, compresses it, registers it as a session resource at `demo://resource/session/<name>` with `mimeType: application/gzip`, and returns either a `resource_link` (default) or an inline `resource` depending on `outputType`.

--- a/src/everything/tools/get-resource-links.ts
+++ b/src/everything/tools/get-resource-links.ts
@@ -38,7 +38,7 @@ const config = {
  *
  * The registered tool retrieves a specified number of resource links and their metadata.
  * Resource links are dynamically generated as either text or binary blob resources,
- * based on their ID being even or odd.
+ * with even resource IDs returning text resources and odd resource IDs returning blobs.
 
  * The response contains a "text" introductory block and multiple "resource_link" blocks.
  *
@@ -57,21 +57,21 @@ export const registerGetResourceLinksTool = (server: McpServer) => {
 
     // Create resource link content blocks
     for (let resourceId = 1; resourceId <= count; resourceId++) {
-      // Get resource uri for text or blob resource based on odd/even resourceId
-      const isOdd = resourceId % 2 === 0;
-      const uri = isOdd
+      // Even IDs use text resources; odd IDs use blob resources.
+      const isTextResource = resourceId % 2 === 0;
+      const uri = isTextResource
         ? textResourceUri(resourceId)
         : blobResourceUri(resourceId);
 
       // Get resource based on the resource type
-      const resource = isOdd
+      const resource = isTextResource
         ? textResource(uri, resourceId)
         : blobResource(uri, resourceId);
 
       content.push({
         type: "resource_link",
         uri: resource.uri,
-        name: `${isOdd ? "Text" : "Blob"} Resource ${resourceId}`,
+        name: `${isTextResource ? "Text" : "Blob"} Resource ${resourceId}`,
         description: `Resource ${resourceId}: ${
           resource.mimeType === "text/plain"
             ? "plaintext resource"


### PR DESCRIPTION
## Summary

- Clarify the `get-resource-links` resource ID mapping in the Everything server docs.
- Rename the local boolean so the implementation reads as "even IDs are text, odd IDs are blob" instead of using a misleading `isOdd` name.

## Why

Issue #475 notes that odd/even resource wording can be confusing. The current Everything server uses dynamic `text/{resourceId}` and `blob/{resourceId}` templates; this keeps the existing behavior and documents the mapping used by `get-resource-links`.

## Validation

- `npm test --workspace @modelcontextprotocol/server-everything -- __tests__/tools.test.ts`
- `npm run build --workspace @modelcontextprotocol/server-everything`
- `npx prettier --check src/everything/tools/get-resource-links.ts src/everything/docs/features.md`

## Related issue

Refs #475
