### PR TITLE
docs(filesystem): clarify read_multiple_files input

### DIFF
--- a/src/filesystem/README.md
+++ b/src/filesystem/README.md
@@ -87,7 +87,8 @@ The server's directory access control follows this flow:
 
 - **read_multiple_files**
   - Read multiple files simultaneously
-  - Input: `paths` (string[])
+  - Input: `paths` (non-empty string array of file paths within allowed directories)
+  - Returns each file's content with its path as a reference, separated by `---`
   - Failed reads won't stop the entire operation
 
 - **write_file**


### PR DESCRIPTION
## Summary

- Clarify that `read_multiple_files` expects a non-empty `paths` array.
- Document that each path must be within the allowed directories.
- Note that returned file contents are separated by path references and `---`.

## Why

Issue #2032 reports that the `read_multiple_files` argument shape and behavior were not clear enough from the filesystem server docs. The tool schema already enforces a non-empty array, so this updates the README to match the current schema and output behavior.

## Validation

- `git diff --check`
- `npm run build --workspace @modelcontextprotocol/server-filesystem`

## Related issue

Refs #2032
