### PR TITLE
fix(sequentialthinking): trim duplicative description sections

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -39,35 +39,6 @@ When to use this tool:
 - Tasks that need to maintain context over multiple steps
 - Situations where irrelevant information needs to be filtered out
 
-Key features:
-- You can adjust total_thoughts up or down as you progress
-- You can question or revise previous thoughts
-- You can add more thoughts even after reaching what seemed like the end
-- You can express uncertainty and explore alternative approaches
-- Not every thought needs to build linearly - you can branch or backtrack
-- Generates a solution hypothesis
-- Verifies the hypothesis based on the Chain of Thought steps
-- Repeats the process until satisfied
-- Provides a correct answer
-
-Parameters explained:
-- thought: Your current thinking step, which can include:
-  * Regular analytical steps
-  * Revisions of previous thoughts
-  * Questions about previous decisions
-  * Realizations about needing more analysis
-  * Changes in approach
-  * Hypothesis generation
-  * Hypothesis verification
-- nextThoughtNeeded: True if you need more thinking, even if at what seemed like the end
-- thoughtNumber: Current number in sequence (can go beyond initial total if needed)
-- totalThoughts: Current estimate of thoughts needed (can be adjusted up/down)
-- isRevision: A boolean indicating if this thought revises previous thinking
-- revisesThought: If is_revision is true, which thought number is being reconsidered
-- branchFromThought: If branching, which thought number is the branching point
-- branchId: Identifier for the current branch (if any)
-- needsMoreThoughts: If reaching end but realizing more thoughts needed
-
 You should:
 1. Start with an initial estimate of needed thoughts, but be ready to adjust
 2. Feel free to question or revise previous thoughts


### PR DESCRIPTION
## Description

Trims the `sequentialthinking` tool's description string, removing two sections that add token cost without adding selection or usage signal:

- **"Parameters explained"** duplicated content already carried by each parameter's own `inputSchema` `.describe()` call — clients receive both, so the text was paid for twice per session.
- **"Key features"** described the tool's internal virtues rather than when to call it, and didn't add anything the "When to use this tool" section doesn't already convey.

The intro paragraph, "When to use this tool" (selection signal), and "You should" (behavioral guidance once the tool is invoked) are all kept unchanged.

Fixes #4507

## Server Details
- Server: sequentialthinking
- Changes to: tools (description text only, no schema/behavior change)

## Motivation and Context
Per #4507: the tool definition costs ~921 tokens per session (tiktoken cl100k), about half of which is the description, and roughly half of the description duplicates content the client already receives via the input schema. This trim removes the duplicated/non-selection-relevant text.

## How Has This Been Tested?
- `npm run build` and `npm test` (vitest) both pass, 14/14 tests green — no test asserts on the removed description text.
- Manually diffed the description string before/after to confirm only the "Key features" and "Parameters explained" blocks were removed; input schema, output schema, and tool behavior are untouched.

## Breaking Changes
None — this only changes the human/LLM-facing description string, not the tool's name, schema, or behavior. No client configuration changes required.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly (README doesn't reproduce the tool description; no update needed)
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling (n/a — no new logic added)
- [x] I have documented all environment variables and configuration options (n/a — no new config)

## Additional context
This PR was prepared with AI assistance (Claude Code), grounded by reading the current `upstream/main` source, confirming no existing tests depend on the removed text, and verifying the build/test suite passes after the change.