### PR TITLE
fix(filesystem): write in place to preserve file identity on edits

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import path from 'path';
 import os from 'os';
 import {
@@ -303,10 +304,110 @@ describe('Lib Functions', () => {
     describe('writeFileContent', () => {
       it('writes file content', async () => {
         mockFs.writeFile.mockResolvedValueOnce(undefined);
-        
+
         await writeFileContent('/test/file.txt', 'new content');
-        
+
         expect(mockFs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'new content', { encoding: "utf-8", flag: 'wx' });
+      });
+
+      it('writes in place when the file already exists, preserving its identity', async () => {
+        const mockHandle = {
+          stat: vi.fn().mockResolvedValue({ isFile: () => true }),
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValueOnce(mockHandle);
+        const eexistError = Object.assign(new Error('exists'), { code: 'EEXIST' });
+        mockFs.writeFile.mockRejectedValueOnce(eexistError);
+
+        await writeFileContent('/test/file.txt', 'updated content');
+
+        expect(mockFs.open).toHaveBeenCalledWith('/test/file.txt', fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+        expect(mockHandle.stat).toHaveBeenCalled();
+        expect(mockHandle.truncate).toHaveBeenCalledWith(0);
+        expect(mockHandle.write).toHaveBeenCalledWith('updated content', 0, 'utf-8');
+        expect(mockHandle.close).toHaveBeenCalled();
+        // Should not fall back to the old temp-file+rename strategy
+        expect(mockFs.rename).not.toHaveBeenCalled();
+      });
+
+      it('refuses to write through a non-regular file', async () => {
+        const mockHandle = {
+          stat: vi.fn().mockResolvedValue({ isFile: () => false }),
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValueOnce(mockHandle);
+        const eexistError = Object.assign(new Error('exists'), { code: 'EEXIST' });
+        mockFs.writeFile.mockRejectedValueOnce(eexistError);
+
+        await expect(writeFileContent('/test/file.txt', 'updated content'))
+          .rejects.toThrow('is not a regular file');
+
+        expect(mockHandle.truncate).not.toHaveBeenCalled();
+        expect(mockHandle.write).not.toHaveBeenCalled();
+        expect(mockHandle.close).toHaveBeenCalled();
+      });
+
+      it('closes the file handle even if the write fails', async () => {
+        const mockHandle = {
+          stat: vi.fn().mockResolvedValue({ isFile: () => true }),
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockRejectedValue(new Error('disk full')),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValueOnce(mockHandle);
+        const eexistError = Object.assign(new Error('exists'), { code: 'EEXIST' });
+        mockFs.writeFile.mockRejectedValueOnce(eexistError);
+
+        await expect(writeFileContent('/test/file.txt', 'updated content'))
+          .rejects.toThrow('disk full');
+
+        expect(mockHandle.close).toHaveBeenCalled();
+      });
+
+      it('propagates errors other than EEXIST without attempting in-place write', async () => {
+        const permissionError = Object.assign(new Error('denied'), { code: 'EACCES' });
+        mockFs.writeFile.mockRejectedValueOnce(permissionError);
+
+        await expect(writeFileContent('/test/file.txt', 'new content'))
+          .rejects.toThrow('denied');
+
+        expect(mockFs.open).not.toHaveBeenCalled();
+      });
+
+      describe('on Windows', () => {
+        const originalPlatform = process.platform;
+
+        beforeEach(() => {
+          Object.defineProperty(process, 'platform', { value: 'win32', writable: true, configurable: true });
+        });
+
+        afterEach(() => {
+          Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true, configurable: true });
+        });
+
+        it('falls back to the temp-file+rename strategy instead of O_NOFOLLOW', async () => {
+          const eexistError = Object.assign(new Error('exists'), { code: 'EEXIST' });
+          mockFs.writeFile.mockRejectedValueOnce(eexistError);
+          mockFs.writeFile.mockResolvedValueOnce(undefined);
+          mockFs.rename.mockResolvedValueOnce(undefined);
+
+          await writeFileContent('/test/file.txt', 'updated content');
+
+          expect(mockFs.open).not.toHaveBeenCalled();
+          expect(mockFs.writeFile).toHaveBeenCalledWith(
+            expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+            'updated content',
+            'utf-8'
+          );
+          expect(mockFs.rename).toHaveBeenCalledWith(
+            expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+            '/test/file.txt'
+          );
+        });
       });
     });
 
@@ -413,31 +514,33 @@ describe('Lib Functions', () => {
 
   describe('File Editing Functions', () => {
     describe('applyFileEdits', () => {
+      let mockHandle: { stat: ReturnType<typeof vi.fn>; truncate: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> };
+
       beforeEach(() => {
         mockFs.readFile.mockResolvedValue('line1\nline2\nline3\n');
-        mockFs.writeFile.mockResolvedValue(undefined);
+        mockHandle = {
+          stat: vi.fn().mockResolvedValue({ isFile: () => true }),
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValue(mockHandle);
       });
 
       it('applies simple text replacement', async () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         const result = await applyFileEdits('/test/file.txt', edits, false);
-        
+
         expect(result).toContain('modified line2');
-        // Should write to temporary file then rename
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          'line1\nmodified line2\nline3\n',
-          'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
-        );
+        // Should write in place: open with O_NOFOLLOW, verify regular file, truncate, write, close
+        expect(mockFs.open).toHaveBeenCalledWith('/test/file.txt', fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+        expect(mockHandle.stat).toHaveBeenCalled();
+        expect(mockHandle.truncate).toHaveBeenCalledWith(0);
+        expect(mockHandle.write).toHaveBeenCalledWith('line1\nmodified line2\nline3\n', 0, 'utf-8');
+        expect(mockHandle.close).toHaveBeenCalled();
       });
 
       it('treats dollar signs in replacement text literally', async () => {
@@ -445,13 +548,11 @@ describe('Lib Functions', () => {
           { oldText: 'line2', newText: "price=$$; match=$&; before=$`; after=$'" }
         ];
 
-        mockFs.rename.mockResolvedValueOnce(undefined);
-
         await applyFileEdits('/test/file.txt', edits, false);
 
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+        expect(mockHandle.write).toHaveBeenCalledWith(
           "line1\nprice=$$; match=$&; before=$`; after=$'\nline3\n",
+          0,
           'utf-8'
         );
       });
@@ -460,11 +561,11 @@ describe('Lib Functions', () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
+
         const result = await applyFileEdits('/test/file.txt', edits, true);
-        
+
         expect(result).toContain('modified line2');
-        expect(mockFs.writeFile).not.toHaveBeenCalled();
+        expect(mockFs.open).not.toHaveBeenCalled();
       });
 
       it('applies multiple edits sequentially', async () => {
@@ -472,123 +573,81 @@ describe('Lib Functions', () => {
           { oldText: 'line1', newText: 'first line' },
           { oldText: 'line3', newText: 'third line' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          'first line\nline2\nthird line\n',
-          'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
-        );
+
+        expect(mockHandle.write).toHaveBeenCalledWith('first line\nline2\nthird line\n', 0, 'utf-8');
       });
 
       it('handles whitespace-flexible matching', async () => {
         mockFs.readFile.mockResolvedValue('  line1\n    line2\n  line3\n');
-        
+
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '  line1\n    modified line2\n  line3\n',
-          'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
-        );
+
+        expect(mockHandle.write).toHaveBeenCalledWith('  line1\n    modified line2\n  line3\n', 0, 'utf-8');
       });
 
       it('throws error for non-matching edits', async () => {
         const edits = [
           { oldText: 'nonexistent line', newText: 'replacement' }
         ];
-        
+
         await expect(applyFileEdits('/test/file.txt', edits, false))
           .rejects.toThrow('Could not find exact match for edit');
       });
 
       it('handles complex multi-line edits with indentation', async () => {
         mockFs.readFile.mockResolvedValue('function test() {\n  console.log("hello");\n  return true;\n}');
-        
+
         const edits = [
-          { 
-            oldText: '  console.log("hello");\n  return true;', 
-            newText: '  console.log("world");\n  console.log("test");\n  return false;' 
+          {
+            oldText: '  console.log("hello");\n  return true;',
+            newText: '  console.log("world");\n  console.log("test");\n  return false;'
           }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.js', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
+
+        expect(mockHandle.write).toHaveBeenCalledWith(
           'function test() {\n  console.log("world");\n  console.log("test");\n  return false;\n}',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
-          '/test/file.js'
         );
       });
 
       it('handles edits with different indentation patterns', async () => {
         mockFs.readFile.mockResolvedValue('    if (condition) {\n        doSomething();\n    }');
-        
+
         const edits = [
-          { 
-            oldText: 'doSomething();', 
-            newText: 'doSomethingElse();\n        doAnotherThing();' 
+          {
+            oldText: 'doSomething();',
+            newText: 'doSomethingElse();\n        doAnotherThing();'
           }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.js', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
+
+        expect(mockHandle.write).toHaveBeenCalledWith(
           '    if (condition) {\n        doSomethingElse();\n        doAnotherThing();\n    }',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
-          '/test/file.js'
         );
       });
 
       it('handles CRLF line endings in file content', async () => {
         mockFs.readFile.mockResolvedValue('line1\r\nline2\r\nline3\r\n');
-        
+
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          'line1\nmodified line2\nline3\n',
-          'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
-        );
+
+        expect(mockHandle.write).toHaveBeenCalledWith('line1\nmodified line2\nline3\n', 0, 'utf-8');
       });
     });
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { constants as fsConstants } from "fs";
 import path from "path";
 import os from 'os';
 import { randomBytes } from 'crypto';
@@ -165,22 +166,54 @@ export async function writeFileContent(filePath: string, content: string): Promi
     await fs.writeFile(filePath, content, { encoding: "utf-8", flag: 'wx' });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      // Security: Use atomic rename to prevent race conditions where symlinks
-      // could be created between validation and write. Rename operations
-      // replace the target file atomically and don't follow symlinks.
-      const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
-      try {
-        await fs.writeFile(tempPath, content, 'utf-8');
-        await fs.rename(tempPath, filePath);
-      } catch (renameError) {
-        try {
-          await fs.unlink(tempPath);
-        } catch {}
-        throw renameError;
-      }
+      await writeFileInPlace(filePath, content);
     } else {
       throw error;
     }
+  }
+}
+
+async function writeFileInPlace(filePath: string, content: string): Promise<void> {
+  if (process.platform === 'win32') {
+    // Windows: symlink creation requires elevated privileges by default, so the
+    // TOCTOU threat model differs, and O_NOFOLLOW isn't reliably enforced there.
+    // Keep the rename-based strategy, which trades file-identity preservation for
+    // the platform's stronger symlink guarantees.
+    await writeFileViaRename(filePath, content);
+    return;
+  }
+
+  // Security: O_NOFOLLOW makes the open() call itself fail if filePath resolves to a
+  // symlink, closing the same TOCTOU window a rename-based swap closed, but writing
+  // into the file's existing inode instead of replacing it. This preserves birthtime,
+  // hard links, and inode-based file watches (see #4512), at the cost of the
+  // crash-atomicity and reader-atomicity a rename gave us: a crash mid-write, or a
+  // concurrent read, can observe truncated/partial content.
+  const handle = await fs.open(filePath, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+  try {
+    // Defense in depth: refuse to write through anything that isn't a regular file
+    // (e.g. a FIFO or device node swapped in at this path).
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      throw new Error(`Refusing to write: ${filePath} is not a regular file`);
+    }
+    await handle.truncate(0);
+    await handle.write(content, 0, 'utf-8');
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeFileViaRename(filePath: string, content: string): Promise<void> {
+  const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
+  try {
+    await fs.writeFile(tempPath, content, 'utf-8');
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fs.unlink(tempPath);
+    } catch {}
+    throw error;
   }
 }
 
@@ -263,19 +296,7 @@ export async function applyFileEdits(
   const formattedDiff = `${'`'.repeat(numBackticks)}diff\n${diff}${'`'.repeat(numBackticks)}\n\n`;
 
   if (!dryRun) {
-    // Security: Use atomic rename to prevent race conditions where symlinks
-    // could be created between validation and write. Rename operations
-    // replace the target file atomically and don't follow symlinks.
-    const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
-    try {
-      await fs.writeFile(tempPath, modifiedContent, 'utf-8');
-      await fs.rename(tempPath, filePath);
-    } catch (error) {
-      try {
-        await fs.unlink(tempPath);
-      } catch {}
-      throw error;
-    }
+    await writeFileInPlace(filePath, modifiedContent);
   }
 
   return formattedDiff;


### PR DESCRIPTION
write_file/edit_file used a temp-file+rename strategy for existing files, which replaces the inode on every write and destroys the file's creation time, hard links, and inode-based file watches.

On POSIX, write in place instead: open with O_RDWR | O_NOFOLLOW to keep the same symlink protection the rename gave us, fstat to confirm the target is still a regular file, then truncate and write. This trades away crash-atomicity (a crash mid-write can now leave a truncated file, where rename left the original untouched).

On win32, keep the rename strategy: O_NOFOLLOW isn't reliably enforced there, and symlink creation already requires elevated privileges by default, so the threat model differs.

Fixes #4512

## Description
`write_file`/`edit_file` used a temp-file+rename strategy for existing files, which replaces the inode on every write and destroys the file's creation time, hard links, and inode-based file watches.

On POSIX, write in place instead: open with `O_RDWR | O_NOFOLLOW` to keep the same symlink protection the rename gave us, `fstat` to confirm the target is still a regular file, then truncate and write. This trades away crash-atomicity (a crash mid-write can now leave a truncated file, where rename left the original untouched).

On win32, keep the rename strategy: `O_NOFOLLOW` isn't reliably enforced there, and symlink creation already requires elevated privileges by default, so the threat model differs.

Fixes #4512

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: `filesystem`
- Changes to: tools (`write_file`, `edit_file`)

## Motivation and Context
The server's own `get_file_info` tool reports a file's `birthtime`, but every edit through `write_file`/`edit_file` silently reset it, because the rename-based write replaced the file's inode. This also broke hard links (a link to the file kept pointing at stale pre-edit content) and confused inode-based file watchers, which saw "delete + create" instead of "modify" on every edit.

## How Has This Been Tested?
- `npm run build` passes (typecheck).
- `npm test` passes — 157/157, including new coverage for the EEXIST in-place path, the non-regular-file rejection, and the win32 rename fallback.
- Manually verified on a real filesystem (Linux) that inode and `birthtime` are preserved across an in-place write, and that opening a symlink with `O_NOFOLLOW` correctly fails with `ELOOP`.
- Tested with Claude Code as an MCP client against the built server: registered the local build, ran `edit_file` and `write_file` against a real file with a hard link, and confirmed inode/birthtime stayed constant across edits while the hard link tracked the change.

## Breaking Changes
None. Tool inputs/outputs are unchanged; this only changes the write mechanism on disk. The only observable behavior difference is that crashes mid-write can now leave a truncated file on POSIX, instead of leaving the original untouched.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options