### PR TITLE
fix(filesystem): write in place to preserve birthtime and file identity (#4512)

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -301,12 +301,30 @@ describe('Lib Functions', () => {
     });
 
     describe('writeFileContent', () => {
-      it('writes file content', async () => {
+      it('creates new file with wx flag', async () => {
         mockFs.writeFile.mockResolvedValueOnce(undefined);
-        
+
         await writeFileContent('/test/file.txt', 'new content');
-        
+
         expect(mockFs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'new content', { encoding: "utf-8", flag: 'wx' });
+      });
+
+      it('writes in place when file exists (preserves inode / birthtime)', async () => {
+        const eexist = Object.assign(new Error('EEXIST'), { code: 'EEXIST' });
+        mockFs.writeFile.mockRejectedValueOnce(eexist);
+        const mockFh = {
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValueOnce(mockFh);
+
+        await writeFileContent('/test/file.txt', 'updated');
+
+        expect(mockFs.open).toHaveBeenCalledWith('/test/file.txt', expect.any(Number));
+        expect(mockFh.truncate).toHaveBeenCalledWith(0);
+        expect(mockFh.write).toHaveBeenCalledWith('updated', 0, 'utf-8');
+        expect(mockFh.close).toHaveBeenCalled();
       });
     });
 
@@ -413,31 +431,34 @@ describe('Lib Functions', () => {
 
   describe('File Editing Functions', () => {
     describe('applyFileEdits', () => {
+      let mockFileHandle: any;
+
       beforeEach(() => {
         mockFs.readFile.mockResolvedValue('line1\nline2\nline3\n');
-        mockFs.writeFile.mockResolvedValue(undefined);
+        mockFileHandle = {
+          truncate: vi.fn().mockResolvedValue(undefined),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        mockFs.open.mockResolvedValue(mockFileHandle);
       });
 
       it('applies simple text replacement', async () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         const result = await applyFileEdits('/test/file.txt', edits, false);
-        
+
         expect(result).toContain('modified line2');
-        // Should write to temporary file then rename
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+        expect(mockFs.open).toHaveBeenCalledWith('/test/file.txt', expect.any(Number));
+        expect(mockFileHandle.truncate).toHaveBeenCalledWith(0);
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           'line1\nmodified line2\nline3\n',
+          0,
           'utf-8'
         );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
-        );
+        expect(mockFileHandle.close).toHaveBeenCalled();
       });
 
       it('treats dollar signs in replacement text literally', async () => {
@@ -445,13 +466,11 @@ describe('Lib Functions', () => {
           { oldText: 'line2', newText: "price=$$; match=$&; before=$`; after=$'" }
         ];
 
-        mockFs.rename.mockResolvedValueOnce(undefined);
-
         await applyFileEdits('/test/file.txt', edits, false);
 
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           "line1\nprice=$$; match=$&; before=$`; after=$'\nline3\n",
+          0,
           'utf-8'
         );
       });
@@ -460,11 +479,11 @@ describe('Lib Functions', () => {
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
+
         const result = await applyFileEdits('/test/file.txt', edits, true);
-        
+
         expect(result).toContain('modified line2');
-        expect(mockFs.writeFile).not.toHaveBeenCalled();
+        expect(mockFs.open).not.toHaveBeenCalled();
       });
 
       it('applies multiple edits sequentially', async () => {
@@ -472,41 +491,29 @@ describe('Lib Functions', () => {
           { oldText: 'line1', newText: 'first line' },
           { oldText: 'line3', newText: 'third line' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           'first line\nline2\nthird line\n',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
         );
       });
 
       it('handles whitespace-flexible matching', async () => {
         mockFs.readFile.mockResolvedValue('  line1\n    line2\n  line3\n');
-        
+
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           '  line1\n    modified line2\n  line3\n',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
         );
       });
 
@@ -514,80 +521,62 @@ describe('Lib Functions', () => {
         const edits = [
           { oldText: 'nonexistent line', newText: 'replacement' }
         ];
-        
+
         await expect(applyFileEdits('/test/file.txt', edits, false))
           .rejects.toThrow('Could not find exact match for edit');
       });
 
       it('handles complex multi-line edits with indentation', async () => {
         mockFs.readFile.mockResolvedValue('function test() {\n  console.log("hello");\n  return true;\n}');
-        
+
         const edits = [
-          { 
-            oldText: '  console.log("hello");\n  return true;', 
-            newText: '  console.log("world");\n  console.log("test");\n  return false;' 
+          {
+            oldText: '  console.log("hello");\n  return true;',
+            newText: '  console.log("world");\n  console.log("test");\n  return false;'
           }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.js', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
+
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           'function test() {\n  console.log("world");\n  console.log("test");\n  return false;\n}',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
-          '/test/file.js'
         );
       });
 
       it('handles edits with different indentation patterns', async () => {
         mockFs.readFile.mockResolvedValue('    if (condition) {\n        doSomething();\n    }');
-        
+
         const edits = [
-          { 
-            oldText: 'doSomething();', 
-            newText: 'doSomethingElse();\n        doAnotherThing();' 
+          {
+            oldText: 'doSomething();',
+            newText: 'doSomethingElse();\n        doAnotherThing();'
           }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.js', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
+
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           '    if (condition) {\n        doSomethingElse();\n        doAnotherThing();\n    }',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.js\.[a-f0-9]+\.tmp$/),
-          '/test/file.js'
         );
       });
 
       it('handles CRLF line endings in file content', async () => {
         mockFs.readFile.mockResolvedValue('line1\r\nline2\r\nline3\r\n');
-        
+
         const edits = [
           { oldText: 'line2', newText: 'modified line2' }
         ];
-        
-        mockFs.rename.mockResolvedValueOnce(undefined);
-        
+
         await applyFileEdits('/test/file.txt', edits, false);
-        
-        expect(mockFs.writeFile).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+
+        expect(mockFileHandle.write).toHaveBeenCalledWith(
           'line1\nmodified line2\nline3\n',
+          0,
           'utf-8'
-        );
-        expect(mockFs.rename).toHaveBeenCalledWith(
-          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
-          '/test/file.txt'
         );
       });
     });

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
+import { constants } from 'fs';
 import path from "path";
 import os from 'os';
-import { randomBytes } from 'crypto';
 import { diffLines, createTwoFilesPatch } from 'diff';
 import { minimatch } from 'minimatch';
 import { normalizePath, expandHome } from './path-utils.js';
@@ -165,22 +165,26 @@ export async function writeFileContent(filePath: string, content: string): Promi
     await fs.writeFile(filePath, content, { encoding: "utf-8", flag: 'wx' });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      // Security: Use atomic rename to prevent race conditions where symlinks
-      // could be created between validation and write. Rename operations
-      // replace the target file atomically and don't follow symlinks.
-      const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
-      try {
-        await fs.writeFile(tempPath, content, 'utf-8');
-        await fs.rename(tempPath, filePath);
-      } catch (renameError) {
-        try {
-          await fs.unlink(tempPath);
-        } catch {}
-        throw renameError;
-      }
+      // Security: O_NOFOLLOW rejects symlinks with ELOOP, giving the same
+      // TOCTOU protection the old temp+rename pattern provided. Writing
+      // in place preserves the file's inode, birthtime, and hard links,
+      // which the rename strategy destroyed on every write (#4512).
+      await writeInPlace(filePath, content);
     } else {
       throw error;
     }
+  }
+}
+
+async function writeInPlace(filePath: string, content: string): Promise<void> {
+  // O_NOFOLLOW rejects symlinks (ELOOP), matching the security guarantee of
+  // the old temp+rename pattern without replacing the inode.
+  const fh = await fs.open(filePath, constants.O_RDWR | constants.O_NOFOLLOW);
+  try {
+    await fh.truncate(0);
+    await fh.write(content, 0, 'utf-8');
+  } finally {
+    await fh.close();
   }
 }
 
@@ -263,19 +267,10 @@ export async function applyFileEdits(
   const formattedDiff = `${'`'.repeat(numBackticks)}diff\n${diff}${'`'.repeat(numBackticks)}\n\n`;
 
   if (!dryRun) {
-    // Security: Use atomic rename to prevent race conditions where symlinks
-    // could be created between validation and write. Rename operations
-    // replace the target file atomically and don't follow symlinks.
-    const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
-    try {
-      await fs.writeFile(tempPath, modifiedContent, 'utf-8');
-      await fs.rename(tempPath, filePath);
-    } catch (error) {
-      try {
-        await fs.unlink(tempPath);
-      } catch {}
-      throw error;
-    }
+    // Write in place to preserve the file's inode, birthtime, and hard
+    // links (#4512). O_NOFOLLOW rejects symlinks with ELOOP, maintaining
+    // the same security guarantee the old temp+rename pattern provided.
+    await writeInPlace(filePath, modifiedContent);
   }
 
   return formattedDiff;


### PR DESCRIPTION
## Description

Closes #4512. `write_file` and `edit_file` destroyed the file's creation timestamp (birthtime), severed hard links, and broke inode-based watchers on every write, because the temp-file + `fs.rename` pattern replaces the target's inode.

## Server Details

- Server: `filesystem`
- Changes to: `tools` (`write_file`, `edit_file` write path; no tool schema or API change)

## Motivation and Context

`writeFileContent` and `applyFileEdits` used temp-file + `fs.rename` for existing files. The rename gives crash-atomicity and symlink safety, but it replaces the target with a *different* file, so the creation timestamp goes (`birthtime` on macOS/APFS, creation time on NTFS, `crtime` on ext4), hard links are severed, and anything tracking the file by inode loses it. The server's own `get_file_info` reports `created:` as a first-class field, so destroying it on every write is internally inconsistent.

This also supersedes the workaround in #4115. That fix restored permission bits with a `stat` + `chmod` round-trip after the rename, because the rename had already replaced the inode and the temp file carried default `0644`. Writing in place never replaces the inode, so mode bits survive by construction and the compensating `chmod` is unnecessary on POSIX. #4115's tests are kept, retargeted to assert no rename and no chmod occur. Its `chmod` path is still live and still covered on the win32 branch described below.

## Implementation

The approach set out in #4512:

1. `fs.open(filePath, O_RDWR | O_NOFOLLOW)` rejects symlinks with `ELOOP`, the same protection the rename pattern provided.
2. `fstat` the handle and refuse anything that is not a regular file, so a FIFO or device swapped in after path validation is not written through.
3. `truncate(0)` + `write` through the handle keeps the inode, birthtime, hard links and mode bits.

New files still use the `wx` flag (exclusive create), unchanged.

Windows keeps the temp+rename strategy. `fs.constants.O_NOFOLLOW` does not exist there, so `O_RDWR | O_NOFOLLOW` silently collapses to a plain `O_RDWR` open, which would remove symlink protection while appearing to enforce it. Creating a symlink on Windows already requires elevation, so the existing strategy stays the right default. The platform split lives in one helper, `replaceExistingFile`.

The Windows problem was caught by @ayushbunny11, who raised it on #4512 and implemented the same fix independently in #4515. An earlier revision of this PR had the unconditional `O_NOFOLLOW` open and would have dropped the protection on win32. #4515 has since been closed in favour of this one, with their agreement.

## How Has This Been Tested?

Full filesystem suite: 174 tests, all passing in CI (16/16 checks green on ubuntu). Locally 3 `unicode-paths` tests fail on macOS, and I checked they fail identically on an unpatched `upstream/main` checkout, so that is pre-existing APFS Unicode-normalisation behaviour and unrelated to this change.

New file `src/filesystem/__tests__/write-preserves-identity.test.ts` runs against the real filesystem rather than mocks, because an inode surviving a write is exactly what a mocked `fs` cannot demonstrate. All four cases fail on current `main` and pass here:

| Case | On `main` | Here |
|---|---|---|
| `write_file` keeps inode / birthtime / mode | inode changes | preserved |
| `edit_file` keeps inode / birthtime / mode | inode changes | preserved |
| hard link survives a write | severed | intact |
| symlinked target | silently replaced with a regular file | rejected with `ELOOP` |

That last row is the one I would look at. On current `main` the write succeeds and replaces the symlink with a regular file. The link target is never written to, so the security property holds, but the link itself is destroyed, which is the same loss of file identity this PR exists to stop.

`lib.test.ts` mocks were updated for the `fs.open` + `FileHandle` path, plus new cases for the not-a-regular-file rejection and the win32 fallback.

### End-to-end over the MCP protocol

Beyond the unit tests, I built the server and drove it over stdio JSON-RPC with a minimal MCP client (`initialize`, `notifications/initialized`, then `tools/call`), issuing real `write_file`, `edit_file` and `get_file_info` calls against a file that had a hard link and mode `0755`. Same client, same calls, both branches:

| After `write_file` + `edit_file` | `upstream/main` | This PR |
|---|---|---|
| inode preserved | no | yes |
| birthtime preserved | no | yes |
| mode `0755` preserved | yes (via #4115's chmod) | yes (natively) |
| hard link sees the edit | no, `"original content"` | yes, `"edited via MCP"` |

The hard-link row is what a user actually hits: on `main` the link is left pointing at the old inode with stale content, so one file quietly becomes two divergent files.

## Breaking Changes

No configuration or client changes required. One behavioural change needs a maintainer's call: in-place writes lose crash-atomicity on POSIX, so a crash mid-write leaves a truncated file rather than an untouched one. For this server's use case, an agent writing text files rather than a database, identity preservation seems the better default. If crash-atomicity is considered essential I am happy to put the strategy behind an opt-in flag instead.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly. No README change needed; no tool schema, argument or configuration is affected.
- [x] I have tested this with an MCP client. See "End-to-end over the MCP protocol" above: stdio JSON-RPC `initialize` then `tools/call`, not unit tests alone.
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options. None added.
