### PR TITLE
[Security] Path validation bypass on Windows via NTFS Alternate Data Streams (ADS) in secure-filesystem-server

### DIFF
--- a/src/filesystem/path-validation.ts
+++ b/src/filesystem/path-validation.ts
@@ -32,6 +32,18 @@ export function isPathWithinAllowedDirectories(absolutePath: string, allowedDire
     return false;
   }
 
+  // Reject Windows Alternate Data Streams (ADS) to prevent path validation bypasses
+  if (process.platform === 'win32' || path.sep === '\\') {
+    const firstColonIndex = normalizedPath.indexOf(':');
+    if (firstColonIndex !== -1) {
+      const hasMoreThanOneColon = normalizedPath.indexOf(':', firstColonIndex + 1) !== -1;
+      const isValidDriveColon = firstColonIndex === 1 && /^[A-Za-z]$/.test(normalizedPath[0]);
+      if (hasMoreThanOneColon || !isValidDriveColon) {
+        return false;
+      }
+    }
+  }
+
   // Verify it's absolute after normalization
   if (!path.isAbsolute(normalizedPath)) {
     throw new Error('Path must be absolute after normalization');


### PR DESCRIPTION
A path validation bypass vulnerability has been identified on Windows environments within the secure-filesystem-server. The isPathWithinAllowedDirectories function fails to restrict NTFS Alternate Data Streams (ADS). As a result, an attacker can supply paths containing a colon separator (e.g., file.txt:payload.exe), which bypasses directory boundary checks and allows reading or writing hidden data directly to NTFS alternate streams within allowed folders

<!-- Provide a brief description of your changes -->

## Description
This change introduces validation to reject paths containing NTFS Alternate Data Streams (ADS) on Windows platforms. It inspects the normalized path in `isPathWithinAllowedDirectories` and blocks paths that contain unexpected colons (`:`) beyond the standard Windows drive letter prefix (e.g., `C:`).

## Publishing Your Server

**Note: We are no longer accepting PRs to add servers to the README.** Instead, please publish your server to the [MCP Server Registry](https://github.com/modelcontextprotocol/registry) to make it discoverable to the MCP ecosystem.

To publish your server, follow the [quickstart guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx). You can browse published servers at [https://registry.modelcontextprotocol.io/](https://registry.modelcontextprotocol.io/).

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: filesystem
- Changes to: path-validation.ts (internally used by all filesystem tools)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
On Windows machines using NTFS, files can have alternate data streams using the `filename:streamname` syntax. The existing validation normalized the path and verified the directory prefix (e.g., `normalizedPath.startsWith(normalizedDir + path.sep)`). 

However, since `path.resolve` and `path.normalize` on Windows preserve the `:` separator, a path like `C:\allowed\dir\safe.txt:payload.exe` would start with the allowed directory prefix and bypass validation. When used in file reads or writes, Node.js and Windows would access the alternate stream instead of a regular file. This fix solves this bypass by validating and rejecting any unexpected colons on Windows, while preserving full compatibility with Linux/Unix platforms where colons are valid characters in filenames.

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->
Tested the function `isPathWithinAllowedDirectories` with the following test cases:
- Windows absolute paths (e.g., `C:\allowed\dir\file.txt`) -> Allowed
- Windows paths with Alternate Data Streams (e.g., `C:\allowed\dir\file.txt:payload.exe`) -> Rejected
- Windows paths with multiple colons (e.g., `C:\allowed\dir\file.txt:stream1:stream2`) -> Rejected
- Standard Linux paths with colons (e.g., `/allowed/dir/file.txt:with:colons`) -> Allowed (retaining compatibility)

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->
None. This is a non-breaking security fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The fix specifically isolates Windows platforms (`process.platform === 'win32' || path.sep === '\\'`) to prevent breaking compatibility on POSIX systems where colons are valid file system characters.