### PR TITLE
fix(git): correct field misalignment in date-filtered git_log

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -169,7 +169,7 @@ def git_log(repo: git.Repo, max_count: int = 10, start_timestamp: Optional[str] 
             args.extend(['--since', start_timestamp])
         if end_timestamp:
             args.extend(['--until', end_timestamp])
-        args.extend(['--format=%H%n%an%n%ad%n%s%n'])
+        args.extend(['--format=%H%n%an%n%ad%n%s'])
 
         log_output = repo.git.log(*args).split('\n')
 

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -234,6 +234,38 @@ def test_git_log_default(test_repository):
     assert len(result) >= 1
     assert "initial commit" in result[0]
 
+def test_git_log_with_timestamp_filter(test_repository):
+    """Date-filtered git_log must map fields correctly for every commit, not
+    just the first. Regression for a trailing ``%n`` in the pretty-format that
+    emitted a blank line per commit, shifting every commit after the first by
+    one field (the hash showed up under ``Author:``, the date under
+    ``Message:``, and a commit could be dropped)."""
+    for i in range(3):
+        file_path = Path(test_repository.working_dir) / f"ts_log_{i}.txt"
+        file_path.write_text(f"content {i}")
+        test_repository.index.add([f"ts_log_{i}.txt"])
+        test_repository.index.commit(f"timestamped commit {i}")
+
+    # initial commit + 3 new commits all fall after this floor
+    result = git_log(test_repository, max_count=10, start_timestamp="2000-01-01")
+
+    assert isinstance(result, list)
+    assert len(result) == 4
+
+    messages = []
+    for entry in result:
+        lines = entry.splitlines()
+        assert lines[0].startswith("Commit: ")
+        assert lines[1].startswith("Author: ")
+        assert lines[2].startswith("Date: ")
+        assert lines[3].startswith("Message: ")
+        messages.append(lines[3][len("Message: "):])
+
+    # Under the bug these messages land in the wrong field for commits 2..n.
+    assert "timestamped commit 2" in messages
+    assert "timestamped commit 1" in messages
+    assert "initial commit" in messages
+
 def test_git_create_branch(test_repository):
     result = git_create_branch(test_repository, "new-feature-branch")
 


### PR DESCRIPTION
## Problem

`git_log`'s date-filtered branch parses `git log` output into fixed groups of 4 lines (hash, author, date, subject), but the pretty-format string ends with a trailing `%n`:

```python
args.extend(['--format=%H%n%an%n%ad%n%s%n'])
```

That trailing `%n` makes git emit a **blank line after every commit**, so each record occupies **5** slots after `.split('\n')` while the loop advances by **4**. Only the first commit lands on a correct boundary. Every commit after it is shifted by one field, and a commit can be dropped or a spurious blank entry emitted.

Concretely, for a repo with an "initial commit" plus a few filtered commits, the second entry comes back as:

```
Commit: <author name>
Author: <date string>
Date:   initial commit
Message:
```

The unfiltered branch (`iter_commits`, used when no `start_timestamp`/`end_timestamp` is given) is correct and unaffected, which is why this went unnoticed.

## Fix

Drop the trailing `%n` so each record is exactly 4 lines and the group-of-4 parser stays aligned:

```python
args.extend(['--format=%H%n%an%n%ad%n%s'])
```

`%s` is the commit subject (first line only), so every field is guaranteed single-line and the 4-line grouping is safe.

## Test

Adds `test_git_log_with_timestamp_filter`, which filters by `start_timestamp` and asserts every commit's fields map correctly across multiple commits. It fails on the old format (returns 5 entries with shifted fields) and passes with the fix. Full git-server suite: **44 passed**.
