### PR TITLE
docs(everything): fix markdown formatting and instructions file references

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -113,7 +113,7 @@ npm run start:streamableHttp
 ### Install 
 ```shell
 npm install -g @modelcontextprotocol/server-everything@latest
-````
+```
 
 ### Run the default (stdio) server
 ```shell

--- a/src/everything/docs/startup.md
+++ b/src/everything/docs/startup.md
@@ -54,7 +54,7 @@
     - `prompts: {}`
     - `resources: { subscribe: true }`
   - **Server Instructions**
-    - Loaded from the docs folder (`server-instructions.md`).
+    - Loaded from the docs folder (`instructions.md`).
   - **Registrations**
     - Registers **tools** via `registerTools(server)`.
     - Registers **resources** via `registerResources(server)`.

--- a/src/everything/docs/structure.md
+++ b/src/everything/docs/structure.md
@@ -85,9 +85,19 @@ src/everything
 ### `docs/`
 
 - `architecture.md`
-  - This document.
+  - Describes the server architecture, including transport layers, session initialization, and primitive registration.
+- `extension.md`
+  - Explains how to extend the server with new tools, prompts, resources, or transports.
+- `features.md`
+  - A comprehensive reference listing all implemented prompts, resources, tools, and protocol behaviors.
+- `how-it-works.md`
+  - Explains how SSE and Streamable HTTP transports are set up and how sessions are managed.
 - `instructions.md`
   - Human‑readable instructions intended to be passed to the client/LLM as guidance on server use. Loaded by the server at startup and returned in the initialize exchange.
+- `startup.md`
+  - Describes the server startup sequence, environment checks, and initialization.
+- `structure.md`
+  - This document.
 
 ### `prompts/`
 


### PR DESCRIPTION
## Summary

Fixes malformed shell code block formatting in `src/everything/README.md` and corrects the references to the server instructions filename from `server-instructions.md` to `instructions.md` in `startup.md` and `structure.md`. Also updates `structure.md` to document all files in the `docs` directory and fix the self-referential description on `architecture.md`.

Closes #4096.

## Test Plan

- Inspected all edited markdown files (`README.md`, `startup.md`, `structure.md`) visually.
- Verified that all file paths and references are correct and render cleanly.