### PR TITLE
test(everything): cover tool annotations during registration

### DIFF
--- a/src/everything/__tests__/registrations.test.ts
+++ b/src/everything/__tests__/registrations.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, it, expect, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Create mock server
 function createMockServer() {
@@ -16,10 +16,21 @@ function createMockServer() {
   } as unknown as McpServer;
 }
 
-describe('Registration Index Files', () => {
-  describe('tools/index.ts', () => {
-    it('should register all standard tools', async () => {
-      const { registerTools } = await import('../tools/index.js');
+function expectToolAnnotations(config: any) {
+  expect(config.annotations).toEqual(
+    expect.objectContaining({
+      readOnlyHint: expect.any(Boolean),
+      destructiveHint: expect.any(Boolean),
+      idempotentHint: expect.any(Boolean),
+      openWorldHint: expect.any(Boolean),
+    })
+  );
+}
+
+describe("Registration Index Files", () => {
+  describe("tools/index.ts", () => {
+    it("should register all standard tools", async () => {
+      const { registerTools } = await import("../tools/index.js");
       const mockServer = createMockServer();
 
       registerTools(mockServer);
@@ -31,22 +42,33 @@ describe('Registration Index Files', () => {
       const registeredTools = (mockServer.registerTool as any).mock.calls.map(
         (call: any[]) => call[0]
       );
-      expect(registeredTools).toContain('echo');
-      expect(registeredTools).toContain('get-sum');
-      expect(registeredTools).toContain('get-env');
-      expect(registeredTools).toContain('get-tiny-image');
-      expect(registeredTools).toContain('get-structured-content');
-      expect(registeredTools).toContain('get-annotated-message');
-      expect(registeredTools).toContain('trigger-long-running-operation');
-      expect(registeredTools).toContain('get-resource-links');
-      expect(registeredTools).toContain('get-resource-reference');
-      expect(registeredTools).toContain('gzip-file-as-resource');
-      expect(registeredTools).toContain('toggle-simulated-logging');
-      expect(registeredTools).toContain('toggle-subscriber-updates');
+      expect(registeredTools).toContain("echo");
+      expect(registeredTools).toContain("get-sum");
+      expect(registeredTools).toContain("get-env");
+      expect(registeredTools).toContain("get-tiny-image");
+      expect(registeredTools).toContain("get-structured-content");
+      expect(registeredTools).toContain("get-annotated-message");
+      expect(registeredTools).toContain("trigger-long-running-operation");
+      expect(registeredTools).toContain("get-resource-links");
+      expect(registeredTools).toContain("get-resource-reference");
+      expect(registeredTools).toContain("gzip-file-as-resource");
+      expect(registeredTools).toContain("toggle-simulated-logging");
+      expect(registeredTools).toContain("toggle-subscriber-updates");
     });
 
-    it('should register conditional tools based on capabilities', async () => {
-      const { registerConditionalTools } = await import('../tools/index.js');
+    it("should register annotations for all standard tools", async () => {
+      const { registerTools } = await import("../tools/index.js");
+      const mockServer = createMockServer();
+
+      registerTools(mockServer);
+
+      for (const [, config] of (mockServer.registerTool as any).mock.calls) {
+        expectToolAnnotations(config);
+      }
+    });
+
+    it("should register conditional tools based on capabilities", async () => {
+      const { registerConditionalTools } = await import("../tools/index.js");
 
       // Server with all capabilities including experimental tasks API
       const mockServerWithCapabilities = {
@@ -75,17 +97,52 @@ describe('Registration Index Files', () => {
       const registeredTools = (
         mockServerWithCapabilities.registerTool as any
       ).mock.calls.map((call: any[]) => call[0]);
-      expect(registeredTools).toContain('get-roots-list');
-      expect(registeredTools).toContain('trigger-elicitation-request');
-      expect(registeredTools).toContain('trigger-url-elicitation');
-      expect(registeredTools).toContain('trigger-sampling-request');
+      expect(registeredTools).toContain("get-roots-list");
+      expect(registeredTools).toContain("trigger-elicitation-request");
+      expect(registeredTools).toContain("trigger-url-elicitation");
+      expect(registeredTools).toContain("trigger-sampling-request");
 
       // Task-based tools are registered via experimental.tasks.registerToolTask
-      expect(mockServerWithCapabilities.experimental.tasks.registerToolTask).toHaveBeenCalled();
+      expect(
+        mockServerWithCapabilities.experimental.tasks.registerToolTask
+      ).toHaveBeenCalled();
     });
 
-    it('should not register conditional tools when capabilities missing', async () => {
-      const { registerConditionalTools } = await import('../tools/index.js');
+    it("should register annotations for all conditional tools", async () => {
+      const { registerConditionalTools } = await import("../tools/index.js");
+
+      const mockServerWithCapabilities = {
+        registerTool: vi.fn(),
+        server: {
+          getClientCapabilities: vi.fn(() => ({
+            roots: {},
+            elicitation: { url: {} },
+            sampling: {},
+          })),
+        },
+        experimental: {
+          tasks: {
+            registerToolTask: vi.fn(),
+          },
+        },
+      } as unknown as McpServer;
+
+      registerConditionalTools(mockServerWithCapabilities);
+
+      for (const [, config] of (mockServerWithCapabilities.registerTool as any)
+        .mock.calls) {
+        expectToolAnnotations(config);
+      }
+
+      for (const [, config] of (
+        mockServerWithCapabilities.experimental.tasks.registerToolTask as any
+      ).mock.calls) {
+        expectToolAnnotations(config);
+      }
+    });
+
+    it("should not register conditional tools when capabilities missing", async () => {
+      const { registerConditionalTools } = await import("../tools/index.js");
 
       const mockServerNoCapabilities = {
         registerTool: vi.fn(),
@@ -106,9 +163,9 @@ describe('Registration Index Files', () => {
     });
   });
 
-  describe('prompts/index.ts', () => {
-    it('should register all prompts', async () => {
-      const { registerPrompts } = await import('../prompts/index.js');
+  describe("prompts/index.ts", () => {
+    it("should register all prompts", async () => {
+      const { registerPrompts } = await import("../prompts/index.js");
       const mockServer = createMockServer();
 
       registerPrompts(mockServer);
@@ -116,39 +173,39 @@ describe('Registration Index Files', () => {
       // Should register 4 prompts
       expect(mockServer.registerPrompt).toHaveBeenCalledTimes(4);
 
-      const registeredPrompts = (mockServer.registerPrompt as any).mock.calls.map(
-        (call: any[]) => call[0]
-      );
-      expect(registeredPrompts).toContain('simple-prompt');
-      expect(registeredPrompts).toContain('args-prompt');
-      expect(registeredPrompts).toContain('completable-prompt');
-      expect(registeredPrompts).toContain('resource-prompt');
+      const registeredPrompts = (
+        mockServer.registerPrompt as any
+      ).mock.calls.map((call: any[]) => call[0]);
+      expect(registeredPrompts).toContain("simple-prompt");
+      expect(registeredPrompts).toContain("args-prompt");
+      expect(registeredPrompts).toContain("completable-prompt");
+      expect(registeredPrompts).toContain("resource-prompt");
     });
   });
 
-  describe('resources/index.ts', () => {
-    it('should register resource templates', async () => {
-      const { registerResources } = await import('../resources/index.js');
+  describe("resources/index.ts", () => {
+    it("should register resource templates", async () => {
+      const { registerResources } = await import("../resources/index.js");
       const mockServer = createMockServer();
 
       registerResources(mockServer);
 
       // Should register at least the 2 resource templates (text and blob) plus file resources
       expect(mockServer.registerResource).toHaveBeenCalled();
-      const registeredResources = (mockServer.registerResource as any).mock.calls.map(
-        (call: any[]) => call[0]
-      );
-      expect(registeredResources).toContain('Dynamic Text Resource');
-      expect(registeredResources).toContain('Dynamic Blob Resource');
+      const registeredResources = (
+        mockServer.registerResource as any
+      ).mock.calls.map((call: any[]) => call[0]);
+      expect(registeredResources).toContain("Dynamic Text Resource");
+      expect(registeredResources).toContain("Dynamic Blob Resource");
     });
 
-    it('should read instructions from file', async () => {
-      const { readInstructions } = await import('../resources/index.js');
+    it("should read instructions from file", async () => {
+      const { readInstructions } = await import("../resources/index.js");
 
       const instructions = readInstructions();
 
       // Should return a string (either content or error message)
-      expect(typeof instructions).toBe('string');
+      expect(typeof instructions).toBe("string");
       expect(instructions.length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
## Description

Adds regression coverage for tool annotations in the Everything reference server registration tests.

The Everything server already demonstrates `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` across its tools. This change makes that contract explicit in tests so future tool additions or refactors do not accidentally drop those annotations from standard, conditional, or task-based tool registrations.

## Publishing Your Server

Not applicable. This modifies an existing reference server test.

## Server Details

- Server: Everything
- Changes to: tests

## Motivation and Context

Tool annotations are an important part of how MCP clients can reason about tool behavior before invocation. The Everything server is a reference implementation, so keeping annotation coverage explicit helps it remain a reliable example for client and server implementers.

## How Has This Been Tested?

- `npm test --workspace @modelcontextprotocol/server-everything -- __tests__/registrations.test.ts`
- `npm test --workspace @modelcontextprotocol/server-everything`
- `npm run build --workspace @modelcontextprotocol/server-everything`
- `git diff --check`

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

No runtime behavior changes. This only adds regression assertions around existing registration metadata.
