### PR TITLE
fix(git): handle non-UTF-8 bytes in git_show

### DIFF
--- a/src/git/src/mcp_server_git/server.py
+++ b/src/git/src/mcp_server_git/server.py
@@ -244,7 +244,10 @@ def git_show(repo: git.Repo, revision: str) -> str:
         if d.diff is None:
             continue
         if isinstance(d.diff, bytes):
-            output.append(d.diff.decode('utf-8'))
+            # Git diffs can contain arbitrary file bytes. Replace malformed
+            # UTF-8 sequences so one binary file cannot make the whole result
+            # fail with UnicodeDecodeError.
+            output.append(d.diff.decode('utf-8', errors='replace'))
         else:
             output.append(d.diff)
     return "".join(output)

--- a/src/git/tests/test_server.py
+++ b/src/git/tests/test_server.py
@@ -277,6 +277,18 @@ def test_git_show_initial_commit(test_repository):
     assert "initial commit" in result
     assert "test.txt" in result
 
+def test_git_show_handles_non_utf8_diff(test_repository):
+    file_path = Path(test_repository.working_dir) / "binary.bin"
+    file_path.write_bytes(b"hello\xffworld\n")
+    test_repository.index.add(["binary.bin"])
+    commit = test_repository.index.commit("binary diff commit")
+
+    result = git_show(test_repository, commit.hexsha)
+
+    assert "binary diff commit" in result
+    assert "binary.bin" in result
+    assert "hello\ufffdworld" in result
+
 
 # Tests for validate_repo_path (repository scoping security fix)
 


### PR DESCRIPTION
## Description

Make the Git server's `git_show` robust to valid commits whose patch contains bytes that are not valid UTF-8. Decode replacement bytes instead of failing the complete result with `UnicodeDecodeError`.

## Root cause

The Git server strictly decoded GitPython patch bytes as UTF-8. One invalid byte could discard the complete patch result, including otherwise useful commit metadata.

## Testing

- Focused `git_show_handles_non_utf8_diff` assertion passed.
- `uv run ruff check` passed.
- `uv run pyright` passed.
- `uv build` passed.
- The full Python module produced 44 passed test bodies plus 38 existing Windows fixture-teardown errors from open GitPython handles; this is not presented as a green full-suite result.
- LLM-client integration was not exercised; tests call the Git server implementation directly.

This is an ordinary correctness/robustness fix, not a security report. Hosted POSIX CI is recommended to remove the Windows-only fixture teardown noise. Maintainer review remains pending.