### PR TITLE
fix(time): correct invalid IANA timezone example in convert_time description

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -165,7 +165,7 @@ async def serve(local_timezone: str | None = None) -> None:
                         },
                         "target_timezone": {
                             "type": "string",
-                            "description": f"Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/San_Francisco'). Use '{local_tz}' as local timezone if no target timezone provided by the user.",
+                            "description": f"Target IANA timezone name (e.g., 'Asia/Tokyo', 'America/Los_Angeles'). Use '{local_tz}' as local timezone if no target timezone provided by the user.",
                         },
                     },
                     "required": ["source_timezone", "time", "target_timezone"],


### PR DESCRIPTION
## Problem

The `convert_time` tool's `target_timezone` parameter description uses `'America/San_Francisco'` as an example. This is **not a valid IANA timezone identifier** — the tz database has no such key (San Francisco uses `'America/Los_Angeles'`).

```python
>>> from zoneinfo import ZoneInfo
>>> ZoneInfo('America/San_Francisco')
ZoneInfoNotFoundError: No time zone found with key America/San_Francisco
```

## Impact

LLM clients consuming this description as a usage hint tend to copy example values verbatim. Passing `'America/San_Francisco'` causes the server to reject the call with `INVALID_PARAMS`, surprising the user.

## Fix

Replace the example with the valid `'America/Los_Angeles'` identifier. This also brings `target_timezone` in line with the `source_timezone` description, which already correctly uses `'America/New_York'` / `'Europe/London'`.

## Verification

- No test asserts on the description text (grep'd `San_Francisco` across `src/time/test/` — only the production code uses it).
- One-line change, no logic affected.