### PR TITLE
fix(memory, sequentialthinking, filesystem): declare zod as a dependency (#4330)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,7 +3835,8 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^8.0.3",
         "glob": "^10.5.0",
-        "minimatch": "^10.0.1"
+        "minimatch": "^10.0.1",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-filesystem": "dist/index.js"
@@ -3855,7 +3856,8 @@
       "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-memory": "dist/index.js"
@@ -3875,7 +3877,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"

--- a/src/filesystem/__tests__/dependencies.test.ts
+++ b/src/filesystem/__tests__/dependencies.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { builtinModules } from 'module';
+
+/**
+ * Guards against phantom dependencies: modules that are imported by the shipped
+ * source but not declared in package.json. Such imports resolve by accident
+ * under npm's hoisted node_modules layout, then fail at startup for anyone
+ * using a strict layout (pnpm, yarn PnP) with ERR_MODULE_NOT_FOUND.
+ */
+describe('declared dependencies', () => {
+  const packageDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+  const packageJson = JSON.parse(
+    readFileSync(path.join(packageDir, 'package.json'), 'utf-8')
+  ) as { dependencies?: Record<string, string> };
+
+  // Source files that get compiled into dist/, i.e. everything except tests and configs.
+  const sourceFiles = readdirSync(packageDir)
+    .filter((file) => file.endsWith('.ts'))
+    .filter((file) => !file.endsWith('.test.ts') && file !== 'vitest.config.ts');
+
+  const IMPORT_PATTERN = /(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+  /** Reduces a specifier like `zod/v4` or `@scope/pkg/sub` to its package name. */
+  const toPackageName = (specifier: string): string => {
+    const segments = specifier.split('/');
+    return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+  };
+
+  const isBareSpecifier = (specifier: string): boolean =>
+    !specifier.startsWith('.') &&
+    !specifier.startsWith('node:') &&
+    !builtinModules.includes(toPackageName(specifier));
+
+  it('finds source files to check', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sourceFiles)('%s imports only declared packages', (file) => {
+    const contents = readFileSync(path.join(packageDir, file), 'utf-8');
+    const declared = Object.keys(packageJson.dependencies ?? {});
+
+    const imported = new Set<string>();
+    for (const match of contents.matchAll(IMPORT_PATTERN)) {
+      const specifier = match[1] ?? match[2];
+      if (specifier && isBareSpecifier(specifier)) {
+        imported.add(toPackageName(specifier));
+      }
+    }
+
+    expect(declared).toEqual(expect.arrayContaining([...imported]));
+  });
+});

--- a/src/filesystem/package.json
+++ b/src/filesystem/package.json
@@ -28,7 +28,8 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^8.0.3",
     "glob": "^10.5.0",
-    "minimatch": "^10.0.1"
+    "minimatch": "^10.0.1",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",

--- a/src/memory/__tests__/dependencies.test.ts
+++ b/src/memory/__tests__/dependencies.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { builtinModules } from 'module';
+
+/**
+ * Guards against phantom dependencies: modules that are imported by the shipped
+ * source but not declared in package.json. Such imports resolve by accident
+ * under npm's hoisted node_modules layout, then fail at startup for anyone
+ * using a strict layout (pnpm, yarn PnP) with ERR_MODULE_NOT_FOUND.
+ */
+describe('declared dependencies', () => {
+  const packageDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+  const packageJson = JSON.parse(
+    readFileSync(path.join(packageDir, 'package.json'), 'utf-8')
+  ) as { dependencies?: Record<string, string> };
+
+  // Source files that get compiled into dist/, i.e. everything except tests and configs.
+  const sourceFiles = readdirSync(packageDir)
+    .filter((file) => file.endsWith('.ts'))
+    .filter((file) => !file.endsWith('.test.ts') && file !== 'vitest.config.ts');
+
+  const IMPORT_PATTERN = /(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+  /** Reduces a specifier like `zod/v4` or `@scope/pkg/sub` to its package name. */
+  const toPackageName = (specifier: string): string => {
+    const segments = specifier.split('/');
+    return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+  };
+
+  const isBareSpecifier = (specifier: string): boolean =>
+    !specifier.startsWith('.') &&
+    !specifier.startsWith('node:') &&
+    !builtinModules.includes(toPackageName(specifier));
+
+  it('finds source files to check', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sourceFiles)('%s imports only declared packages', (file) => {
+    const contents = readFileSync(path.join(packageDir, file), 'utf-8');
+    const declared = Object.keys(packageJson.dependencies ?? {});
+
+    const imported = new Set<string>();
+    for (const match of contents.matchAll(IMPORT_PATTERN)) {
+      const specifier = match[1] ?? match[2];
+      if (specifier && isBareSpecifier(specifier)) {
+        imported.add(toPackageName(specifier));
+      }
+    }
+
+    expect(declared).toEqual(expect.arrayContaining([...imported]));
+  });
+});

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/__tests__/dependencies.test.ts
+++ b/src/sequentialthinking/__tests__/dependencies.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { builtinModules } from 'module';
+
+/**
+ * Guards against phantom dependencies: modules that are imported by the shipped
+ * source but not declared in package.json. Such imports resolve by accident
+ * under npm's hoisted node_modules layout, then fail at startup for anyone
+ * using a strict layout (pnpm, yarn PnP) with ERR_MODULE_NOT_FOUND.
+ */
+describe('declared dependencies', () => {
+  const packageDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+  const packageJson = JSON.parse(
+    readFileSync(path.join(packageDir, 'package.json'), 'utf-8')
+  ) as { dependencies?: Record<string, string> };
+
+  // Source files that get compiled into dist/, i.e. everything except tests and configs.
+  const sourceFiles = readdirSync(packageDir)
+    .filter((file) => file.endsWith('.ts'))
+    .filter((file) => !file.endsWith('.test.ts') && file !== 'vitest.config.ts');
+
+  const IMPORT_PATTERN = /(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+  /** Reduces a specifier like `zod/v4` or `@scope/pkg/sub` to its package name. */
+  const toPackageName = (specifier: string): string => {
+    const segments = specifier.split('/');
+    return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+  };
+
+  const isBareSpecifier = (specifier: string): boolean =>
+    !specifier.startsWith('.') &&
+    !specifier.startsWith('node:') &&
+    !builtinModules.includes(toPackageName(specifier));
+
+  it('finds source files to check', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sourceFiles)('%s imports only declared packages', (file) => {
+    const contents = readFileSync(path.join(packageDir, file), 'utf-8');
+    const declared = Object.keys(packageJson.dependencies ?? {});
+
+    const imported = new Set<string>();
+    for (const match of contents.matchAll(IMPORT_PATTERN)) {
+      const specifier = match[1] ?? match[2];
+      if (specifier && isBareSpecifier(specifier)) {
+        imported.add(toPackageName(specifier));
+      }
+    }
+
+    expect(declared).toEqual(expect.arrayContaining([...imported]));
+  });
+});

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Description

`memory`, `sequentialthinking` and `filesystem` all `import { z } from "zod"` but none of them declared `zod` in `package.json`. This PR declares it, and adds a regression test so a phantom dependency cannot silently return.

Fixes #4330.

## Server Details

- Server: `memory`, `sequentialthinking`, `filesystem`
- Changes to: `package.json` dependencies (+ tests). No tool, resource, or prompt behaviour changes.

## Motivation and Context

Each of the three servers imports `zod` directly:

| Server | Import |
|---|---|
| memory | `src/memory/index.ts:6` |
| sequentialthinking | `src/sequentialthinking/index.ts:5` |
| filesystem | `src/filesystem/index.ts:13` |

None declared it. The import resolves only by accident: `@modelcontextprotocol/sdk` depends on `zod`, and npm's hoisted `node_modules` layout happens to place it somewhere these packages can reach. That is a phantom dependency — it works until the layout changes.

Under a strict layout (pnpm without hoisting, yarn PnP) it is not reachable, and the servers die on startup. Reproduced against the current published packages:

```console
$ cat .npmrc
node-linker=isolated
hoist=false

$ pnpm add @modelcontextprotocol/server-memory \
           @modelcontextprotocol/server-sequential-thinking \
           @modelcontextprotocol/server-filesystem

$ node node_modules/@modelcontextprotocol/server-memory/dist/index.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod' imported from
  .../@modelcontextprotocol/server-memory/dist/index.js
```

All three fail identically. The issue reports `memory` and `sequentialthinking`; `filesystem` has the same defect and is included here.

Note this is not only a strict-layout concern. The SDK's zod range is `^3.25 || ^4.0`, so even under npm the servers silently bind to whichever major the SDK happens to hoist — a future SDK release could flip that under them.

### Why `^4.0.0`

- It matches the `everything` server, the one TS server that already declared `zod`, so the repo stays consistent.
- It sits inside the SDK's `^3.25 || ^4.0` peer range, so `zod` still dedupes to **one** instance shared with the SDK. That matters: two zod copies would make schemas built here unrecognisable to the SDK's `instanceof` checks. Verified after the fix — a single `zod@4.4.3` is installed and linked.

## How Has This Been Tested?

**Reproduction, before and after.** Packed all three servers from this branch and installed the tarballs into a clean project using the same strict config that fails above (`node-linker=isolated`, `hoist=false`):

```console
$ node node_modules/@modelcontextprotocol/server-memory/dist/index.js
Knowledge Graph MCP Server running on stdio
$ node node_modules/@modelcontextprotocol/server-sequential-thinking/dist/index.js
Sequential Thinking MCP Server running on stdio
$ node node_modules/@modelcontextprotocol/server-filesystem/dist/index.js .
Secure MCP Filesystem Server running on stdio
```

All three now start over stdio where all three previously aborted.

**Regression test.** Each package gets `__tests__/dependencies.test.ts`, which scans the sources that compile into `dist/` for bare import specifiers and asserts each is declared in `dependencies` (relative paths and Node builtins are skipped, deep/scoped specifiers reduce to the package name). Confirmed it actually catches the bug by removing `zod` from `src/memory/package.json` and re-running:

```console
AssertionError: expected [ '@modelcontextprotocol/sdk' ] to deeply equal ArrayContaining{…}
- ArrayContaining [
+ [
    "@modelcontextprotocol/sdk",
-   "zod",
  ]
```

It is written with vitest, per CONTRIBUTING.md.

**Suites and build.** `npm ci` from a clean tree (so the lockfile is verified the way CI installs it), `npm run build`, then per-package `npm test`:

| Server | Result |
|---|---|
| memory | 4 files, 52 tests passed |
| sequentialthinking | 2 files, 17 tests passed |
| filesystem | 8 files, 158 tests passed |

`tsc --noEmit` is clean for all three.

**Not tested with an LLM client.** This change adds no tools and alters no schemas or behaviour — the servers either start or they do not, which is what the reproduction above covers end to end. Happy to run a client check if you would like one anyway.

## Breaking Changes

None. No client configuration changes. Existing installs on hoisted npm layouts are unaffected, since they already resolve to the same zod v4 — the declaration just makes that guaranteed instead of incidental.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly — not applicable, no user-facing configuration or behaviour change
- [ ] I have tested this with an LLM client — see the note above; verified by launching each server over stdio under the layout that reproduces the bug
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options — not applicable, none added

## Additional context

`package-lock.json` is regenerated to record the new declarations for the three workspaces; validated with a clean `npm ci`.

The regression test is duplicated per package rather than shared from a common helper, since each server is published standalone and its `tsconfig.json` sets `rootDir` to the package directory — reaching outside it would break the build. Tests are already excluded from compilation via `**/*.test.ts`, so nothing new ships in `dist/`.

Worth noting the same class of bug is easy to reintroduce elsewhere; the test is deliberately generic, so dropping it into another server would guard that one too.
