### PR TITLE
refactor(time): remove unused TimeConversionInput model

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -32,12 +32,6 @@ class TimeConversionResult(BaseModel):
     time_difference: str
 
 
-class TimeConversionInput(BaseModel):
-    source_tz: str
-    time: str
-    target_tz_list: list[str]
-
-
 def get_local_tz(local_tz_override: str | None = None) -> ZoneInfo:
     if local_tz_override:
         return ZoneInfo(local_tz_override)


### PR DESCRIPTION
## Summary

The `TimeConversionInput` pydantic model (`source_tz`, `time`, `target_tz_list`) is defined but never used anywhere in the codebase. The actual `convert_time` method uses plain parameters:

```python
def convert_time(self, source_tz: str, time_str: str, target_tz: str) -> TimeConversionResult:
```

This is dead code left over from a past refactor.

## Why

Unused code is a maintenance burden and a source of confusion: a reader might assume `TimeConversionInput` is the canonical input shape for `convert_time`, when in fact the real signature uses three separate `str` parameters.

## Verification

Ran the existing test suite locally — all tests pass:

```
$ cd src/time && uv run pytest test/ -v
============================== 38 passed in 1.06s ==============================
```

## Changes

- Removed the unused `TimeConversionInput` class (4 lines + surrounding blank lines).

No behavioral change.