### PR TITLE
Add Trends MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,5 @@ If you find MCP servers useful, please consider starring the repository and cont
 ---
 
 Managed by Anthropic, but built together with the community. The Model Context Protocol is open source and we encourage everyone to contribute their own servers and improvements!
+
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Live cross-platform trend data (Google, YouTube, TikTok, Reddit, Amazon, and more). Free key at https://trendsmcp.ai


### PR DESCRIPTION
﻿Adds [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP): live cross-platform trend data for AI agents across Google, YouTube, TikTok, Reddit, Amazon, Wikipedia, news, npm, Steam, and more.

Free API key at https://trendsmcp.ai
