### PR TITLE
fix: read memory version from package.json, add missing zod deps

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,7 +4,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs, readFileSync } from 'fs';
+import { promises as fs } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,16 +4,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs, readFileSync } from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PACKAGE_VERSION: string = JSON.parse(
-  readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")
-).version;
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const PACKAGE_VERSION: string = require('../package.json').version;
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,9 +4,16 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs } from 'fs';
+import { promises as fs, readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_VERSION: string = JSON.parse(
+  readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")
+).version;
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -256,7 +263,7 @@ const RelationSchema = z.object({
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: PACKAGE_VERSION,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,8 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs } from 'node:fs';
-import { readFileSync } from 'node:fs';
+import { promises as fs, readFileSync } from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { promises as fs, readFileSync } from 'node:fs';
+import { promises as fs, readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/src/memory/package.json
+++ b/src/memory/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
Fixes #4406, fixes #4330.

Two small fixes:

1. **memory server version** — reads `serverInfo.version` from `package.json` at startup instead of hardcoding `"0.6.3"`, so it stays in sync with the published package version.

2. **missing zod dependency** — `zod` is imported at runtime by both `server-memory` and `server-sequential-thinking` but was only available transitively through `@modelcontextprotocol/sdk`. With strict package managers (pnpm), this causes `ERR_MODULE_NOT_FOUND` at startup. Added `zod: "^3"` to both `dependencies`.