### PR TITLE
fix(filesystem): note allowed-directories scope on read_file

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -214,7 +214,7 @@ server.registerTool(
   "read_file",
   {
     title: "Read File (Deprecated)",
-    description: "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead.",
+    description: "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead. Only works within allowed directories.",
     inputSchema: ReadTextFileArgsSchema.shape,
     outputSchema: { content: z.string() },
     annotations: { readOnlyHint: true, openWorldHint: false }


### PR DESCRIPTION
## What

Adds the access-boundary sentence to `read_file`'s description in the filesystem
server, matching every other tool it ships with.

```diff
-    description: "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead.",
+    description: "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead. Only works within allowed directories.",
```

## Why

All 14 filesystem tools end their description with **"Only works within allowed
directories."** — except `read_file`, the deprecated alias:

| Tool | States the boundary |
| --- | --- |
| `read_file` | **no** |
| `read_text_file`, `read_media_file`, `read_multiple_files`, `write_file`, `edit_file`, `create_directory`, `list_directory`, `list_directory_with_sizes`, `directory_tree`, `move_file`, `search_files`, `get_file_info`, `list_allowed_directories` | yes |

`read_file` is registered with `ReadTextFileArgsSchema.shape` and dispatches to
`readTextFileHandler` — the same schema and the same handler as
`read_text_file`. The boundary is therefore enforced identically; the two differ
only in how they are described.

**This is a documentation gap, not a security issue.** Path validation is
unchanged and works correctly. Nothing here suggests unrestricted access.

It's worth fixing because the description is the part an LLM agent reasons over
when selecting a tool. `read_text_file` tells the model it is constrained to
allowed directories; its alias, backed by the identical code path, does not — so
the same operation is presented to the model two different ways. Restating the
constraint costs one sentence and removes the discrepancy.

## Notes

- One-line change to a string literal; no behaviour, schema, or handler changes.
- No test asserts this string (it appears exactly once in the tree).
- Consistent with the recent metadata tidy-up in #4480, which brought
  `openWorldHint` into line across the same tool set.

<sub>Found while auditing MCP tool definitions for description/behaviour drift.
Prepared with assistance from Claude.</sub>
