### PR TITLE
fix(time): cap mcp dependency below 2.0

### DIFF
--- a/src/time/pyproject.toml
+++ b/src/time/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "mcp>=1.23.0",
+    "mcp>=1.23.0,<2",
     "pydantic>=2.0.0",
     "tzdata>=2024.2",
     "tzlocal>=5.3.1",

--- a/src/time/test/time_server_test.py
+++ b/src/time/test/time_server_test.py
@@ -1,9 +1,15 @@
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11 (.python-version is 3.10)
+    import tomli as tomllib
+from pathlib import Path
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
 from mcp.shared.exceptions import McpError
+from packaging.requirements import Requirement
 import pytest
-from unittest.mock import patch
-from zoneinfo import ZoneInfo
 
 from mcp_server_time.server import TimeServer, get_local_tz
 
@@ -526,3 +532,28 @@ def test_get_local_tz_various_timezones(mock_get_localzone, timezone_name):
     result = get_local_tz()
     assert str(result) == timezone_name
     assert isinstance(result, ZoneInfo)
+
+
+class TestDeclaredDependencies:
+    """Tests for the dependencies declared in pyproject.toml."""
+
+    def test_mcp_requirement_excludes_2x(self):
+        """Test that the mcp requirement admits 1.x but excludes 2.x.
+
+        mcp 2.0.0 renamed McpError to MCPError, so server.py fails to import
+        against it. Without an upper bound, unpinned launchers such as uvx
+        resolve 2.x and the server dies on startup.
+
+        A rename-only alias is not a safe fix either: MCPError's constructor
+        also changed (ErrorData -> code/message), so we cap below 2 instead.
+        """
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with pyproject.open("rb") as f:
+            dependencies = tomllib.load(f)["project"]["dependencies"]
+
+        requirements = [Requirement(dep) for dep in dependencies]
+        mcp_requirement = next(req for req in requirements if req.name == "mcp")
+
+        assert mcp_requirement.specifier.contains("1.23.0")
+        assert mcp_requirement.specifier.contains("1.29.0")
+        assert not mcp_requirement.specifier.contains("2.0.0")

--- a/src/time/uv.lock
+++ b/src/time/uv.lock
@@ -362,7 +362,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "tzdata", specifier = ">=2024.2" },
     { name = "tzlocal", specifier = ">=5.3.1" },


### PR DESCRIPTION
Fixes #4570

`mcp` 2.0.0 renamed `McpError` to `MCPError`, so `server.py` raises `ImportError` at module import and the process exits before any MCP handshake. `src/time/pyproject.toml` declared `mcp>=1.23.0` with no upper bound, so unpinned launchers like `uvx` started resolving 2.0.0 as soon as it shipped.

This caps the dependency at `mcp>=1.23.0,<2` and regenerates `uv.lock`. Resolution stays on the 1.x line (fresh install resolves `mcp==1.29.0`); only the recorded specifier moves.

I deliberately did not add an alias import. In 2.0.0 the constructor changed too (`MCPError(ErrorData(...))` → `MCPError(code, message, data=None)`), and the `@server.list_tools()` / `@server.call_tool()` decorator API was removed. An alias would import cleanly and then fail later. The real 2.x migration is a separate job (same shape as fetch #4565 / git #4564).

Also adds a regression test that parses `pyproject.toml` and asserts the declared `mcp` specifier admits 1.23.0 / 1.29.0 but not 2.0.0. `packaging` already comes in with pytest; `tomllib`/`tomli` handles `.python-version` 3.10.

## Motivation and Context
Unpinned `uvx mcp-server-time` is broken for every user as of the SDK 2.0.0 release. Same class of failure as #4560 / #4563 for fetch.

## How Has This Been Tested?
- Reproduced the exact `McpError` → `MCPError` ImportError with `mcp==2.0.0`
- Confirmed the new test fails before the cap and passes after
- `uv run pytest` in `src/time` — 39 passed
- `uv run ruff check` and `uv run pyright` clean; `uv lock --check` clean
- Fresh unpinned install of the patched package resolves `mcp==1.29.0`, import succeeds, and a real stdio `initialize` + `list_tools` returns `get_current_time` / `convert_time`

This patch does not make time work on mcp 2.x — it only stops 2.x from being selected.

## Server Details
- Server: time
- Changes to: dependency bound + lockfile + regression test

## Breaking Changes
None. Users stay on mcp 1.x, which is what the published server was built against.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have tested this with an LLM client (stdio initialize / list_tools smoke)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
