### PR TITLE
Fix time server MCP error compatibility

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -9,7 +9,11 @@ from tzlocal import get_localzone_name  # ← returns "Europe/Paris", etc.
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import Tool, ToolAnnotations, TextContent, ImageContent, EmbeddedResource, ErrorData, INVALID_PARAMS
-from mcp.shared.exceptions import McpError
+try:
+    from mcp.shared.exceptions import MCPError
+except ImportError:
+    # Fallback for older versions of the mcp SDK
+    from mcp.shared.exceptions import McpError as MCPError
 
 from pydantic import BaseModel
 
@@ -54,7 +58,11 @@ def get_zoneinfo(timezone_name: str) -> ZoneInfo:
     try:
         return ZoneInfo(timezone_name)
     except Exception as e:
-        raise McpError(ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone: {str(e)}"))
+        error_data = ErrorData(code=INVALID_PARAMS, message=f"Invalid timezone: {str(e)}")
+        try:
+            raise MCPError(INVALID_PARAMS, error_data.message, error_data)
+        except TypeError:
+            raise MCPError(error_data)
 
 
 class TimeServer:

--- a/src/time/test/time_server_test.py
+++ b/src/time/test/time_server_test.py
@@ -1,9 +1,13 @@
 
 from freezegun import freeze_time
-from mcp.shared.exceptions import McpError
 import pytest
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
+
+try:
+    from mcp.shared.exceptions import MCPError
+except ImportError:
+    from mcp.shared.exceptions import McpError as MCPError
 
 from mcp_server_time.server import TimeServer, get_local_tz
 
@@ -85,7 +89,7 @@ def test_get_current_time(test_time, timezone, expected):
 def test_get_current_time_with_invalid_timezone():
     time_server = TimeServer()
     with pytest.raises(
-        McpError,
+        MCPError,
         match=r"Invalid timezone: 'No time zone found with key Invalid/Timezone'",
     ):
         time_server.get_current_time("Invalid/Timezone")
@@ -116,7 +120,7 @@ def test_get_current_time_with_invalid_timezone():
 )
 def test_convert_time_errors(source_tz, time_str, target_tz, expected_error):
     time_server = TimeServer()
-    with pytest.raises((McpError, ValueError), match=expected_error):
+    with pytest.raises((MCPError, ValueError), match=expected_error):
         time_server.convert_time(source_tz, time_str, target_tz)
 
 


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

## Description

## Publishing Your Server

**Note: We are no longer accepting PRs to add servers to the README.** Instead, please publish your server to the [MCP Server Registry](https://github.com/modelcontextprotocol/registry) to make it discoverable to the MCP ecosystem.

To publish your server, follow the [quickstart guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx). You can browse published servers at [https://registry.modelcontextprotocol.io/](https://registry.modelcontextprotocol.io/).

## Server Details
<!-- If modifying an existing server, provide details -->
- Server: <!-- e.g., filesystem, github -->
- Changes to: <!-- e.g., tools, resources, prompts -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this with an LLM client? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their MCP client configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [ ] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
