### PR TITLE
docs(time): correct example tool responses to match server output

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -218,6 +218,7 @@ Response:
 {
   "timezone": "Europe/Warsaw",
   "datetime": "2024-01-01T13:00:00+01:00",
+  "day_of_week": "Monday",
   "is_dst": false
 }
 ```
@@ -238,15 +239,17 @@ Response:
 {
   "source": {
     "timezone": "America/New_York",
-    "datetime": "2024-01-01T12:30:00-05:00",
+    "datetime": "2024-01-01T16:30:00-05:00",
+    "day_of_week": "Monday",
     "is_dst": false
   },
   "target": {
     "timezone": "Asia/Tokyo",
-    "datetime": "2024-01-01T12:30:00+09:00",
+    "datetime": "2024-01-02T06:30:00+09:00",
+    "day_of_week": "Tuesday",
     "is_dst": false
   },
-  "time_difference": "+13.0h",
+  "time_difference": "+14.0h"
 }
 ```
 


### PR DESCRIPTION
## What

The `get_current_time` and `convert_time` example responses in `src/time/README.md` don't match what the server actually returns. Corrected them against `src/time/src/mcp_server_time/server.py`.

## Corrections

**`get_current_time`** and **`convert_time`** both omitted `day_of_week`, which `TimeResult` always includes (`server.py` populates it via `strftime("%A")`).

**`convert_time`** (input `source=America/New_York`, `time=16:30`, `target=Asia/Tokyo`):
- `source.datetime` showed `12:30`; the requested time is `16:30`, and the server builds it from the parsed hour/minute → `2024-01-01T16:30:00-05:00`.
- `target.datetime` showed `2024-01-01T12:30:00+09:00`; `target = source.astimezone(Asia/Tokyo)` is +14h → next day, `2024-01-02T06:30:00+09:00`.
- `time_difference` showed `+13.0h`; `(+09:00) − (−05:00)` is 14 hours → `+14.0h`.
- the response object had a trailing comma, which is invalid JSON.

Resulting `time_difference`, offsets, and day-of-week are now internally consistent (Mon → Tue rollover).

## Note

PR #4142 removes only the trailing comma on the `time_difference` line while keeping the incorrect `+13.0h`; this PR also fixes the value and the other example inaccuracies, so it covers that change too.
