### PR TITLE
Fix: TS server version drift

### DIFF
--- a/src/everything/__tests__/version.test.ts
+++ b/src/everything/__tests__/version.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolvePackageVersion } from '../version.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+const readFileSyncMock = vi.mocked(readFileSync);
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
+const fsError = (code: string) => Object.assign(new Error(code), { code });
+
+beforeEach(() => {
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+});
+
+describe('resolvePackageVersion', () => {
+  it('reports the version from package.json', () => {
+    expect(resolvePackageVersion()).toBe(version);
+  });
+
+  it('does not fall back while the manifest is readable', () => {
+    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  });
+
+  it('falls back when no manifest is found', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
+  });
+
+  it('falls back to 0.0.0-dev by default', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion()).toBe('0.0.0-dev');
+  });
+
+  it('checks the parent directory, covering the dist/ layout', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOENT');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+
+    expect(resolvePackageVersion()).toBe('9.9.9');
+  });
+
+  it('treats ENOTDIR as a missing manifest', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOTDIR');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
+
+    expect(resolvePackageVersion()).toBe('8.8.8');
+  });
+
+  it('skips a manifest that has no version field', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
+      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+
+    expect(resolvePackageVersion()).toBe('7.7.7');
+  });
+
+  it('stops searching at the package root', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    resolvePackageVersion();
+
+    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors other than a missing manifest', () => {
+    const denied = fsError('EACCES');
+    readFileSyncMock.mockImplementation(() => {
+      throw denied;
+    });
+
+    expect(() => resolvePackageVersion()).toThrow(denied);
+  });
+
+  it('propagates a malformed manifest', () => {
+    readFileSyncMock.mockImplementation(() => '{ "version": ');
+
+    expect(() => resolvePackageVersion()).toThrow(SyntaxError);
+  });
+});

--- a/src/everything/__tests__/version.test.ts
+++ b/src/everything/__tests__/version.test.ts
@@ -1,26 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion } from '../version.js';
+import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>();
+  return { ...actual, createRequire: vi.fn(actual.createRequire) };
 });
 
-const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
-const readFileSyncMock = vi.mocked(readFileSync);
+const actualModule = await vi.importActual<typeof import('node:module')>('node:module');
+const createRequireMock = vi.mocked(createRequire);
 
-const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
 
-/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
-const fsError = (code: string) => Object.assign(new Error(code), { code });
+/** A `require` that fails to find a module carries this code; anything else is a real failure. */
+const moduleNotFound = () =>
+  Object.assign(new Error('Cannot find module'), { code: 'MODULE_NOT_FOUND' });
+
+/** Stands in for the `require` returned by createRequire, driven by `impl`. */
+const stubRequire = (impl: (id: string) => unknown) =>
+  impl as unknown as ReturnType<typeof createRequire>;
 
 beforeEach(() => {
-  readFileSyncMock.mockReset();
-  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+  createRequireMock.mockReset();
+  createRequireMock.mockImplementation(actualModule.createRequire);
 });
 
 describe('resolvePackageVersion', () => {
@@ -28,75 +34,65 @@ describe('resolvePackageVersion', () => {
     expect(resolvePackageVersion()).toBe(version);
   });
 
-  it('does not fall back while the manifest is readable', () => {
-    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  it('exposes the resolved version as SERVER_VERSION', () => {
+    expect(SERVER_VERSION).toBe(version);
   });
 
-  it('falls back when no manifest is found', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
-  });
-
-  it('falls back to 0.0.0-dev by default', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion()).toBe('0.0.0-dev');
-  });
-
-  it('checks the parent directory, covering the dist/ layout', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOENT');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+  it('falls through to the parent directory, covering the dist/ layout', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        if (seen.length === 1) throw moduleNotFound();
+        return { version: '9.9.9' };
+      }),
+    );
 
     expect(resolvePackageVersion()).toBe('9.9.9');
-  });
-
-  it('treats ENOTDIR as a missing manifest', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOTDIR');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
-
-    expect(resolvePackageVersion()).toBe('8.8.8');
+    expect(seen).toHaveLength(2);
   });
 
   it('skips a manifest that has no version field', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
-      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+    let call = 0;
+    createRequireMock.mockReturnValue(
+      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
+    );
 
     expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
-  it('stops searching at the package root', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
+  it('throws when no manifest is found, without searching past the package root', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        throw moduleNotFound();
+      }),
+    );
 
-    resolvePackageVersion();
-
-    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(() => resolvePackageVersion()).toThrow(
+      'Could not locate package.json for server version',
+    );
+    expect(seen).toHaveLength(2);
   });
 
   it('propagates errors other than a missing manifest', () => {
-    const denied = fsError('EACCES');
-    readFileSyncMock.mockImplementation(() => {
-      throw denied;
-    });
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw denied;
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(denied);
   });
 
-  it('propagates a malformed manifest', () => {
-    readFileSyncMock.mockImplementation(() => '{ "version": ');
+  it('propagates a malformed manifest instead of reporting it as missing', () => {
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw new SyntaxError('Unexpected end of JSON input');
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });

--- a/src/everything/__tests__/version.test.ts
+++ b/src/everything/__tests__/version.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { resolvePackageVersion } from '../version.js';
 
 vi.mock('node:module', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:module')>();
@@ -32,33 +34,6 @@ beforeEach(() => {
 describe('resolvePackageVersion', () => {
   it('reports the version from package.json', () => {
     expect(resolvePackageVersion()).toBe(version);
-  });
-
-  it('exposes the resolved version as SERVER_VERSION', () => {
-    expect(SERVER_VERSION).toBe(version);
-  });
-
-  it('falls through to the parent directory, covering the dist/ layout', () => {
-    const seen: string[] = [];
-    createRequireMock.mockReturnValue(
-      stubRequire((id) => {
-        seen.push(id);
-        if (seen.length === 1) throw moduleNotFound();
-        return { version: '9.9.9' };
-      }),
-    );
-
-    expect(resolvePackageVersion()).toBe('9.9.9');
-    expect(seen).toHaveLength(2);
-  });
-
-  it('skips a manifest that has no version field', () => {
-    let call = 0;
-    createRequireMock.mockReturnValue(
-      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
-    );
-
-    expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
   it('throws when no manifest is found, without searching past the package root', () => {
@@ -96,4 +71,36 @@ describe('resolvePackageVersion', () => {
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });
+});
+
+// The cases above drive the resolver directly; these exercise the real build.
+// They skip when dist/ is absent so an unbuilt tree still passes.
+const distVersionPath = path.join(packageRoot, 'dist', 'version.js');
+const distIndexPath = path.join(packageRoot, 'dist', 'index.js');
+
+describe('built output', () => {
+  it.skipIf(!existsSync(distVersionPath))(
+    'resolves package.json from the dist layout after build',
+    async () => {
+      const dist = await import(/* @vite-ignore */ pathToFileURL(distVersionPath).href);
+
+      expect(dist.SERVER_VERSION).toBe(version);
+    },
+  );
+
+  it.skipIf(!existsSync(distIndexPath))(
+    'stdio initialize reports package.json version in serverInfo',
+    async () => {
+      const client = new Client({ name: 'version-test', version: '1.0.0' }, { capabilities: {} });
+      await client.connect(
+        new StdioClientTransport({ command: process.execPath, args: [distIndexPath] }),
+      );
+
+      try {
+        expect(client.getServerVersion()?.version).toBe(version);
+      } finally {
+        await client.close();
+      }
+    },
+  );
 });

--- a/src/everything/server/index.ts
+++ b/src/everything/server/index.ts
@@ -12,6 +12,7 @@ import { registerResources, readInstructions } from "../resources/index.js";
 import { registerPrompts } from "../prompts/index.js";
 import { stopSimulatedLogging } from "./logging.js";
 import { syncRoots } from "./roots.js";
+import { resolvePackageVersion } from "../version.js";
 
 // Server Factory response
 export type ServerFactoryResponse = {
@@ -47,7 +48,7 @@ export const createServer: () => ServerFactoryResponse = () => {
     {
       name: "mcp-servers/everything",
       title: "Everything Reference Server",
-      version: "2.0.0",
+      version: resolvePackageVersion(),
     },
     {
       capabilities: {

--- a/src/everything/server/index.ts
+++ b/src/everything/server/index.ts
@@ -12,7 +12,7 @@ import { registerResources, readInstructions } from "../resources/index.js";
 import { registerPrompts } from "../prompts/index.js";
 import { stopSimulatedLogging } from "./logging.js";
 import { syncRoots } from "./roots.js";
-import { resolvePackageVersion } from "../version.js";
+import { SERVER_VERSION } from "../version.js";
 
 // Server Factory response
 export type ServerFactoryResponse = {
@@ -48,7 +48,7 @@ export const createServer: () => ServerFactoryResponse = () => {
     {
       name: "mcp-servers/everything",
       title: "Everything Reference Server",
-      version: resolvePackageVersion(),
+      version: SERVER_VERSION,
     },
     {
       capabilities: {

--- a/src/everything/version.ts
+++ b/src/everything/version.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Only "manifest isn't here" is skippable; other errors propagate. */
+const isMissingFile = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+};
+
+/**
+ * Reads this package's version from package.json. release.py stamps the version
+ * at release time, so a literal in source is always stale.
+ */
+export const resolvePackageVersion = (fallback = "0.0.0-dev"): string => {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+  // Manifest sits alongside this module from source, one level up from dist/.
+  for (const dir of [moduleDir, dirname(moduleDir)]) {
+    let manifest: string;
+    try {
+      manifest = readFileSync(join(dir, "package.json"), "utf8");
+    } catch (error) {
+      if (isMissingFile(error)) continue;
+      throw error;
+    }
+
+    const { version } = JSON.parse(manifest);
+    if (typeof version === "string") return version;
+  }
+
+  return fallback;
+};

--- a/src/everything/version.ts
+++ b/src/everything/version.ts
@@ -1,33 +1,36 @@
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-/** Only "manifest isn't here" is skippable; other errors propagate. */
-const isMissingFile = (error: unknown): boolean => {
-  const code = (error as NodeJS.ErrnoException)?.code;
-  return code === "ENOENT" || code === "ENOTDIR";
-};
-
 /**
- * Reads this package's version from package.json. release.py stamps the version
- * at release time, so a literal in source is always stale.
+ * Resolve this package's version from package.json.
+ *
+ * Works both from source (`src/everything/`) and from the published
+ * layout (`dist/`), where package.json lives one directory up.
  */
-export const resolvePackageVersion = (fallback = "0.0.0-dev"): string => {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
+export function resolvePackageVersion(): string {
+  const require = createRequire(import.meta.url);
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(moduleDir, "package.json"),
+    path.join(moduleDir, "..", "package.json"),
+  ];
 
-  // Manifest sits alongside this module from source, one level up from dist/.
-  for (const dir of [moduleDir, dirname(moduleDir)]) {
-    let manifest: string;
+  for (const candidate of candidates) {
     try {
-      manifest = readFileSync(join(dir, "package.json"), "utf8");
+      const pkg = require(candidate) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
     } catch (error) {
-      if (isMissingFile(error)) continue;
-      throw error;
+      // Only a missing manifest is skippable; a corrupt or unreadable one is a real failure.
+      if ((error as NodeJS.ErrnoException)?.code !== "MODULE_NOT_FOUND") {
+        throw error;
+      }
     }
-
-    const { version } = JSON.parse(manifest);
-    if (typeof version === "string") return version;
   }
 
-  return fallback;
-};
+  throw new Error("Could not locate package.json for server version");
+}
+
+export const SERVER_VERSION = resolvePackageVersion();

--- a/src/filesystem/__tests__/version.test.ts
+++ b/src/filesystem/__tests__/version.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolvePackageVersion } from '../version.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+const readFileSyncMock = vi.mocked(readFileSync);
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
+const fsError = (code: string) => Object.assign(new Error(code), { code });
+
+beforeEach(() => {
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+});
+
+describe('resolvePackageVersion', () => {
+  it('reports the version from package.json', () => {
+    expect(resolvePackageVersion()).toBe(version);
+  });
+
+  it('does not fall back while the manifest is readable', () => {
+    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  });
+
+  it('falls back when no manifest is found', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
+  });
+
+  it('falls back to 0.0.0-dev by default', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion()).toBe('0.0.0-dev');
+  });
+
+  it('checks the parent directory, covering the dist/ layout', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOENT');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+
+    expect(resolvePackageVersion()).toBe('9.9.9');
+  });
+
+  it('treats ENOTDIR as a missing manifest', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOTDIR');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
+
+    expect(resolvePackageVersion()).toBe('8.8.8');
+  });
+
+  it('skips a manifest that has no version field', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
+      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+
+    expect(resolvePackageVersion()).toBe('7.7.7');
+  });
+
+  it('stops searching at the package root', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    resolvePackageVersion();
+
+    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors other than a missing manifest', () => {
+    const denied = fsError('EACCES');
+    readFileSyncMock.mockImplementation(() => {
+      throw denied;
+    });
+
+    expect(() => resolvePackageVersion()).toThrow(denied);
+  });
+
+  it('propagates a malformed manifest', () => {
+    readFileSyncMock.mockImplementation(() => '{ "version": ');
+
+    expect(() => resolvePackageVersion()).toThrow(SyntaxError);
+  });
+});

--- a/src/filesystem/__tests__/version.test.ts
+++ b/src/filesystem/__tests__/version.test.ts
@@ -1,26 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion } from '../version.js';
+import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>();
+  return { ...actual, createRequire: vi.fn(actual.createRequire) };
 });
 
-const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
-const readFileSyncMock = vi.mocked(readFileSync);
+const actualModule = await vi.importActual<typeof import('node:module')>('node:module');
+const createRequireMock = vi.mocked(createRequire);
 
-const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
 
-/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
-const fsError = (code: string) => Object.assign(new Error(code), { code });
+/** A `require` that fails to find a module carries this code; anything else is a real failure. */
+const moduleNotFound = () =>
+  Object.assign(new Error('Cannot find module'), { code: 'MODULE_NOT_FOUND' });
+
+/** Stands in for the `require` returned by createRequire, driven by `impl`. */
+const stubRequire = (impl: (id: string) => unknown) =>
+  impl as unknown as ReturnType<typeof createRequire>;
 
 beforeEach(() => {
-  readFileSyncMock.mockReset();
-  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+  createRequireMock.mockReset();
+  createRequireMock.mockImplementation(actualModule.createRequire);
 });
 
 describe('resolvePackageVersion', () => {
@@ -28,75 +34,65 @@ describe('resolvePackageVersion', () => {
     expect(resolvePackageVersion()).toBe(version);
   });
 
-  it('does not fall back while the manifest is readable', () => {
-    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  it('exposes the resolved version as SERVER_VERSION', () => {
+    expect(SERVER_VERSION).toBe(version);
   });
 
-  it('falls back when no manifest is found', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
-  });
-
-  it('falls back to 0.0.0-dev by default', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion()).toBe('0.0.0-dev');
-  });
-
-  it('checks the parent directory, covering the dist/ layout', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOENT');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+  it('falls through to the parent directory, covering the dist/ layout', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        if (seen.length === 1) throw moduleNotFound();
+        return { version: '9.9.9' };
+      }),
+    );
 
     expect(resolvePackageVersion()).toBe('9.9.9');
-  });
-
-  it('treats ENOTDIR as a missing manifest', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOTDIR');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
-
-    expect(resolvePackageVersion()).toBe('8.8.8');
+    expect(seen).toHaveLength(2);
   });
 
   it('skips a manifest that has no version field', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
-      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+    let call = 0;
+    createRequireMock.mockReturnValue(
+      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
+    );
 
     expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
-  it('stops searching at the package root', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
+  it('throws when no manifest is found, without searching past the package root', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        throw moduleNotFound();
+      }),
+    );
 
-    resolvePackageVersion();
-
-    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(() => resolvePackageVersion()).toThrow(
+      'Could not locate package.json for server version',
+    );
+    expect(seen).toHaveLength(2);
   });
 
   it('propagates errors other than a missing manifest', () => {
-    const denied = fsError('EACCES');
-    readFileSyncMock.mockImplementation(() => {
-      throw denied;
-    });
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw denied;
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(denied);
   });
 
-  it('propagates a malformed manifest', () => {
-    readFileSyncMock.mockImplementation(() => '{ "version": ');
+  it('propagates a malformed manifest instead of reporting it as missing', () => {
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw new SyntaxError('Unexpected end of JSON input');
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });

--- a/src/filesystem/__tests__/version.test.ts
+++ b/src/filesystem/__tests__/version.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { resolvePackageVersion } from '../version.js';
 
 vi.mock('node:module', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:module')>();
@@ -32,33 +34,6 @@ beforeEach(() => {
 describe('resolvePackageVersion', () => {
   it('reports the version from package.json', () => {
     expect(resolvePackageVersion()).toBe(version);
-  });
-
-  it('exposes the resolved version as SERVER_VERSION', () => {
-    expect(SERVER_VERSION).toBe(version);
-  });
-
-  it('falls through to the parent directory, covering the dist/ layout', () => {
-    const seen: string[] = [];
-    createRequireMock.mockReturnValue(
-      stubRequire((id) => {
-        seen.push(id);
-        if (seen.length === 1) throw moduleNotFound();
-        return { version: '9.9.9' };
-      }),
-    );
-
-    expect(resolvePackageVersion()).toBe('9.9.9');
-    expect(seen).toHaveLength(2);
-  });
-
-  it('skips a manifest that has no version field', () => {
-    let call = 0;
-    createRequireMock.mockReturnValue(
-      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
-    );
-
-    expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
   it('throws when no manifest is found, without searching past the package root', () => {
@@ -96,4 +71,36 @@ describe('resolvePackageVersion', () => {
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });
+});
+
+// The cases above drive the resolver directly; these exercise the real build.
+// They skip when dist/ is absent so an unbuilt tree still passes.
+const distVersionPath = path.join(packageRoot, 'dist', 'version.js');
+const distIndexPath = path.join(packageRoot, 'dist', 'index.js');
+
+describe('built output', () => {
+  it.skipIf(!existsSync(distVersionPath))(
+    'resolves package.json from the dist layout after build',
+    async () => {
+      const dist = await import(/* @vite-ignore */ pathToFileURL(distVersionPath).href);
+
+      expect(dist.SERVER_VERSION).toBe(version);
+    },
+  );
+
+  it.skipIf(!existsSync(distIndexPath))(
+    'stdio initialize reports package.json version in serverInfo',
+    async () => {
+      const client = new Client({ name: 'version-test', version: '1.0.0' }, { capabilities: {} });
+      await client.connect(
+        new StdioClientTransport({ command: process.execPath, args: [distIndexPath] }),
+      );
+
+      try {
+        expect(client.getServerVersion()?.version).toBe(version);
+      } finally {
+        await client.close();
+      }
+    },
+  );
 });

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -27,6 +27,7 @@ import {
   headFile,
   setAllowedDirectories,
 } from './lib.js';
+import { resolvePackageVersion } from './version.js';
 
 // Command line argument parsing
 const args = process.argv.slice(2);
@@ -163,7 +164,7 @@ const GetFileInfoArgsSchema = z.object({
 const server = new McpServer(
   {
     name: "secure-filesystem-server",
-    version: "0.2.0",
+    version: resolvePackageVersion(),
   }
 );
 

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -27,7 +27,7 @@ import {
   headFile,
   setAllowedDirectories,
 } from './lib.js';
-import { resolvePackageVersion } from './version.js';
+import { SERVER_VERSION } from './version.js';
 
 // Command line argument parsing
 const args = process.argv.slice(2);
@@ -164,7 +164,7 @@ const GetFileInfoArgsSchema = z.object({
 const server = new McpServer(
   {
     name: "secure-filesystem-server",
-    version: resolvePackageVersion(),
+    version: SERVER_VERSION,
   }
 );
 

--- a/src/filesystem/version.ts
+++ b/src/filesystem/version.ts
@@ -1,33 +1,36 @@
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-/** Only "manifest isn't here" is skippable; other errors propagate. */
-const isMissingFile = (error: unknown): boolean => {
-  const code = (error as NodeJS.ErrnoException)?.code;
-  return code === 'ENOENT' || code === 'ENOTDIR';
-};
-
 /**
- * Reads this package's version from package.json. release.py stamps the version
- * at release time, so a literal in source is always stale.
+ * Resolve this package's version from package.json.
+ *
+ * Works both from source (`src/filesystem/`) and from the published
+ * layout (`dist/`), where package.json lives one directory up.
  */
-export const resolvePackageVersion = (fallback = '0.0.0-dev'): string => {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
+export function resolvePackageVersion(): string {
+  const require = createRequire(import.meta.url);
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(moduleDir, 'package.json'),
+    path.join(moduleDir, '..', 'package.json'),
+  ];
 
-  // Manifest sits alongside this module from source, one level up from dist/.
-  for (const dir of [moduleDir, dirname(moduleDir)]) {
-    let manifest: string;
+  for (const candidate of candidates) {
     try {
-      manifest = readFileSync(join(dir, 'package.json'), 'utf8');
+      const pkg = require(candidate) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
     } catch (error) {
-      if (isMissingFile(error)) continue;
-      throw error;
+      // Only a missing manifest is skippable; a corrupt or unreadable one is a real failure.
+      if ((error as NodeJS.ErrnoException)?.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
     }
-
-    const { version } = JSON.parse(manifest);
-    if (typeof version === 'string') return version;
   }
 
-  return fallback;
-};
+  throw new Error('Could not locate package.json for server version');
+}
+
+export const SERVER_VERSION = resolvePackageVersion();

--- a/src/filesystem/version.ts
+++ b/src/filesystem/version.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Only "manifest isn't here" is skippable; other errors propagate. */
+const isMissingFile = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+};
+
+/**
+ * Reads this package's version from package.json. release.py stamps the version
+ * at release time, so a literal in source is always stale.
+ */
+export const resolvePackageVersion = (fallback = '0.0.0-dev'): string => {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+  // Manifest sits alongside this module from source, one level up from dist/.
+  for (const dir of [moduleDir, dirname(moduleDir)]) {
+    let manifest: string;
+    try {
+      manifest = readFileSync(join(dir, 'package.json'), 'utf8');
+    } catch (error) {
+      if (isMissingFile(error)) continue;
+      throw error;
+    }
+
+    const { version } = JSON.parse(manifest);
+    if (typeof version === 'string') return version;
+  }
+
+  return fallback;
+};

--- a/src/memory/__tests__/version.test.ts
+++ b/src/memory/__tests__/version.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolvePackageVersion } from '../version.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+const readFileSyncMock = vi.mocked(readFileSync);
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
+const fsError = (code: string) => Object.assign(new Error(code), { code });
+
+beforeEach(() => {
+  readFileSyncMock.mockReset();
+  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+});
+
+describe('resolvePackageVersion', () => {
+  it('reports the version from package.json', () => {
+    expect(resolvePackageVersion()).toBe(version);
+  });
+
+  it('does not fall back while the manifest is readable', () => {
+    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  });
+
+  it('falls back when no manifest is found', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
+  });
+
+  it('falls back to 0.0.0-dev by default', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    expect(resolvePackageVersion()).toBe('0.0.0-dev');
+  });
+
+  it('checks the parent directory, covering the dist/ layout', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOENT');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+
+    expect(resolvePackageVersion()).toBe('9.9.9');
+  });
+
+  it('treats ENOTDIR as a missing manifest', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => {
+        throw fsError('ENOTDIR');
+      })
+      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
+
+    expect(resolvePackageVersion()).toBe('8.8.8');
+  });
+
+  it('skips a manifest that has no version field', () => {
+    readFileSyncMock
+      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
+      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+
+    expect(resolvePackageVersion()).toBe('7.7.7');
+  });
+
+  it('stops searching at the package root', () => {
+    readFileSyncMock.mockImplementation(() => {
+      throw fsError('ENOENT');
+    });
+
+    resolvePackageVersion();
+
+    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates errors other than a missing manifest', () => {
+    const denied = fsError('EACCES');
+    readFileSyncMock.mockImplementation(() => {
+      throw denied;
+    });
+
+    expect(() => resolvePackageVersion()).toThrow(denied);
+  });
+
+  it('propagates a malformed manifest', () => {
+    readFileSyncMock.mockImplementation(() => '{ "version": ');
+
+    expect(() => resolvePackageVersion()).toThrow(SyntaxError);
+  });
+});

--- a/src/memory/__tests__/version.test.ts
+++ b/src/memory/__tests__/version.test.ts
@@ -1,26 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion } from '../version.js';
+import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
 
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>();
+  return { ...actual, createRequire: vi.fn(actual.createRequire) };
 });
 
-const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
-const readFileSyncMock = vi.mocked(readFileSync);
+const actualModule = await vi.importActual<typeof import('node:module')>('node:module');
+const createRequireMock = vi.mocked(createRequire);
 
-const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const { version } = JSON.parse(actualFs.readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const { version } = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
 
-/** fs errors carry a `code`; only ENOENT/ENOTDIR mean "not at this path". */
-const fsError = (code: string) => Object.assign(new Error(code), { code });
+/** A `require` that fails to find a module carries this code; anything else is a real failure. */
+const moduleNotFound = () =>
+  Object.assign(new Error('Cannot find module'), { code: 'MODULE_NOT_FOUND' });
+
+/** Stands in for the `require` returned by createRequire, driven by `impl`. */
+const stubRequire = (impl: (id: string) => unknown) =>
+  impl as unknown as ReturnType<typeof createRequire>;
 
 beforeEach(() => {
-  readFileSyncMock.mockReset();
-  readFileSyncMock.mockImplementation(actualFs.readFileSync);
+  createRequireMock.mockReset();
+  createRequireMock.mockImplementation(actualModule.createRequire);
 });
 
 describe('resolvePackageVersion', () => {
@@ -28,75 +34,65 @@ describe('resolvePackageVersion', () => {
     expect(resolvePackageVersion()).toBe(version);
   });
 
-  it('does not fall back while the manifest is readable', () => {
-    expect(resolvePackageVersion('unused-fallback')).toBe(version);
+  it('exposes the resolved version as SERVER_VERSION', () => {
+    expect(SERVER_VERSION).toBe(version);
   });
 
-  it('falls back when no manifest is found', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion('1.2.3-fallback')).toBe('1.2.3-fallback');
-  });
-
-  it('falls back to 0.0.0-dev by default', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
-
-    expect(resolvePackageVersion()).toBe('0.0.0-dev');
-  });
-
-  it('checks the parent directory, covering the dist/ layout', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOENT');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '9.9.9' }));
+  it('falls through to the parent directory, covering the dist/ layout', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        if (seen.length === 1) throw moduleNotFound();
+        return { version: '9.9.9' };
+      }),
+    );
 
     expect(resolvePackageVersion()).toBe('9.9.9');
-  });
-
-  it('treats ENOTDIR as a missing manifest', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => {
-        throw fsError('ENOTDIR');
-      })
-      .mockImplementationOnce(() => JSON.stringify({ version: '8.8.8' }));
-
-    expect(resolvePackageVersion()).toBe('8.8.8');
+    expect(seen).toHaveLength(2);
   });
 
   it('skips a manifest that has no version field', () => {
-    readFileSyncMock
-      .mockImplementationOnce(() => JSON.stringify({ name: 'no-version-here' }))
-      .mockImplementationOnce(() => JSON.stringify({ version: '7.7.7' }));
+    let call = 0;
+    createRequireMock.mockReturnValue(
+      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
+    );
 
     expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
-  it('stops searching at the package root', () => {
-    readFileSyncMock.mockImplementation(() => {
-      throw fsError('ENOENT');
-    });
+  it('throws when no manifest is found, without searching past the package root', () => {
+    const seen: string[] = [];
+    createRequireMock.mockReturnValue(
+      stubRequire((id) => {
+        seen.push(id);
+        throw moduleNotFound();
+      }),
+    );
 
-    resolvePackageVersion();
-
-    expect(readFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(() => resolvePackageVersion()).toThrow(
+      'Could not locate package.json for server version',
+    );
+    expect(seen).toHaveLength(2);
   });
 
   it('propagates errors other than a missing manifest', () => {
-    const denied = fsError('EACCES');
-    readFileSyncMock.mockImplementation(() => {
-      throw denied;
-    });
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw denied;
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(denied);
   });
 
-  it('propagates a malformed manifest', () => {
-    readFileSyncMock.mockImplementation(() => '{ "version": ');
+  it('propagates a malformed manifest instead of reporting it as missing', () => {
+    createRequireMock.mockReturnValue(
+      stubRequire(() => {
+        throw new SyntaxError('Unexpected end of JSON input');
+      }),
+    );
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });

--- a/src/memory/__tests__/version.test.ts
+++ b/src/memory/__tests__/version.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { resolvePackageVersion, SERVER_VERSION } from '../version.js';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { resolvePackageVersion } from '../version.js';
 
 vi.mock('node:module', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:module')>();
@@ -32,33 +34,6 @@ beforeEach(() => {
 describe('resolvePackageVersion', () => {
   it('reports the version from package.json', () => {
     expect(resolvePackageVersion()).toBe(version);
-  });
-
-  it('exposes the resolved version as SERVER_VERSION', () => {
-    expect(SERVER_VERSION).toBe(version);
-  });
-
-  it('falls through to the parent directory, covering the dist/ layout', () => {
-    const seen: string[] = [];
-    createRequireMock.mockReturnValue(
-      stubRequire((id) => {
-        seen.push(id);
-        if (seen.length === 1) throw moduleNotFound();
-        return { version: '9.9.9' };
-      }),
-    );
-
-    expect(resolvePackageVersion()).toBe('9.9.9');
-    expect(seen).toHaveLength(2);
-  });
-
-  it('skips a manifest that has no version field', () => {
-    let call = 0;
-    createRequireMock.mockReturnValue(
-      stubRequire(() => (++call === 1 ? { name: 'no-version-here' } : { version: '7.7.7' })),
-    );
-
-    expect(resolvePackageVersion()).toBe('7.7.7');
   });
 
   it('throws when no manifest is found, without searching past the package root', () => {
@@ -96,4 +71,36 @@ describe('resolvePackageVersion', () => {
 
     expect(() => resolvePackageVersion()).toThrow(SyntaxError);
   });
+});
+
+// The cases above drive the resolver directly; these exercise the real build.
+// They skip when dist/ is absent so an unbuilt tree still passes.
+const distVersionPath = path.join(packageRoot, 'dist', 'version.js');
+const distIndexPath = path.join(packageRoot, 'dist', 'index.js');
+
+describe('built output', () => {
+  it.skipIf(!existsSync(distVersionPath))(
+    'resolves package.json from the dist layout after build',
+    async () => {
+      const dist = await import(/* @vite-ignore */ pathToFileURL(distVersionPath).href);
+
+      expect(dist.SERVER_VERSION).toBe(version);
+    },
+  );
+
+  it.skipIf(!existsSync(distIndexPath))(
+    'stdio initialize reports package.json version in serverInfo',
+    async () => {
+      const client = new Client({ name: 'version-test', version: '1.0.0' }, { capabilities: {} });
+      await client.connect(
+        new StdioClientTransport({ command: process.execPath, args: [distIndexPath] }),
+      );
+
+      try {
+        expect(client.getServerVersion()?.version).toBe(version);
+      } finally {
+        await client.close();
+      }
+    },
+  );
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { resolvePackageVersion } from './version.js';
+import { SERVER_VERSION } from './version.js';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -257,7 +257,7 @@ const RelationSchema = z.object({
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: resolvePackageVersion(),
+  version: SERVER_VERSION,
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { resolvePackageVersion } from './version.js';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -256,7 +257,7 @@ const RelationSchema = z.object({
 // The server instance and tools exposed to Claude
 const server = new McpServer({
   name: "memory-server",
-  version: "0.6.3",
+  version: resolvePackageVersion(),
 });
 
 const RESOURCE_URI = "memory://knowledge-graph";

--- a/src/memory/version.ts
+++ b/src/memory/version.ts
@@ -1,33 +1,36 @@
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-/** Only "manifest isn't here" is skippable; other errors propagate. */
-const isMissingFile = (error: unknown): boolean => {
-  const code = (error as NodeJS.ErrnoException)?.code;
-  return code === 'ENOENT' || code === 'ENOTDIR';
-};
-
 /**
- * Reads this package's version from package.json. release.py stamps the version
- * at release time, so a literal in source is always stale.
+ * Resolve this package's version from package.json.
+ *
+ * Works both from source (`src/memory/`) and from the published
+ * layout (`dist/`), where package.json lives one directory up.
  */
-export const resolvePackageVersion = (fallback = '0.0.0-dev'): string => {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
+export function resolvePackageVersion(): string {
+  const require = createRequire(import.meta.url);
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.join(moduleDir, 'package.json'),
+    path.join(moduleDir, '..', 'package.json'),
+  ];
 
-  // Manifest sits alongside this module from source, one level up from dist/.
-  for (const dir of [moduleDir, dirname(moduleDir)]) {
-    let manifest: string;
+  for (const candidate of candidates) {
     try {
-      manifest = readFileSync(join(dir, 'package.json'), 'utf8');
+      const pkg = require(candidate) as { version?: string };
+      if (pkg.version) {
+        return pkg.version;
+      }
     } catch (error) {
-      if (isMissingFile(error)) continue;
-      throw error;
+      // Only a missing manifest is skippable; a corrupt or unreadable one is a real failure.
+      if ((error as NodeJS.ErrnoException)?.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
     }
-
-    const { version } = JSON.parse(manifest);
-    if (typeof version === 'string') return version;
   }
 
-  return fallback;
-};
+  throw new Error('Could not locate package.json for server version');
+}
+
+export const SERVER_VERSION = resolvePackageVersion();

--- a/src/memory/version.ts
+++ b/src/memory/version.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Only "manifest isn't here" is skippable; other errors propagate. */
+const isMissingFile = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+};
+
+/**
+ * Reads this package's version from package.json. release.py stamps the version
+ * at release time, so a literal in source is always stale.
+ */
+export const resolvePackageVersion = (fallback = '0.0.0-dev'): string => {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+  // Manifest sits alongside this module from source, one level up from dist/.
+  for (const dir of [moduleDir, dirname(moduleDir)]) {
+    let manifest: string;
+    try {
+      manifest = readFileSync(join(dir, 'package.json'), 'utf8');
+    } catch (error) {
+      if (isMissingFile(error)) continue;
+      throw error;
+    }
+
+    const { version } = JSON.parse(manifest);
+    if (typeof version === 'string') return version;
+  }
+
+  return fallback;
+};


### PR DESCRIPTION
> **Draft .. parked until #4576 lands.** That PR establishes the pattern for `sequentialthinking`; this one applies it to the remaining three TypeScript servers. Opening it early so the work is visible and nobody duplicates it. I'll mark it ready once #4576 merges, and rebase if its implementation changes during review.

## Description

Follow-up to #4576, as suggested by @KarlLeen there. `filesystem`, `memory`, and `everything` hardcode a version literal in their `McpServer` constructor .. the same defect #4575 reports for `sequentialthinking`. Those literals cannot be kept correct, because `scripts/release.py` rewrites `package.json["version"]` at release time, so every server eventually misreports its version over the wire.

This replaces each literal with `SERVER_VERSION`, read from the package's own `package.json` at runtime.

| Server | Literal in source | `package.json` | |
|---|---|---|---|
| filesystem | `0.2.0` | 0.6.3 | drifted today |
| memory | `0.6.3` | 0.6.3 | matches now, drifts at next release |
| everything | `2.0.0` | 2.0.0 | matches now, drifts at next release |

`memory` and `everything` match at rest but drift the moment a release stamps a CalVer version into their manifests, so all three are fixed together. `sequentialthinking` is deliberately untouched here .. it belongs to #4576.

## Server Details

- Server: filesystem, memory, everything
- Changes to: reported `serverInfo.version` (no tools, resources, or prompts changed)

## Motivation and Context

Related to #4575.

`scripts/release.py:70-76` (`NpmPackage.update_version`) rewrites `package.json["version"]` to a date-based version generated by `gen_version()` at release time. A version committed in TypeScript source is therefore stale by construction .. it is never the version that ships. That makes this one systemic defect rather than a series of independent oversights, and it is why the fix has to read the manifest at runtime rather than sync a literal.

This stays correct if #4463 (semver via changesets) changes how versions are stamped, since it reads whatever ends up in the shipped manifest.

### Implementation

`version.ts` is duplicated at each package root rather than extracted into a shared package. A shared `src/shared/` workspace package would be auto-detected as publishable by both `find_changed_packages` (`release.py`) and the CI `detect-packages` matrix, would need its own npm trusted-publisher registration per `RELEASING.md`, and would make each server's release depend on a separately-versioned package. That is disproportionate for ~30 lines, so the duplication is deliberate.

The implementation matches #4576 deliberately, so all four servers end up with the same file. Two details worth noting for review:

- **The search is bounded.** The manifest is either alongside the module (running from source, e.g. under vitest) or one level up (running from `dist/`). Those two locations are checked and nothing else, it never walks up into the monorepo and cannot pick up a parent `package.json`.
- **`version.ts` must stay at the package root.** Moving it into a subdirectory breaks the `dist/` case. This matters for `everything`, where the surrounding code is organised into subfolders.

There is one intentional difference from #4576:

```diff
-    } catch {
-      // Try the next candidate when running from dist/ or source.
+    } catch (error) {
+      // Only a missing manifest is skippable; a corrupt or unreadable one is a real failure.
+      if ((error as NodeJS.ErrnoException)?.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      }
     }
```

A blanket `catch` swallows every failure, so a corrupt or permission-denied `package.json` reports `Could not locate package.json for server version` .. misleading for a file that was found and is unreadable for a different reason. Narrowing to `MODULE_NOT_FOUND` lets real failures surface. Happy to drop this if reviewers would rather the four files stay byte-identical, and equally happy to open it against #4576 instead.

## How Has This Been Tested?

- `npm run build` clean across all packages (`everything` type-checks its tests, and passes).
- Suites pass: everything 113, filesystem 158, memory 56. 18 of those are new (6 per package). `sequentialthinking` unchanged at 14.
- Ran a server in Claude Desktop against the local build: connects, negotiates, and its tools work normally.

Each package's `version.ts` gets six tests, in two groups:

- **Four drive the resolver directly**, with `createRequire` mocked: the happy path against the real manifest, throwing when neither candidate exists (asserting the search stops at the package root), propagation of non-`MODULE_NOT_FOUND` errors (`EACCES`), and propagation of a malformed manifest. The mock is a pass-through by default, so the happy-path assertion runs against the real filesystem in the same file; only tests that need a failure inject one.
- **Two exercise the real build** .. importing `dist/version.js`, and spawning `node dist/index.js` to read `serverInfo.version` back over a stdio handshake (`everything` 2.0.0, `filesystem` 0.6.3, `memory` 0.6.3; `filesystem` reported `0.2.0` before this change). These use `it.skipIf` so an unbuilt tree still passes, matching #4576. They do run in CI, since `npm ci` triggers `prepare` .. `npm run build`.

The two propagation tests and the bounded-search test were mutation-tested: reverting the catch to a blanket `catch {}` fails the first two, and adding a third candidate path beyond the package root fails the third.

## Breaking Changes

None. No client configuration changes. Servers now report their actual published version instead of a stale literal, which is the intent of the fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly — n/a, no README documents the server version
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options — n/a, none added

## Additional context

This overlaps existing work, and I'd rather flag that up front than have a reviewer find it:

- **#4576** fixes `sequentialthinking`. This PR is the follow-up @KarlLeen proposed there and stays out of its way.
- **#4557** fixes `memory` and `sequentialthinking` (alongside a zod dependency fix). If that lands first, I'll drop `memory` here and reduce this to `filesystem` and `everything`.
- **#4406**, the equivalent report for `memory`, was closed as not planned.

If maintainers would rather have one combined change, I'm happy for this to be folded into #4576 instead. Credit to @KarlLeen for reporting #4575 and to the authors of #4576 and #4557 .. the direction here is the same as theirs.
