### PR TITLE
Make memory graph writes atomic

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -18,6 +18,8 @@ describe('KnowledgeGraphManager', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
+
     // Clean up test file
     try {
       await fs.unlink(testFilePath);
@@ -396,6 +398,35 @@ describe('KnowledgeGraphManager', () => {
   });
 
   describe('file persistence', () => {
+    it('should preserve existing data when a write is interrupted', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: ['persistent data'] },
+      ]);
+
+      const originalFileContent = await fs.readFile(testFilePath, 'utf-8');
+      const writeFile = fs.writeFile.bind(fs);
+
+      vi.spyOn(fs, 'writeFile').mockImplementation(async (file, data) => {
+        await writeFile(file, data.toString().slice(0, 1));
+        throw new Error('interrupted write');
+      });
+
+      await expect(
+        manager.createEntities([
+          { name: 'Bob', entityType: 'person', observations: [] },
+        ])
+      ).rejects.toThrow('interrupted write');
+
+      await expect(fs.readFile(testFilePath, 'utf-8')).resolves.toBe(
+        originalFileContent
+      );
+
+      const files = await fs.readdir(path.dirname(testFilePath));
+      expect(
+        files.filter(file => file.startsWith(`${path.basename(testFilePath)}.`))
+      ).toEqual([]);
+    });
+
     it('should persist data across manager instances', async () => {
       await manager.createEntities([
         { name: 'Alice', entityType: 'person', observations: ['persistent data'] },

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { randomBytes } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -114,7 +115,17 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    const temporaryFilePath = `${this.memoryFilePath}.${randomBytes(16).toString('hex')}.tmp`;
+
+    try {
+      await fs.writeFile(temporaryFilePath, lines.join("\n"));
+      await fs.rename(temporaryFilePath, this.memoryFilePath);
+    } catch (error) {
+      try {
+        await fs.unlink(temporaryFilePath);
+      } catch {}
+      throw error;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {


### PR DESCRIPTION
## Description

Memory graph updates are now written to a unique temporary file in the same directory. The completed file is renamed over the target only after the write succeeds. Failed writes remove the temporary file and leave the previous graph intact.

Fixes #4614.

## Server Details

- Server: memory
- Changes to: persistence

## Motivation and Context

Direct writes truncate the target before the replacement content is complete. An interrupted write can therefore corrupt the only persisted copy of the graph.

## How Has This Been Tested?

- Added a regression test that simulates a partial write failure and verifies the original graph remains unchanged.
- Verified temporary files are removed after failure.
- `npm test --workspace @modelcontextprotocol/server-memory -- --maxWorkers=4` (51 tests)
- `npm run build --workspace @modelcontextprotocol/server-memory`

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context

The temporary file is created beside the memory file so the rename stays on the same filesystem. Its randomized name also avoids collisions between concurrent processes.