### PR TITLE
fix(memory): write memory graph atomically to prevent corruption

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -18,6 +18,8 @@ describe('KnowledgeGraphManager', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
+
     // Clean up test file
     try {
       await fs.unlink(testFilePath);
@@ -407,6 +409,38 @@ describe('KnowledgeGraphManager', () => {
 
       expect(graph.entities).toHaveLength(1);
       expect(graph.entities[0].name).toBe('Alice');
+    });
+
+    it('should preserve existing data when a write is interrupted', async () => {
+      await manager.createEntities([
+        { name: 'Alice', entityType: 'person', observations: ['persistent data'] },
+      ]);
+
+      const originalFileContent = await fs.readFile(testFilePath, 'utf-8');
+      const writeFile = fs.writeFile.bind(fs);
+
+      // Simulate the process being killed mid-write: partial bytes written, then error
+      vi.spyOn(fs, 'writeFile').mockImplementation(async (file, data) => {
+        await writeFile(file, data.toString().slice(0, 1));
+        throw new Error('interrupted write');
+      });
+
+      await expect(
+        manager.createEntities([
+          { name: 'Bob', entityType: 'person', observations: [] },
+        ])
+      ).rejects.toThrow('interrupted write');
+
+      // The original memory file must be untouched
+      await expect(fs.readFile(testFilePath, 'utf-8')).resolves.toBe(
+        originalFileContent
+      );
+
+      // No temp files may leak from the failed write
+      const files = await fs.readdir(path.dirname(testFilePath));
+      expect(
+        files.filter(file => file.startsWith(`${path.basename(testFilePath)}.`))
+      ).toEqual([]);
     });
 
     it('should handle JSONL format correctly', async () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import { randomBytes } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -114,7 +115,22 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    // Write atomically: write to a unique temp file, then rename into place, so
+    // an interruption mid-write can never leave a truncated or corrupted file.
+    // The random suffix avoids collisions when saves overlap.
+    const tmpPath = `${this.memoryFilePath}.${randomBytes(16).toString('hex')}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, lines.join("\n"));
+      await fs.rename(tmpPath, this.memoryFilePath);
+    } catch (error) {
+      // Clean up the temp file so a failed save never leaks artifacts.
+      try {
+        await fs.unlink(tmpPath);
+      } catch {
+        /* best-effort cleanup: never mask the original error */
+      }
+      throw error;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -118,6 +118,10 @@ export class KnowledgeGraphManager {
     // Write atomically: write to a unique temp file, then rename into place, so
     // an interruption mid-write can never leave a truncated or corrupted file.
     // The random suffix avoids collisions when saves overlap.
+    //
+    // Known limitation: a hard kill (SIGKILL) between the write and the rename
+    // leaves a stray .tmp file behind. This is unavoidable without a journal;
+    // the guarantee we provide is that memory.jsonl itself is never corrupted.
     const tmpPath = `${this.memoryFilePath}.${randomBytes(16).toString('hex')}.tmp`;
     try {
       await fs.writeFile(tmpPath, lines.join("\n"));


### PR DESCRIPTION
## What

Fixes #4614.

`saveGraph()` wrote the memory file directly with `fs.writeFile`, so an interruption mid-write (process crash, kill, power loss) could leave a truncated or corrupted memory file — permanently losing the agent's long-term memory.

## How

Write the graph to a unique temp file, then `rename()` it into place. Rename is atomic on POSIX and Windows, so the memory file is always either the old complete version or the new complete version — never a half-written one.

- Random suffix (`randomBytes(16)`) prevents collisions when saves overlap
- Temp file is cleaned up on failure so failed saves never leak artifacts

## Tests

Added a regression test that simulates an interruption mid-write (partial bytes written, then error) and verifies:
- The original memory file is untouched
- No temp files leak

`tsc --noEmit` passes. Full suite: 51/51 tests pass.

## Notes

This complements (not duplicates) #4555, which serializes concurrent graph mutations. #4555 fixes concurrent writes racing each other; this fixes a single write being interrupted mid-write — two different failure modes.

Known limitation: a hard kill between write and rename can still leave a temp file behind (inherent to the temp+rename pattern). The memory file itself is never corrupted.
