### PR TITLE
fix(filesystem): make move_file fail instead of silently overwriting the destination

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -14,6 +14,7 @@ import {
   getFileStats,
   readFileContent,
   writeFileContent,
+  moveFile,
   // Search & filtering functions
   searchFilesWithValidation,
   // File editing functions
@@ -307,6 +308,29 @@ describe('Lib Functions', () => {
         await writeFileContent('/test/file.txt', 'new content');
         
         expect(mockFs.writeFile).toHaveBeenCalledWith('/test/file.txt', 'new content', { encoding: "utf-8", flag: 'wx' });
+      });
+    });
+
+    describe('moveFile', () => {
+      it('moves the file when the destination does not exist', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await moveFile('/test/source.txt', '/test/dest.txt');
+
+        expect(mockFs.rename).toHaveBeenCalledWith('/test/source.txt', '/test/dest.txt');
+      });
+
+      it('fails without overwriting when the destination already exists', async () => {
+        // lstat resolving means the destination is occupied.
+        mockFs.lstat.mockResolvedValueOnce({} as any);
+
+        await expect(moveFile('/test/source.txt', '/test/dest.txt')).rejects.toThrow(
+          'Destination already exists'
+        );
+
+        expect(mockFs.rename).not.toHaveBeenCalled();
       });
     });
 

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -21,6 +21,7 @@ import {
   getFileStats,
   readFileContent,
   writeFileContent,
+  moveFile,
   searchFilesWithValidation,
   applyFileEdits,
   tailFile,
@@ -631,7 +632,7 @@ server.registerTool(
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
     const validSourcePath = await validatePath(args.source);
     const validDestPath = await validatePath(args.destination);
-    await fs.rename(validSourcePath, validDestPath);
+    await moveFile(validSourcePath, validDestPath);
     const text = `Successfully moved ${args.source} to ${args.destination}`;
     const contentBlock = { type: "text" as const, text };
     return {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -185,6 +185,25 @@ export async function writeFileContent(filePath: string, content: string): Promi
 }
 
 
+export async function moveFile(sourcePath: string, destinationPath: string): Promise<void> {
+  // The move_file tool contract (and README) state the operation fails if the
+  // destination already exists. fs.rename would silently overwrite it, which is
+  // a data-loss bug, so reject up front when anything - file, directory, or
+  // symlink - occupies the target. lstat is used so an existing symlink at the
+  // destination is detected rather than followed.
+  try {
+    await fs.lstat(destinationPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      await fs.rename(sourcePath, destinationPath);
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`Destination already exists: ${destinationPath}`);
+}
+
+
 // File Editing Functions
 interface FileEdit {
   oldText: string;


### PR DESCRIPTION
Fixes #4628.

`move_file`'s description and the README both say the move fails if the destination already exists:

> If the destination exists, the operation will fail.

But the handler calls `fs.rename` directly, which silently overwrites the destination and still reports success. Because this server ships no delete tool, an agent that reads the contract reasonably treats `move_file` as non-clobbering, so this quietly turns into unadvertised, irreversible file deletion: move any file onto an existing target and the target's contents are gone.

## Fix

Added a `moveFile` helper in `lib.ts` that checks the destination first and rejects if anything already occupies it, then renames only when the target is free:

```ts
try {
  await fs.lstat(destinationPath);
} catch (error) {
  if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
    await fs.rename(sourcePath, destinationPath);
    return;
  }
  throw error;
}
throw new Error(`Destination already exists: ${destinationPath}`);
```

`lstat` (not `stat`) is used so an existing symlink at the destination is detected rather than followed. The `move_file` handler now calls this helper. Behaviour now matches the documented contract, and the successful-move path is unchanged.

## Tests

Added two cases to `__tests__/lib.test.ts`:
- moves when the destination doesn't exist (rename is called)
- rejects with "Destination already exists" and never calls rename when the destination is present

The second test fails against the old `fs.rename`-only behaviour and passes with the fix. Full file suite green:

```
cd src/filesystem && npm run build && npx vitest run __tests__/lib.test.ts
# 48 passed
```