### PR TITLE
Add container images workflow for multi-arch container builds

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,0 +1,84 @@
+name: Container Images
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-servers:
+    runs-on: ubuntu-latest
+    outputs:
+      servers: ${{ steps.find-servers.outputs.servers }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Find servers with Dockerfiles
+        id: find-servers
+        run: |
+          SERVERS=$(find src -maxdepth 2 -name Dockerfile -exec dirname {} \; | while read dir; do
+            name=$(basename "$dir")
+            # TS Dockerfiles reference repo-root paths (src/<name>, tsconfig.json) --> context = repo root
+            # Python Dockerfiles use relative paths (ADD . /app) --> context = server directory
+            if [ -f "$dir/package.json" ]; then
+              context="."
+            else
+              context="$dir"
+            fi
+            jq -n --arg name "$name" --arg context "$context" \
+              '{name: $name, context: $context}'
+          done | jq -s -c '.')
+          echo "servers=$SERVERS" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [detect-servers]
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.detect-servers.outputs.servers) }}
+    name: Build ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mcp-server-${{ matrix.name }}
+          tags: |
+            type=raw,value=main,enable=${{ github.event_name == 'push' }}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: src/${{ matrix.name }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}


### PR DESCRIPTION
Provide container images of servers.

## Description

Currently the servers are not provided as container images. This PR addresses it and builds and pushes multi-arch (amd64/arm64) container images to GHCR for all servers under `src/` that have a Dockerfile. 
Triggers on push to main (tagged `main`) and on release (tagged with release version and `latest`). 
Uses dynamic server detection to avoid a static build matrix.

## Publishing Your Server

n/a

## Server Details

n/a

## Motivation and Context

To run the MCP Servers for example on Kubernetes, we need those as a container image. As the servers already have the Dockerfiles, there is no need for the users to build them on their own each time, when we could provide them here centrally.

## How Has This Been Tested?

n/a

## Breaking Changes

no

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io) (n/a)
- [x] My changes follows MCP security best practices  (n/a)
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client  (n/a)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling  (n/a)
- [x] I have documented all environment variables and configuration options  (n/a)
