### PR TITLE
fix(fetch): make request timeout configurable via CLI, env var, and per-call override

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -18,6 +18,7 @@ The fetch tool will truncate the response, but by using the `start_index` argume
     - `max_length` (integer, optional): Maximum number of characters to return (default: 5000)
     - `start_index` (integer, optional): Start content from this character index (default: 0)
     - `raw` (boolean, optional): Get raw content without markdown conversion (default: false)
+    - `timeout_ms` (integer, optional): Override the server's default request timeout for this call, in milliseconds
 
 ### Prompts
 
@@ -171,6 +172,13 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 ### Customization - Proxy
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
+
+### Customization - Timeout
+
+By default, requests time out after 30 seconds. This can be changed server-wide with the `--timeout`
+argument (in milliseconds), or by setting the `FETCH_TIMEOUT_MS` environment variable — the `--timeout`
+argument takes precedence if both are set. Individual `fetch` tool calls can also override this by
+passing `timeout_ms` in the call arguments.
 
 ## Windows Configuration
 

--- a/src/fetch/src/mcp_server_fetch/__init__.py
+++ b/src/fetch/src/mcp_server_fetch/__init__.py
@@ -5,6 +5,7 @@ def main():
     """MCP Fetch Server - HTTP fetching functionality for MCP"""
     import argparse
     import asyncio
+    import os
 
     parser = argparse.ArgumentParser(
         description="give a model the ability to make web requests"
@@ -16,9 +17,18 @@ def main():
         help="Ignore robots.txt restrictions",
     )
     parser.add_argument("--proxy-url", type=str, help="Proxy URL to use for requests")
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        help="Default request timeout in milliseconds, used when a fetch call "
+        "doesn't specify its own timeout_ms (env: FETCH_TIMEOUT_MS, default: 30000)",
+    )
 
     args = parser.parse_args()
-    asyncio.run(serve(args.user_agent, args.ignore_robots_txt, args.proxy_url))
+    default_timeout_ms = args.timeout or int(os.environ.get("FETCH_TIMEOUT_MS", 30000))
+    asyncio.run(
+        serve(args.user_agent, args.ignore_robots_txt, args.proxy_url, default_timeout_ms)
+    )
 
 
 if __name__ == "__main__":

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -109,7 +109,11 @@ async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url:
 
 
 async def fetch_url(
-    url: str, user_agent: str, force_raw: bool = False, proxy_url: str | None = None
+    url: str,
+    user_agent: str,
+    force_raw: bool = False,
+    proxy_url: str | None = None,
+    timeout: float = 30,
 ) -> Tuple[str, str]:
     """
     Fetch the URL and return the content in a form ready for the LLM, as well as a prefix string with status information.
@@ -122,7 +126,7 @@ async def fetch_url(
                 url,
                 follow_redirects=True,
                 headers={"User-Agent": user_agent},
-                timeout=30,
+                timeout=timeout,
             )
         except HTTPError as e:
             raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Failed to fetch {url}: {e!r}"))
@@ -176,12 +180,21 @@ class Fetch(BaseModel):
             description="Get the actual HTML content of the requested page, without simplification.",
         ),
     ]
+    timeout_ms: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Override the server's default request timeout for this call, in milliseconds.",
+            gt=0,
+        ),
+    ]
 
 
 async def serve(
     custom_user_agent: str | None = None,
     ignore_robots_txt: bool = False,
     proxy_url: str | None = None,
+    default_timeout_ms: int = 30000,
 ) -> None:
     """Run the fetch MCP server.
 
@@ -189,6 +202,8 @@ async def serve(
         custom_user_agent: Optional custom User-Agent string to use for requests
         ignore_robots_txt: Whether to ignore robots.txt restrictions
         proxy_url: Optional proxy URL to use for requests
+        default_timeout_ms: Default request timeout in milliseconds, used when a
+            call doesn't specify its own timeout_ms
     """
     server = Server("mcp-fetch")
     user_agent_autonomous = custom_user_agent or DEFAULT_USER_AGENT_AUTONOMOUS
@@ -234,8 +249,13 @@ Although originally you did not have internet access, and were advised to refuse
         if not ignore_robots_txt:
             await check_may_autonomously_fetch_url(url, user_agent_autonomous, proxy_url)
 
+        timeout_ms = args.timeout_ms if args.timeout_ms is not None else default_timeout_ms
         content, prefix = await fetch_url(
-            url, user_agent_autonomous, force_raw=args.raw, proxy_url=proxy_url
+            url,
+            user_agent_autonomous,
+            force_raw=args.raw,
+            proxy_url=proxy_url,
+            timeout=timeout_ms / 1000,
         )
         original_length = len(content)
         if args.start_index >= original_length:
@@ -262,7 +282,12 @@ Although originally you did not have internet access, and were advised to refuse
         url = arguments["url"]
 
         try:
-            content, prefix = await fetch_url(url, user_agent_manual, proxy_url=proxy_url)
+            content, prefix = await fetch_url(
+                url,
+                user_agent_manual,
+                proxy_url=proxy_url,
+                timeout=default_timeout_ms / 1000,
+            )
             # TODO: after SDK bug is addressed, don't catch the exception
         except McpError as e:
             return GetPromptResult(

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -303,6 +303,48 @@ class TestFetchUrl:
                 )
 
     @pytest.mark.asyncio
+    async def test_fetch_default_timeout(self):
+        """Test that fetch_url uses a 30s timeout by default."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"data": "test"}'
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await fetch_url("https://example.com/data", DEFAULT_USER_AGENT_AUTONOMOUS)
+
+            _, kwargs = mock_client.get.call_args
+            assert kwargs["timeout"] == 30
+
+    @pytest.mark.asyncio
+    async def test_fetch_custom_timeout(self):
+        """Test that a custom timeout is passed through to the HTTP client."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"data": "test"}'
+        mock_response.headers = {"content-type": "application/json"}
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await fetch_url(
+                "https://example.com/data",
+                DEFAULT_USER_AGENT_AUTONOMOUS,
+                timeout=120,
+            )
+
+            _, kwargs = mock_client.get.call_args
+            assert kwargs["timeout"] == 120
+
+    @pytest.mark.asyncio
     async def test_fetch_with_proxy(self):
         """Test that proxy URL is passed to client."""
         mock_response = MagicMock()


### PR DESCRIPTION
## Description

The `fetch` MCP server hardcodes a 30s httpx timeout with no way to override it. This makes legitimate large downloads (big files, slow APIs) fail outright, and gives no way to fail fast on quick health-check-style calls.

## Server Details
- Server: fetch
- Changes to: tools (new `timeout_ms` argument), CLI args, environment variables

## Motivation and Context

Closes #4448. Different use cases need different timeouts — a 5-10s timeout for doc lookups vs. 60-300s for large file downloads. One hardcoded value forces a bad tradeoff either way.

Adds three ways to configure it, most specific wins:
1. Per-call `timeout_ms` argument on the `fetch` tool
2. `FETCH_TIMEOUT_MS` environment variable (server-wide default)
3. `--timeout` CLI flag in milliseconds (takes precedence over the env var if both are set)

Default stays 30000ms if none of the above are set, so this is non-breaking.

## How Has This Been Tested?

- Added unit tests asserting `fetch_url` passes both the default and a custom timeout through to the underlying httpx call (`uv run pytest`: 22 passed).
- `uv run ruff check .`: clean. `uv run pyright`: 0 errors.
- Manually smoke-tested that both `--timeout` and `FETCH_TIMEOUT_MS` reach `serve()` with correct precedence.
- Have not tested this against a live LLM client (e.g. Claude Desktop) — happy to if that's wanted before merge.

## Breaking Changes

None. Default behavior (30s timeout) is unchanged if no new option is used.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

`timeout_ms` uses `gt=0` validation like the other numeric fields on the `Fetch` model. Precedence order (per-call > CLI flag > env var > 30s default) matches the issue's request, with CLI winning over env var when a server operator sets both.