### PR TITLE
fix(fetch): retry transient errors with exponential backoff

### DIFF
--- a/src/fetch/README.md
+++ b/src/fetch/README.md
@@ -172,6 +172,14 @@ This can be customized by adding the argument `--user-agent=YourUserAgent` to th
 
 The server can be configured to use a proxy by using the `--proxy-url` argument.
 
+### Customization - Retries
+
+Transient errors (`429`, `500`, `502`, `503`, `504`, or a network error) are retried with
+exponential backoff, up to 3 attempts by default with an initial 1s delay (doubling each
+retry, capped at 10s). A numeric `Retry-After` header on a `429` response is honored. This
+can be configured with the `FETCH_MAX_RETRIES` and `FETCH_RETRY_DELAY_MS` environment
+variables.
+
 ## Windows Configuration
 
 If you're experiencing timeout issues on Windows, you may need to set the `PYTHONIOENCODING` environment variable to ensure proper character encoding:

--- a/src/fetch/src/mcp_server_fetch/__init__.py
+++ b/src/fetch/src/mcp_server_fetch/__init__.py
@@ -1,10 +1,11 @@
-from .server import serve
+from .server import serve, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY_MS
 
 
 def main():
     """MCP Fetch Server - HTTP fetching functionality for MCP"""
     import argparse
     import asyncio
+    import os
 
     parser = argparse.ArgumentParser(
         description="give a model the ability to make web requests"
@@ -18,7 +19,11 @@ def main():
     parser.add_argument("--proxy-url", type=str, help="Proxy URL to use for requests")
 
     args = parser.parse_args()
-    asyncio.run(serve(args.user_agent, args.ignore_robots_txt, args.proxy_url))
+    max_retries = int(os.environ.get("FETCH_MAX_RETRIES", DEFAULT_MAX_RETRIES))
+    retry_delay_ms = int(os.environ.get("FETCH_RETRY_DELAY_MS", DEFAULT_RETRY_DELAY_MS))
+    asyncio.run(
+        serve(args.user_agent, args.ignore_robots_txt, args.proxy_url, max_retries, retry_delay_ms)
+    )
 
 
 if __name__ == "__main__":

--- a/src/fetch/src/mcp_server_fetch/server.py
+++ b/src/fetch/src/mcp_server_fetch/server.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Annotated, Tuple
 from urllib.parse import urlparse, urlunparse
 
@@ -22,6 +23,24 @@ from pydantic import BaseModel, Field, AnyUrl
 
 DEFAULT_USER_AGENT_AUTONOMOUS = "ModelContextProtocol/1.0 (Autonomous; +https://github.com/modelcontextprotocol/servers)"
 DEFAULT_USER_AGENT_MANUAL = "ModelContextProtocol/1.0 (User-Specified; +https://github.com/modelcontextprotocol/servers)"
+
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY_MS = 1000
+MAX_RETRY_DELAY_MS = 10000
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _compute_retry_delay_seconds(
+    attempt: int, base_delay_ms: int, retry_after_header: str | None = None
+) -> float:
+    """Delay before the next retry: honors a numeric Retry-After header, else exponential backoff."""
+    if retry_after_header is not None:
+        try:
+            return min(float(retry_after_header), MAX_RETRY_DELAY_MS / 1000)
+        except ValueError:
+            pass  # not a numeric Retry-After (e.g. an HTTP-date) — fall back to backoff
+    delay_ms = min(base_delay_ms * (2**attempt), MAX_RETRY_DELAY_MS)
+    return delay_ms / 1000
 
 
 def extract_content_from_html(html: str) -> str:
@@ -109,43 +128,66 @@ async def check_may_autonomously_fetch_url(url: str, user_agent: str, proxy_url:
 
 
 async def fetch_url(
-    url: str, user_agent: str, force_raw: bool = False, proxy_url: str | None = None
+    url: str,
+    user_agent: str,
+    force_raw: bool = False,
+    proxy_url: str | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay_ms: int = DEFAULT_RETRY_DELAY_MS,
 ) -> Tuple[str, str]:
     """
     Fetch the URL and return the content in a form ready for the LLM, as well as a prefix string with status information.
+
+    Transient failures (429/500/502/503/504 and network errors) are retried with exponential
+    backoff, up to max_retries attempts total. A numeric Retry-After header on a 429 is honored.
     """
     from httpx import AsyncClient, HTTPError
 
     async with AsyncClient(proxy=proxy_url) as client:
-        try:
-            response = await client.get(
-                url,
-                follow_redirects=True,
-                headers={"User-Agent": user_agent},
-                timeout=30,
+        for attempt in range(max_retries):
+            is_last_attempt = attempt == max_retries - 1
+            try:
+                response = await client.get(
+                    url,
+                    follow_redirects=True,
+                    headers={"User-Agent": user_agent},
+                    timeout=30,
+                )
+            except HTTPError as e:
+                if is_last_attempt:
+                    raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Failed to fetch {url}: {e!r}"))
+                await asyncio.sleep(_compute_retry_delay_seconds(attempt, retry_delay_ms))
+                continue
+
+            if response.status_code in RETRYABLE_STATUS_CODES and not is_last_attempt:
+                await asyncio.sleep(
+                    _compute_retry_delay_seconds(
+                        attempt, retry_delay_ms, response.headers.get("retry-after")
+                    )
+                )
+                continue
+
+            if response.status_code >= 400:
+                raise McpError(ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=f"Failed to fetch {url} - status code {response.status_code}",
+                ))
+
+            page_raw = response.text
+            content_type = response.headers.get("content-type", "")
+            is_page_html = (
+                "<html" in page_raw[:100] or "text/html" in content_type or not content_type
             )
-        except HTTPError as e:
-            raise McpError(ErrorData(code=INTERNAL_ERROR, message=f"Failed to fetch {url}: {e!r}"))
-        if response.status_code >= 400:
-            raise McpError(ErrorData(
-                code=INTERNAL_ERROR,
-                message=f"Failed to fetch {url} - status code {response.status_code}",
-            ))
 
-        page_raw = response.text
+            if is_page_html and not force_raw:
+                return extract_content_from_html(page_raw), ""
 
-    content_type = response.headers.get("content-type", "")
-    is_page_html = (
-        "<html" in page_raw[:100] or "text/html" in content_type or not content_type
-    )
+            return (
+                page_raw,
+                f"Content type {content_type} cannot be simplified to markdown, but here is the raw content:\n",
+            )
 
-    if is_page_html and not force_raw:
-        return extract_content_from_html(page_raw), ""
-
-    return (
-        page_raw,
-        f"Content type {content_type} cannot be simplified to markdown, but here is the raw content:\n",
-    )
+    raise AssertionError("unreachable: fetch_url's retry loop always returns or raises")
 
 
 class Fetch(BaseModel):
@@ -182,6 +224,8 @@ async def serve(
     custom_user_agent: str | None = None,
     ignore_robots_txt: bool = False,
     proxy_url: str | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay_ms: int = DEFAULT_RETRY_DELAY_MS,
 ) -> None:
     """Run the fetch MCP server.
 
@@ -189,6 +233,9 @@ async def serve(
         custom_user_agent: Optional custom User-Agent string to use for requests
         ignore_robots_txt: Whether to ignore robots.txt restrictions
         proxy_url: Optional proxy URL to use for requests
+        max_retries: Max attempts for a fetch, including the first, before giving up on
+            transient errors (429/500/502/503/504 or network errors)
+        retry_delay_ms: Initial backoff delay in milliseconds, doubled on each retry
     """
     server = Server("mcp-fetch")
     user_agent_autonomous = custom_user_agent or DEFAULT_USER_AGENT_AUTONOMOUS
@@ -235,7 +282,12 @@ Although originally you did not have internet access, and were advised to refuse
             await check_may_autonomously_fetch_url(url, user_agent_autonomous, proxy_url)
 
         content, prefix = await fetch_url(
-            url, user_agent_autonomous, force_raw=args.raw, proxy_url=proxy_url
+            url,
+            user_agent_autonomous,
+            force_raw=args.raw,
+            proxy_url=proxy_url,
+            max_retries=max_retries,
+            retry_delay_ms=retry_delay_ms,
         )
         original_length = len(content)
         if args.start_index >= original_length:
@@ -262,7 +314,13 @@ Although originally you did not have internet access, and were advised to refuse
         url = arguments["url"]
 
         try:
-            content, prefix = await fetch_url(url, user_agent_manual, proxy_url=proxy_url)
+            content, prefix = await fetch_url(
+                url,
+                user_agent_manual,
+                proxy_url=proxy_url,
+                max_retries=max_retries,
+                retry_delay_ms=retry_delay_ms,
+            )
             # TODO: after SDK bug is addressed, don't catch the exception
         except McpError as e:
             return GetPromptResult(

--- a/src/fetch/tests/test_server.py
+++ b/src/fetch/tests/test_server.py
@@ -10,6 +10,7 @@ from mcp_server_fetch.server import (
     check_may_autonomously_fetch_url,
     fetch_url,
     DEFAULT_USER_AGENT_AUTONOMOUS,
+    _compute_retry_delay_seconds,
 )
 
 
@@ -286,11 +287,14 @@ class TestFetchUrl:
 
     @pytest.mark.asyncio
     async def test_fetch_500_raises_error(self):
-        """Test that 500 response raises McpError."""
+        """Test that a 500 response raises McpError once retries are exhausted."""
         mock_response = MagicMock()
         mock_response.status_code = 500
+        mock_response.headers = {}
 
-        with patch("httpx.AsyncClient") as mock_client_class:
+        with patch("httpx.AsyncClient") as mock_client_class, patch(
+            "mcp_server_fetch.server.asyncio.sleep", new=AsyncMock()
+        ):
             mock_client = AsyncMock()
             mock_client.get = AsyncMock(return_value=mock_response)
             mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -301,6 +305,108 @@ class TestFetchUrl:
                     "https://example.com/error",
                     DEFAULT_USER_AGENT_AUTONOMOUS
                 )
+
+            # Default max_retries=3: the initial attempt plus 2 retries
+            assert mock_client.get.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_fetch_404_does_not_retry(self):
+        """Test that a non-retryable status like 404 fails on the first attempt."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("httpx.AsyncClient") as mock_client_class, patch(
+            "mcp_server_fetch.server.asyncio.sleep", new=AsyncMock()
+        ) as mock_sleep:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            with pytest.raises(McpError):
+                await fetch_url(
+                    "https://example.com/notfound",
+                    DEFAULT_USER_AGENT_AUTONOMOUS
+                )
+
+            assert mock_client.get.call_count == 1
+            mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_retries_then_succeeds(self):
+        """Test that a transient 503 is retried and a subsequent success is returned."""
+        error_response = MagicMock()
+        error_response.status_code = 503
+        error_response.headers = {}
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.text = '{"data": "ok"}'
+        success_response.headers = {"content-type": "application/json"}
+
+        with patch("httpx.AsyncClient") as mock_client_class, patch(
+            "mcp_server_fetch.server.asyncio.sleep", new=AsyncMock()
+        ) as mock_sleep:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[error_response, success_response])
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            content, _ = await fetch_url(
+                "https://example.com/flaky",
+                DEFAULT_USER_AGENT_AUTONOMOUS
+            )
+
+            assert content == '{"data": "ok"}'
+            assert mock_client.get.call_count == 2
+            mock_sleep.assert_awaited_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_fetch_respects_retry_after_header(self):
+        """Test that a numeric Retry-After header on a 429 overrides the backoff delay."""
+        rate_limited_response = MagicMock()
+        rate_limited_response.status_code = 429
+        rate_limited_response.headers = {"retry-after": "7"}
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.text = "ok"
+        success_response.headers = {"content-type": "text/plain"}
+
+        with patch("httpx.AsyncClient") as mock_client_class, patch(
+            "mcp_server_fetch.server.asyncio.sleep", new=AsyncMock()
+        ) as mock_sleep:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[rate_limited_response, success_response])
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            await fetch_url("https://example.com/limited", DEFAULT_USER_AGENT_AUTONOMOUS)
+
+            mock_sleep.assert_awaited_once_with(7.0)
+
+    @pytest.mark.asyncio
+    async def test_fetch_network_error_retries(self):
+        """Test that a network-level HTTPError is retried like a transient status code."""
+        from httpx import HTTPError
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.text = "ok"
+        success_response.headers = {"content-type": "text/plain"}
+
+        with patch("httpx.AsyncClient") as mock_client_class, patch(
+            "mcp_server_fetch.server.asyncio.sleep", new=AsyncMock()
+        ):
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[HTTPError("boom"), success_response])
+            mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            content, _ = await fetch_url("https://example.com/flaky", DEFAULT_USER_AGENT_AUTONOMOUS)
+
+            assert content == "ok"
+            assert mock_client.get.call_count == 2
 
     @pytest.mark.asyncio
     async def test_fetch_with_proxy(self):
@@ -324,3 +430,31 @@ class TestFetchUrl:
 
             # Verify AsyncClient was called with proxy
             mock_client_class.assert_called_once_with(proxy="http://proxy.example.com:8080")
+
+
+class TestComputeRetryDelaySeconds:
+    """Tests for _compute_retry_delay_seconds function."""
+
+    def test_exponential_backoff(self):
+        """Test that the delay doubles with each attempt."""
+        assert _compute_retry_delay_seconds(0, 1000) == 1.0
+        assert _compute_retry_delay_seconds(1, 1000) == 2.0
+        assert _compute_retry_delay_seconds(2, 1000) == 4.0
+
+    def test_caps_at_max_delay(self):
+        """Test that backoff is capped at MAX_RETRY_DELAY_MS."""
+        assert _compute_retry_delay_seconds(10, 1000) == 10.0
+
+    def test_numeric_retry_after_overrides_backoff(self):
+        """Test that a numeric Retry-After header takes precedence over backoff."""
+        assert _compute_retry_delay_seconds(0, 1000, retry_after_header="5") == 5.0
+
+    def test_retry_after_capped_at_max_delay(self):
+        """Test that an oversized Retry-After is still capped."""
+        assert _compute_retry_delay_seconds(0, 1000, retry_after_header="9999") == 10.0
+
+    def test_non_numeric_retry_after_falls_back_to_backoff(self):
+        """Test that an HTTP-date Retry-After (unsupported) falls back to backoff."""
+        assert _compute_retry_delay_seconds(
+            1, 1000, retry_after_header="Wed, 21 Oct 2026 07:28:00 GMT"
+        ) == 2.0


### PR DESCRIPTION
## Description

The `fetch` MCP server returns transient HTTP errors (`429`, `5xx`) and network errors straight to the calling agent, with no retry. A short backoff would clear most of these, but every caller has to reimplement that logic itself.

## Server Details
- Server: fetch
- Changes to: internal retry/backoff behavior of the `fetch` tool and prompt, environment variables

## Motivation and Context

Closes #4449. Transient errors are the norm for public APIs and documentation sites under load. Handling retries in the server keeps agent prompts clean and avoids wasted LLM turns handling errors a retry would have resolved.

- Retryable: `429`, `500`, `502`, `503`, `504`, and network-level errors (connection reset, timeout, DNS failure, etc. — anything `httpx` raises as `HTTPError`)
- Non-retryable: everything else (`400`, `401`, `403`, `404`, `405`, `409`, `410`, `422`, ...) — fails on the first attempt, no wasted delay
- Default policy: 3 attempts total, 1s initial delay, 2x backoff factor, capped at 10s
- A numeric `Retry-After` header on a `429` response overrides the backoff delay for that wait; a non-numeric value (e.g. an HTTP-date) falls back to the computed backoff
- Configurable via `FETCH_MAX_RETRIES` and `FETCH_RETRY_DELAY_MS` environment variables

Scope note: the fetch server only ever issues GET requests, so the "don't retry non-idempotent methods" concern from the issue doesn't apply here — there's nothing else to opt out of.

## How Has This Been Tested?

- 9 new tests: retry-then-succeed on a 503, non-retryable 404 fails fast with no sleep, `Retry-After` override, network-error (`HTTPError`) retry, and direct unit tests of the backoff-delay helper (exponential growth, max-delay cap, numeric vs. non-numeric `Retry-After`). `uv run pytest`: 29 passed, all fast (`asyncio.sleep` is mocked so no test actually waits).
- `uv run ruff check .`: clean. `uv run pyright`: 0 errors.
- Manually smoke-tested that `FETCH_MAX_RETRIES` / `FETCH_RETRY_DELAY_MS` reach `serve()` correctly, and that defaults (3 / 1000ms) apply when unset.
- Have not tested this against a live LLM client — happy to if wanted before merge.

## Breaking Changes

Behavioral, not interface-breaking: a request that previously failed immediately on a transient error will now retry up to 3 times before failing, adding up to ~3s of latency in the worst case. No config changes required for existing users; opt out isn't currently exposed (`FETCH_MAX_RETRIES=1` achieves the same effect if needed).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options

## Additional context

This PR is independent of #4636 (the `--timeout` PR, also against `fetch`) — built on a separate branch off current `main`, no shared commits. They touch adjacent but non-overlapping code in `fetch_url`/`serve`, so either can merge first without blocking the other; happy to rebase if needed.