### PR TITLE
fix(filesystem): resolve Unicode-equivalent paths

### DIFF
--- a/src/filesystem/__tests__/unicode-paths.test.ts
+++ b/src/filesystem/__tests__/unicode-paths.test.ts
@@ -1,0 +1,49 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { setAllowedDirectories, validatePath } from '../lib.js';
+
+describe('Unicode-equivalent filesystem paths', () => {
+  let testDirectory: string;
+
+  beforeEach(async () => {
+    testDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-unicode-paths-'));
+    setAllowedDirectories([testDirectory]);
+  });
+
+  afterEach(async () => {
+    setAllowedDirectories([]);
+    await fs.rm(testDirectory, { recursive: true, force: true });
+  });
+
+  it('resolves an existing decomposed path from a composed request', async () => {
+    const onDiskDirectory = 'de\u0301marche';
+    const onDiskFile = 're\u0301sume\u0301.txt';
+    await fs.mkdir(path.join(testDirectory, onDiskDirectory));
+    await fs.writeFile(path.join(testDirectory, onDiskDirectory, onDiskFile), 'content');
+
+    const resolved = await validatePath(path.join(testDirectory, 'd\u00e9marche', 'r\u00e9sum\u00e9.txt'));
+
+    expect(resolved).toBe(await fs.realpath(path.join(testDirectory, onDiskDirectory, onDiskFile)));
+  });
+
+  it('preserves a new basename after resolving a Unicode-equivalent parent', async () => {
+    const onDiskDirectory = 'de\u0301marche';
+    await fs.mkdir(path.join(testDirectory, onDiskDirectory));
+
+    const resolved = await validatePath(path.join(testDirectory, 'd\u00e9marche', 'new.txt'));
+
+    expect(resolved).toBe(path.join(await fs.realpath(path.join(testDirectory, onDiskDirectory)), 'new.txt'));
+  });
+
+  it('rejects ambiguous canonically equivalent entries', async () => {
+    const composed = 'caf\u00e9';
+    const decomposed = 'cafe\u0301';
+    await fs.mkdir(path.join(testDirectory, composed));
+    await fs.mkdir(path.join(testDirectory, decomposed));
+
+    await expect(validatePath(path.join(testDirectory, 'cafe\u0341', 'file.txt')))
+      .rejects.toThrow('Ambiguous Unicode path component');
+  });
+});

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -96,6 +96,46 @@ function resolveRelativePathAgainstAllowedDirectories(relativePath: string): str
 }
 
 // Security & Validation Functions
+async function resolveUnicodeEquivalentPath(absolutePath: string): Promise<string> {
+  const allowedDirectory = [...allowedDirectories]
+    .sort((left, right) => right.length - left.length)
+    .find(directory => isPathWithinAllowedDirectories(normalizePath(absolutePath), [directory]));
+
+  if (!allowedDirectory) {
+    return absolutePath;
+  }
+
+  let currentPath = await fs.realpath(allowedDirectory);
+  const relativeParts = path.relative(allowedDirectory, absolutePath).split(path.sep).filter(Boolean);
+
+  for (let index = 0; index < relativeParts.length; index++) {
+    const requestedPart = relativeParts[index];
+    const entries = (await fs.readdir(currentPath)) ?? [];
+    const exactMatch = entries.find(entry => entry === requestedPart);
+    const equivalentMatches = exactMatch
+      ? [exactMatch]
+      : entries.filter(entry => entry.normalize('NFC') === requestedPart.normalize('NFC'));
+
+    if (equivalentMatches.length > 1) {
+      throw new Error(`Ambiguous Unicode path component: ${requestedPart}`);
+    }
+
+    if (equivalentMatches.length === 0) {
+      if (index === relativeParts.length - 1) {
+        return path.join(currentPath, requestedPart);
+      }
+      throw new Error(`Parent directory does not exist: ${path.join(currentPath, requestedPart)}`);
+    }
+
+    currentPath = await fs.realpath(path.join(currentPath, equivalentMatches[0]));
+    if (!isPathWithinAllowedDirectories(normalizePath(currentPath), allowedDirectories)) {
+      throw new Error(`Access denied - symlink target outside allowed directories: ${currentPath} not in ${allowedDirectories.join(', ')}`);
+    }
+  }
+
+  return currentPath;
+}
+
 export async function validatePath(requestedPath: string): Promise<string> {
   const expandedPath = expandHome(requestedPath);
   const absolute = path.isAbsolute(expandedPath)
@@ -123,16 +163,13 @@ export async function validatePath(requestedPath: string): Promise<string> {
     // Security: For new files that don't exist yet, verify parent directory
     // This ensures we can't create files in unauthorized locations
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      const parentDir = path.dirname(absolute);
       try {
-        const realParentPath = await fs.realpath(parentDir);
-        const normalizedParent = normalizePath(realParentPath);
-        if (!isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
-          throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
+        return await resolveUnicodeEquivalentPath(absolute);
+      } catch (resolutionError) {
+        if ((resolutionError as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new Error(`Parent directory does not exist: ${path.dirname(absolute)}`);
         }
-        return absolute;
-      } catch {
-        throw new Error(`Parent directory does not exist: ${parentDir}`);
+        throw resolutionError;
       }
     }
     throw error;


### PR DESCRIPTION
﻿## Description

Resolve filesystem paths whose requested spelling and on-disk entry differ only by Unicode normalization (for example NFC `?` versus NFD `e + combining acute`).

The normal lookup remains the fast path. After `fs.realpath()` returns `ENOENT`, validation now walks from the most specific allowed directory and:
- prefers exact component matches;
- falls back to canonically equivalent NFC matches;
- rejects ambiguous equivalent entries;
- resolves and revalidates every matched component against the existing allowed-directory boundary;
- preserves a missing final basename so create and move destinations continue to work.

## Server Details
- Server: filesystem
- Changes to: shared path validation used by filesystem tools

## Motivation and Context

Fixes #4633.

This differs from #3238: normalizing strings used by the security comparison does not resolve an OS lookup when the actual directory entry uses another normalization form. This change locates the real entry and then retains the existing realpath-based security checks.

## How Has This Been Tested?

- `npx vitest run src/filesystem/__tests__/unicode-paths.test.ts src/filesystem/__tests__/lib.test.ts --config src/filesystem/vitest.config.ts` (49 passed)
- `npm run build --workspace @modelcontextprotocol/server-filesystem`
- Full filesystem suite: 154 passed, 1 pre-existing Windows-only failure in `path-validation.test.ts > handles root directory as allowed` (`D:\other` with allowed `['/']`).

Added real-filesystem regression coverage for:
- composed request resolving a decomposed directory and filename;
- a new destination basename under a Unicode-equivalent parent;
- rejection of ambiguous canonically equivalent entries.

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

The path containment implementation itself is unchanged. The fallback only runs after `ENOENT`, starts from an already allowed root, and re-checks each resolved component to prevent a normalization fallback from bypassing symlink boundaries.
