### PR TITLE
fix(memory): constrain search_nodes query length

### DIFF
--- a/src/memory/__tests__/search-nodes-schema.test.ts
+++ b/src/memory/__tests__/search-nodes-schema.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { SearchNodesQuerySchema, SEARCH_QUERY_MAX_LENGTH } from '../index.js';
+
+describe('search_nodes input schema', () => {
+  it('should accept a normal query', () => {
+    expect(SearchNodesQuerySchema.safeParse('Alice').success).toBe(true);
+    expect(SearchNodesQuerySchema.safeParse('works at Acme Corp').success).toBe(true);
+  });
+
+  it('should accept a query at exactly the max length', () => {
+    const atLimit = 'a'.repeat(SEARCH_QUERY_MAX_LENGTH);
+    expect(SearchNodesQuerySchema.safeParse(atLimit).success).toBe(true);
+  });
+
+  it('should reject a query longer than the max length', () => {
+    const oversized = 'a'.repeat(SEARCH_QUERY_MAX_LENGTH + 1);
+    const result = SearchNodesQuerySchema.safeParse(oversized);
+    expect(result.success).toBe(false);
+  });
+
+  it('should still reject non-string input', () => {
+    expect(SearchNodesQuerySchema.safeParse(42).success).toBe(false);
+    expect(SearchNodesQuerySchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -486,6 +486,13 @@ server.registerTool(
   }
 );
 
+export const SEARCH_QUERY_MAX_LENGTH = 2048;
+
+export const SearchNodesQuerySchema = z
+  .string()
+  .max(SEARCH_QUERY_MAX_LENGTH)
+  .describe("The search query to match against entity names, types, and observation content");
+
 // Register search_nodes tool
 server.registerTool(
   "search_nodes",
@@ -493,7 +500,7 @@ server.registerTool(
     title: "Search Nodes",
     description: "Search for nodes in the knowledge graph based on a query",
     inputSchema: {
-      query: z.string().describe("The search query to match against entity names, types, and observation content")
+      query: SearchNodesQuerySchema
     },
     outputSchema: {
       entities: z.array(EntitySchema),


### PR DESCRIPTION
## Summary

Add a length constraint to the memory server's `search_nodes` `query` parameter, per #3537 (official servers' string parameters lack `maxLength`/`pattern` constraints, creating DoS and malformed-input risk).

## Root Cause

`src/memory/index.ts` registers `search_nodes` with `query: z.string()` — completely unbounded. Each call with an oversized query still triggers a full O(graph) scan over every entity name, type, and observation, for no retrieval value.

## Fix

Follows the pattern in #4282 (time server string constraints):

- `SEARCH_QUERY_MAX_LENGTH = 2048` named constant — generous for real retrieval queries, hard cap against abuse.
- Exported `SearchNodesQuerySchema` (`z.string().max(...)`) used by the tool's `inputSchema`, so the constraint is testable directly.

Scope kept to `query` as named in #3537's memory-server finding; other parameters can follow in separate PRs.

## Test

New `src/memory/__tests__/search-nodes-schema.test.ts` (vitest, per CONTRIBUTING):

- normal query accepted; query at exactly the limit accepted; over-limit rejected; non-string input still rejected.

`npm test` in `src/memory`: 4 test files, 54 tests passed (including the 4 new cases).

## Diff scope

`src/memory/index.ts` (+8/-1), new test file (+25).
