### PR TITLE
docs: add Unified Pay CLI to ADDITIONAL.md

### DIFF
--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -20,6 +20,7 @@ This is a curated collection of community-built frameworks and resources that si
 * **[mcp_sse (Elixir)](https://github.com/kEND/mcp_sse)** An SSE implementation in Elixir for rapidly creating MCP servers.
 * **[mxcp](https://github.com/raw-labs/mxcp)** (Python) - Open-source framework for building enterprise-grade MCP servers using just YAML, SQL, and Python, with built-in auth, monitoring, ETL and policy enforcement.
 * **[Next.js MCP Server Template](https://github.com/vercel-labs/mcp-for-next.js)** (Typescript) - A starter Next.js project that uses the MCP Adapter to allow MCP clients to connect and access resources.
+* **[Unified Pay CLI](https://github.com/pritam825/unified-pay-cli)** (TypeScript) - Universal payment gateway orchestration and checkout generation for AI agents across Stripe, Razorpay, and LemonSqueezy. [npm](https://www.npmjs.com/package/unified-pay-cli)
 * **[PayMCP](https://github.com/blustAI/paymcp)** (Python & TypeScript) - Lightweight payments layer for MCP servers: turn tools into paid endpoints with a two-line decorator. [PyPI](https://pypi.org/project/paymcp/) · [npm](https://www.npmjs.com/package/paymcp) · [TS repo](https://github.com/blustAI/paymcp-ts)
 * **[Perl SDK](https://github.com/mojolicious/mojo-mcp)** - An SDK for building MCP servers and clients with the Perl programming language.
 * **[Quarkus MCP Server SDK](https://github.com/quarkiverse/quarkus-mcp-server)** (Java)


### PR DESCRIPTION
Adds unified-pay-cli under the Finance & Payments category.

Repository: https://github.com/pritam825/unified-pay-cli
NPM: https://www.npmjs.com/package/unified-pay-cli
Description: Universal CLI and MCP server providing unified payment links, customer prefilling, expiring checkouts, refund management, fee comparison, and HMAC-verified webhook proxying across Stripe, Razorpay, and LemonSqueezy.