### PR TITLE
fix(filesystem): reject move_file when destination exists

### DIFF
--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -631,6 +631,20 @@ server.registerTool(
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
     const validSourcePath = await validatePath(args.source);
     const validDestPath = await validatePath(args.destination);
+
+    // Check if destination exists (documented behavior: fail if destination exists)
+    try {
+      await fs.stat(validDestPath);
+      throw new Error(`Destination already exists: ${args.destination}`);
+    } catch (err: any) {
+      if (err instanceof Error && err.message.startsWith("Destination already exists")) {
+        throw err;
+      }
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+
     await fs.rename(validSourcePath, validDestPath);
     const text = `Successfully moved ${args.source} to ${args.destination}`;
     const contentBlock = { type: "text" as const, text };


### PR DESCRIPTION
Closes #4628

## Problem
`move_file` silently overwrites an existing destination file even though the README and the tool description both state it will *fail if the destination exists*. This is a data-loss bug: an agent that trusts the documented safety contract can destroy files.

## Fix
Add an existence check via `fs.stat` before `fs.rename`. If the destination already exists, an error is thrown immediately, matching the documented contract.

```ts
try {
  await fs.stat(validDestPath);
  throw new Error(`Destination already exists: ${args.destination}`);
} catch (err: any) {
  if (err instanceof Error && err.message.startsWith("Destination already exists")) {
    throw err;
  }
  if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
    throw err;
  }
}
await fs.rename(validSourcePath, validDestPath);
```

## Testing
- `server-filesystem` test suite: **152 passed** (7 test files).