### PR TITLE
Add SRI to Resources

### DIFF
--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -88,6 +88,7 @@ This is a curated collection of community-built frameworks and resources that si
 - **[MCP.ing](https://mcp.ing/)** - A list of MCP services for discovering MCP servers in the community and providing a convenient search function for MCP services by **[iiiusky](https://github.com/iiiusky)**
 - **[MCP Hunt](https://mcp-hunt.com)** - Realtime platform for discovering trending MCP servers with momentum tracking, upvoting, and community discussions - like Product Hunt meets Reddit for MCP
 - **[Smithery](https://smithery.ai/)** - A registry of MCP servers to find the right tools for your LLM agents by **[Henry Mao](https://github.com/calclavia)**
+- **[SRI](https://sri-test.biz)** - Reads the published source of MCP servers and reports what they actually do, with every finding quoted at `file:line`. 2,000+ registry servers already read; free, no key, no signup. [Method and raw counts](https://github.com/SRITEST0001/sri/tree/main/research)
 - **[Toolbase](https://gettoolbase.ai)** - Desktop application that manages tools and MCP servers with just a few clicks - no coding required by **[gching](https://github.com/gching)**
 - **[ToolHive](https://github.com/StacklokLabs/toolhive)** - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization by **[StacklokLabs](https://github.com/StacklokLabs)**
 - **[NetMind](https://www.netmind.ai/AIServices)** - Access powerful AI services via simple APIs or MCP servers to supercharge your productivity.


### PR DESCRIPTION
Adds SRI to the Resources list in ADDITIONAL.md.

SRI reads the published source of MCP servers and reports what they do, with
every finding anchored to a file:line and the code quoted verbatim. Findings
whose quoted evidence cannot be located in the file are dropped, so the claims
are checkable rather than asserted.

It reports observations, not verdicts — it does not certify that a server is
safe, and an empty result is not a clearance.

2,174 registry servers have been read so far. The per-category counts and the
method are published, so the numbers can be recomputed rather than trusted:
https://github.com/SRITEST0001/sri/tree/main/research

The live figures are also served as JSON, free and without a key:

    curl https://sri-test.biz/v1/corpus

Checking one server, free, no key:

    curl -X POST https://sri-test.biz/v1/verify \
      -H 'Content-Type: application/json' \
      -d '{"ecosystem":"mcp","name":"io.github.firebase/firebase-mcp","version":"0.3.0"}'

Also published in the MCP Registry as biz.sri-test/verifier.

Disclosure: I built and run this. It is free right now. If a finding is wrong
there is a form on the site and it will be withdrawn.