### PR TITLE
fix(filesystem): strip trailing whitespace on write and edits

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -6,6 +6,7 @@ import {
   // Pure utility functions
   formatSize,
   normalizeLineEndings,
+  stripTrailingWhitespace,
   createUnifiedDiff,
   // Security & validation functions
   validatePath,
@@ -377,6 +378,57 @@ describe('Lib Functions', () => {
         await expect(writeFileContent('/test/script.sh', 'new content')).resolves.toBeUndefined();
         expect(mockFs.unlink).not.toHaveBeenCalled();
       });
+
+      it('strips trailing whitespace from each line before writing', async () => {
+        mockFs.writeFile.mockResolvedValueOnce(undefined);
+
+        await writeFileContent('/test/file.txt', 'line1   \nline2\t\nline3');
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          '/test/file.txt',
+          'line1\nline2\nline3',
+          { encoding: "utf-8", flag: 'wx' }
+        );
+      });
+
+      it('strips trailing whitespace on the EEXIST/atomic-rename fallback path too', async () => {
+        const eexistError = Object.assign(new Error('exists'), { code: 'EEXIST' });
+        mockFs.writeFile.mockRejectedValueOnce(eexistError);
+        mockFs.stat.mockResolvedValueOnce({ mode: 0o100644 });
+        mockFs.writeFile.mockResolvedValueOnce(undefined);
+        mockFs.rename.mockResolvedValueOnce(undefined);
+        mockFs.chmod.mockResolvedValueOnce(undefined);
+
+        await writeFileContent('/test/file.txt', 'line1   \nline2  ');
+
+        expect(mockFs.writeFile).toHaveBeenLastCalledWith(
+          expect.stringContaining('/test/file.txt.'),
+          'line1\nline2',
+          'utf-8'
+        );
+      });
+    });
+
+    describe('stripTrailingWhitespace', () => {
+      it('removes trailing spaces and tabs from each line', () => {
+        const input = 'line1   \nline2\t\t\nline3';
+        expect(stripTrailingWhitespace(input)).toBe('line1\nline2\nline3');
+      });
+
+      it('leaves leading whitespace untouched', () => {
+        const input = '    indented line   \n\tmixed indent\t';
+        expect(stripTrailingWhitespace(input)).toBe('    indented line\n\tmixed indent');
+      });
+
+      it('does not change content with no trailing whitespace', () => {
+        const input = 'line1\nline2\nline3';
+        expect(stripTrailingWhitespace(input)).toBe(input);
+      });
+
+      it('preserves blank lines and trailing newline', () => {
+        const input = 'line1  \n\nline3   \n';
+        expect(stripTrailingWhitespace(input)).toBe('line1\n\nline3\n');
+      });
     });
 
     describe('moveFile', () => {
@@ -601,6 +653,60 @@ describe('Lib Functions', () => {
         expect(mockFs.rename).toHaveBeenCalledWith(
           expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
           '/test/file.txt'
+        );
+      });
+
+      it('strips trailing whitespace from the new text of an edit', async () => {
+        const edits = [
+          { oldText: 'line2', newText: 'modified line2   \t' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'line1\nmodified line2\nline3\n',
+          'utf-8'
+        );
+      });
+
+      it('does not touch trailing whitespace on lines outside the edit', async () => {
+        // line3 has trailing spaces but is never targeted by an edit
+        mockFs.readFile.mockResolvedValue('line1\nline2\nline3   \n');
+
+        const edits = [
+          { oldText: 'line1', newText: 'first line' }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'first line\nline2\nline3   \n',
+          'utf-8'
+        );
+      });
+
+      it('strips trailing whitespace from multi-line replacement text', async () => {
+        const edits = [
+          {
+            oldText: 'line1\nline2',
+            newText: 'first line  \nsecond line\t'
+          }
+        ];
+
+        mockFs.rename.mockResolvedValueOnce(undefined);
+
+        await applyFileEdits('/test/file.txt', edits, false);
+
+        expect(mockFs.writeFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\/test\/file\.txt\.[a-f0-9]+\.tmp$/),
+          'first line\nsecond line\nline3\n',
+          'utf-8'
         );
       });
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -58,6 +58,17 @@ export function normalizeLineEndings(text: string): string {
   return text.replace(/\r\n/g, '\n');
 }
 
+// Strips trailing horizontal whitespace (spaces/tabs) from every line.
+// Applied only to content that is actually being written, so callers
+// that pass already-clean content see no behavioral change, and edits
+// never touch whitespace on lines outside the edit itself.
+export function stripTrailingWhitespace(text: string): string {
+  return text
+    .split('\n')
+    .map(line => line.replace(/[ \t]+$/, ''))
+    .join('\n');
+}
+
 export function createUnifiedDiff(originalContent: string, newContent: string, filepath: string = 'file'): string {
   // Ensure consistent line endings for diff
   const normalizedOriginal = normalizeLineEndings(originalContent);
@@ -203,10 +214,14 @@ export async function readFileContent(filePath: string, encoding: string = 'utf-
 }
 
 export async function writeFileContent(filePath: string, content: string): Promise<void> {
+  // Strip trailing whitespace from every line before writing. This is the
+  // content the caller is asking us to write, so cleaning it here avoids
+  // the trailing-whitespace/lint churn reported in #1590.
+  const cleanedContent = stripTrailingWhitespace(content);
   try {
     // Security: 'wx' flag ensures exclusive creation - fails if file/symlink exists,
     // preventing writes through pre-existing symlinks
-    await fs.writeFile(filePath, content, { encoding: "utf-8", flag: 'wx' });
+    await fs.writeFile(filePath, cleanedContent, { encoding: "utf-8", flag: 'wx' });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
       // Security: Use atomic rename to prevent race conditions where symlinks
@@ -215,7 +230,7 @@ export async function writeFileContent(filePath: string, content: string): Promi
       const origStats = await fs.stat(filePath);
       const tempPath = `${filePath}.${randomBytes(16).toString('hex')}.tmp`;
       try {
-        await fs.writeFile(tempPath, content, 'utf-8');
+        await fs.writeFile(tempPath, cleanedContent, 'utf-8');
         await fs.rename(tempPath, filePath);
       } catch (renameError) {
         try {
@@ -274,7 +289,10 @@ export async function applyFileEdits(
   let modifiedContent = content;
   for (const edit of edits) {
     const normalizedOld = normalizeLineEndings(edit.oldText);
-    const normalizedNew = normalizeLineEndings(edit.newText);
+    // Strip trailing whitespace from the incoming replacement text only -
+    // this is the content the edit is introducing, so it's safe to clean
+    // without touching whitespace on unrelated lines elsewhere in the file.
+    const normalizedNew = stripTrailingWhitespace(normalizeLineEndings(edit.newText));
 
     // If exact match exists, use it
     if (modifiedContent.includes(normalizedOld)) {


### PR DESCRIPTION
Fixes #1590.

## Description
`writeFileContent` and `applyFileEdits` now strip trailing horizontal
whitespace before writing. Scoped narrowly:
- `writeFileContent` cleans the full content being written.
- `applyFileEdits` only cleans the `newText` an edit introduces — untouched
  lines elsewhere in the file are unaffected.

## Server Details
- Server: filesystem
- Changes to: tools (write_file, edit_file behavior)

## Motivation and Context
Many linters/repos reject trailing whitespace, and the assistant was
producing it on every write, triggering repeated cleanup loops (see #1590).
A similar normalization system was previously removed in b477af5 for being
over-engineered fuzzy matching — this is intentionally much narrower.

## How Has This Been Tested?
Added unit tests for `stripTrailingWhitespace`, `writeFileContent`, and
`applyFileEdits` (including a test confirming lines outside an edit are
left untouched). Ran `npm test` (161/161 passing) and `npm run build`
(clean) locally.

## Breaking Changes
None. No MCP client config changes needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follow MCP security best practices
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling