### PR TITLE
docs: remove dead opentoolsteam attribution link from ADDITIONAL.md

### DIFF
--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -81,7 +81,7 @@ This is a curated collection of community-built frameworks and resources that si
 - **[MCPWatch](https://github.com/kapilduraphe/mcp-watch)** - A comprehensive security scanner for Model Context Protocol (MCP) servers that detects vulnerabilities and security issues in your MCP server implementations.
 - **[mkinf](https://mkinf.io)** - An Open Source registry of hosted MCP Servers to accelerate AI agent workflows.
 - **[Open-Sourced MCP Servers Directory](https://github.com/chatmcp/mcp-directory)** - A curated list of MCP servers by **[mcpso](https://mcp.so)**
-- **[OpenTools](https://opentools.com)** - An open registry for finding, installing, and building with MCP servers by **[opentoolsteam](https://github.com/opentoolsteam)**
+- **[OpenTools](https://opentools.com)** - An open registry for finding, installing, and building with MCP servers
 - **[Programmatic MCP Prototype](https://github.com/domdomegg/programmatic-mcp-prototype)** - Experimental agent prototype demonstrating programmatic MCP tool composition, progressive tool discovery, state persistence, and skill building through TypeScript code execution by **[Adam Jones](https://github.com/domdomegg)**
 - **[PulseMCP](https://www.pulsemcp.com)** ([API](https://www.pulsemcp.com/api)) - Community hub & weekly newsletter for discovering MCP servers, clients, articles, and news by **[Tadas Antanavicius](https://github.com/tadasant)**, **[Mike Coughlin](https://github.com/macoughl)**, and **[Ravina Patel](https://github.com/ravinahp)**
 - **[r/mcp](https://www.reddit.com/r/mcp)** – A Reddit community dedicated to MCP by **[Frank Fiegel](https://github.com/punkpeye)**


### PR DESCRIPTION
## Description

Removes the attribution link to `opentoolsteam` from the OpenTools entry in `ADDITIONAL.md`, since that GitHub organization no longer exists.

## Motivation and Context

The link https://github.com/opentoolsteam returns 404, while the OpenTools product site itself (https://opentools.com) is still live. This change removes the dead link and keeps the OpenTools entry intact.

## How Has This Been Tested?

Documentation-only change. Verified:
- `https://api.github.com/users/opentoolsteam` returns 404
- `https://opentools.com` is live and serving the OpenTools registry
- no other references to `opentoolsteam` remain in the repository

## Breaking Changes

None.

## Types of changes
- [x] Documentation update