### PR TITLE
Add OpenLM MCP Server

### DIFF
--- a/servers/openlm-mcp-server/README.md
+++ b/servers/openlm-mcp-server/README.md
@@ -1,0 +1,81 @@
+# OpenLM MCP Server
+
+Query license usage, allocations, and analytics data directly through Claude using the OpenLM MCP Server.
+
+## Overview
+
+The OpenLM MCP Server exposes 43 powerful tools that enable Claude users to access their OpenLM license management data through natural conversation. Users can query license usage metrics, view allocations, and access detailed analytics without leaving Claude.
+
+## Features
+
+- **43 Tools** for license management queries
+- **License Usage Queries** - Real-time consumption metrics and trends
+- **Allocations** - View and manage license assignments
+- **Analytics & Reporting** - Comprehensive dashboards and data exports
+- **OAuth 2.0 Authentication** - Secure, credential-based access
+- **Read-Only Access** - Safe exploration of license data
+
+## Authentication
+
+The server uses OAuth 2.0 authentication with OpenLM credentials. Users authenticate once in Claude and gain access to all their OpenLM license data with read-only permissions.
+
+## Setup
+
+1. Add the OpenLM connector in Claude Settings → Connectors
+2. Authenticate with your OpenLM credentials
+3. Grant permission for license data access
+4. Start querying your license data!
+
+For detailed setup instructions, see [SETUP.md](./SETUP.md)
+
+## Available Tools
+
+### License Usage (15 tools)
+- Query current license usage
+- View usage trends and analytics
+- Analyze consumption patterns
+- Compare usage across departments
+
+### Allocations (14 tools)
+- View current allocations
+- See allocation assignments
+- Track allocation history
+- Manage user assignments
+
+### Analytics & Reporting (14 tools)
+- Generate custom reports
+- Access pre-built dashboards
+- Export data in multiple formats
+- Visualize license metrics
+
+## Example Queries
+
+Once connected, you can ask Claude questions like:
+
+- "What's our current license usage?"
+- "Show me our license allocations"
+- "Generate a usage report for this quarter"
+- "Which licenses are running low?"
+- "What's our license utilization rate?"
+- "Compare our usage to allocations"
+
+## Support
+
+- **Documentation**: https://www.openlm.com/docs/mcp-server
+- **Support Email**: support@openlm.com
+- **Issues**: Report problems on GitHub
+
+## About OpenLM
+
+OpenLM is the industry-leading platform for AI and software license management. Learn more at https://www.openlm.com
+
+## License
+
+Proprietary - OpenLM
+
+---
+
+**Protocol**: Model Context Protocol (MCP)  
+**Version**: 0.1.0  
+**Author**: OpenLM  
+**Last Updated**: August 2026

--- a/servers/openlm-mcp-server/SETUP.md
+++ b/servers/openlm-mcp-server/SETUP.md
@@ -1,0 +1,89 @@
+# OpenLM MCP Server - Claude Setup Guide
+
+## Overview
+
+The OpenLM MCP Server connects Claude to your OpenLM license management system, giving you instant access to license usage data, allocations, and analytics through natural conversation.
+
+## Prerequisites
+
+- An active OpenLM account with valid credentials
+- - Access to the OpenLM platform (https://www.openlm.com)
+  - - Claude desktop app or web interface with connector support
+   
+    - ## Installation Steps
+   
+    - ### Step 1: Add the OpenLM Connector in Claude
+   
+    - 1. Open Claude (desktop app or web)
+      2. 2. Go to **Settings** → **Connectors** (or **Integrations**)
+         3. 3. Search for **"OpenLM"** or **"OpenLM License Manager"**
+            4. 4. Click **"Add"** or **"Install"**
+              
+               5. ### Step 2: Authenticate with OpenLM
+              
+               6. When prompted, you'll see the OpenLM login screen:
+              
+               7. 1. Enter your **OpenLM username** (or email)
+                  2. 2. Enter your **OpenLM password**
+                     3. 3. Click **"Sign In"**
+                       
+                        4. The authentication uses OAuth 2.0 through the secure OpenLM endpoint (https://cloud-us.openlm.com/mcp).
+                       
+                        5. ### Step 3: Grant Permissions
+                       
+                        6. Claude will request permission to access:
+                        7. - License usage data (read-only)
+                           - - License allocations (read-only)
+                             - - Analytics and reporting data (read-only)
+                              
+                               - Click **"Allow"** to proceed.
+                              
+                               - ### Step 4: Verify Connection
+                              
+                               - Once connected, the OpenLM connector status will show as **"Connected"** in your integrations list.
+                              
+                               - ## Using the OpenLM Connector
+                              
+                               - After setup, you can ask Claude questions like:
+                              
+                               - - "What's my current license usage?"
+                                 - - "Show me my license allocations"
+                                   - - "Give me a summary of license analytics"
+                                     - - "Which licenses are running low?"
+                                       - - "What's my license utilization rate?"
+                                        
+                                         - ## Troubleshooting
+                                        
+                                         - ### Authentication Failed
+                                         - - Verify your OpenLM credentials are correct
+                                           - - Check if your account is active on the OpenLM platform
+                                             - - Try logging in directly at https://www.openlm.com to confirm access
+                                              
+                                               - ### Permission Denied
+                                               - - Ensure you granted all required permissions during authentication
+                                                 - - Re-authenticate by removing and re-adding the connector
+                                                  
+                                                   - ### No Data Appearing
+                                                   - - Verify the connector shows "Connected" status
+                                                     - - Check that your OpenLM account has active licenses
+                                                       - - Contact OpenLM support if issues persist
+                                                        
+                                                         - ## Support
+                                                        
+                                                         - For additional help:
+                                                         - - Visit OpenLM documentation: https://www.openlm.com/docs/mcp-server
+                                                           - - Contact OpenLM support: support@openlm.com
+                                                             - - Check the MCP Server repository: https://openlm.visualstudio.com/OpenLM/_git/OpenlmAIReporting
+                                                              
+                                                               - ## Security & Privacy
+                                                              
+                                                               - - All authentication happens through secure OAuth 2.0
+                                                                 - - Your credentials are never stored in Claude
+                                                                   - - Data access is limited to read-only operations
+                                                                     - - OpenLM maintains SOC 2 compliance for data security
+                                                                      
+                                                                       - ---
+
+                                                                       **Version:** 0.1.0
+                                                                       **Last Updated:** August 2026
+                                                                       **Protocol:** Model Context Protocol (MCP)

--- a/servers/openlm-mcp-server/manifest.json
+++ b/servers/openlm-mcp-server/manifest.json
@@ -1,0 +1,55 @@
+{
+    "name": "openlm-mcp-server",
+    "version": "0.1.0",
+    "displayName": "OpenLM License Manager",
+    "description": "Query license usage, allocations, and analytics data through Claude",
+    "author": {
+          "name": "OpenLM",
+          "email": "support@openlm.com",
+          "url": "https://www.openlm.com"
+    },
+    "homepage": "https://www.openlm.com",
+    "documentationUrl": "https://www.openlm.com/docs/mcp-server",
+    "repositoryUrl": "https://openlm.visualstudio.com/OpenLM/_git/OpenlmAIReporting",
+    "protocol": "mcp",
+    "protocolVersion": "2024-11-05",
+    "capabilities": {
+          "resources": false,
+          "prompts": false,
+          "tools": true
+    },
+    "tools": [
+          {
+                  "name": "Query License Usage",
+                  "description": "Query license usage data and metrics"
+          },
+          {
+                  "name": "Get Allocations",
+                  "description": "Retrieve license allocations and assignments"
+          },
+          {
+                  "name": "View Analytics",
+                  "description": "Access license analytics and reporting data"
+          }
+    ],
+    "authentication": {
+          "type": "oauth2",
+          "endpoint": "https://cloud-us.openlm.com/mcp",
+          "tokenEndpoint": "https://cloud-us.openlm.com/oauth/token",
+          "scopes": ["read:licenses", "read:usage", "read:analytics"],
+          "description": "Authenticate with your OpenLM credentials via OAuth 2.0"
+    },
+    "pricing": {
+          "model": "free",
+          "description": "Free for OpenLM subscribers"
+    },
+    "keywords": [
+          "license-management",
+          "mcp",
+          "model-context-protocol",
+          "openlm",
+          "reporting",
+          "analytics"
+    ],
+    "tags": ["integration", "productivity", "analytics"]
+}


### PR DESCRIPTION
## Summary
This adds the OpenLM MCP Server to the registry, enabling Claude users to query license usage, allocations, and analytics data through natural conversation.

## Details
- **Server Name:** OpenLM License Manager
- **Total Tools:** 43 tools across three categories
  - License Usage: 15 tools for querying usage metrics and trends
  - Allocations: 14 tools for viewing and managing license assignments
  - Analytics & Reporting: 14 tools for generating reports and accessing dashboards
- **Authentication:** OAuth 2.0 with OpenLM credentials
- **Endpoint:** https://cloud-us.openlm.com/mcp
- **Website:** https://www.openlm.com

## User Setup
Users authenticate with their OpenLM credentials via OAuth 2.0. Complete installation instructions are provided in SETUP.md, with a step-by-step guide for adding the connector in Claude, authenticating, granting permissions, and verifying the connection.

## Files Included
- `manifest.json` - Server metadata and configuration
- `README.md` - User-facing documentation with feature overview and example queries
- `SETUP.md` - Installation guide with troubleshooting and security information