### PR TITLE
docs(time): correct Example Interactions to match server output

### DIFF
--- a/src/time/README.md
+++ b/src/time/README.md
@@ -220,6 +220,7 @@ Response:
 {
   "timezone": "Europe/Warsaw",
   "datetime": "2024-01-01T13:00:00+01:00",
+  "day_of_week": "Monday",
   "is_dst": false
 }
 ```
@@ -240,15 +241,17 @@ Response:
 {
   "source": {
     "timezone": "America/New_York",
-    "datetime": "2024-01-01T12:30:00-05:00",
+    "datetime": "2024-01-01T16:30:00-05:00",
+    "day_of_week": "Monday",
     "is_dst": false
   },
   "target": {
     "timezone": "Asia/Tokyo",
-    "datetime": "2024-01-01T12:30:00+09:00",
+    "datetime": "2024-01-02T06:30:00+09:00",
+    "day_of_week": "Tuesday",
     "is_dst": false
   },
-  "time_difference": "+13.0h",
+  "time_difference": "+14.0h"
 }
 ```
 


### PR DESCRIPTION
The "Example Interactions" responses in `src/time/README.md` don't match what the server actually returns. Verified against `src/time/src/mcp_server_time/server.py`, where `TimeResult` declares four fields (`timezone`, `datetime`, `day_of_week`, `is_dst`).

Five issues:

1. Both examples omit `day_of_week`, which the server always sets via `strftime("%A")`.
2. The `convert_time` source shows `12:30` though the request asks for `16:30`.
3. The target shows `2024-01-01T12:30:00+09:00` — the conversion did nothing. New York 16:30 EST is `2024-01-02T06:30:00+09:00` in Tokyo.
4. `time_difference` reads `+13.0h`; EST (-5) to JST (+9) is **+14.0h**.
5. A trailing comma after `time_difference` makes the JSON invalid.

Documentation only — no code changes.

Credit to @latent-9, who identified these same issues in #4597 and closed that PR themselves.
