### PR TITLE
fix(memory): write graph atomically in saveGraph to prevent file corruption

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -515,4 +515,20 @@ describe('KnowledgeGraphManager', () => {
       expect(result.relations[0]).not.toHaveProperty('type');
     });
   });
+
+  describe('atomic saveGraph persistence', () => {
+    it('should cleanly persist data and leave no leftover temp files', async () => {
+      await manager.createEntities([
+        { name: 'Carol', entityType: 'person', observations: ['software engineer'] },
+      ]);
+
+      const dir = path.dirname(testFilePath);
+      const files = await fs.readdir(dir);
+      const tempFiles = files.filter(f => f.startsWith(path.basename(testFilePath)) && f.endsWith('.tmp'));
+      expect(tempFiles).toHaveLength(0);
+
+      const content = await fs.readFile(testFilePath, 'utf-8');
+      expect(content).toContain('Carol');
+    });
+  });
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -114,7 +114,18 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    const tmpPath = `${this.memoryFilePath}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, lines.join("\n"));
+      await fs.rename(tmpPath, this.memoryFilePath);
+    } catch (error) {
+      try {
+        await fs.unlink(tmpPath);
+      } catch {
+        // Ignore cleanup error if temp file does not exist
+      }
+      throw error;
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {


### PR DESCRIPTION
## Description

Fixes #4614.

In `KnowledgeGraphManager.saveGraph()` (`src/memory/index.ts`), the knowledge graph was written directly in-place to `this.memoryFilePath` via `fs.writeFile`. If the process was terminated mid-write (SIGKILL, container stop, OOM kill, power loss), the memory file could be truncated or left corrupt without recovery.

This PR makes saving atomic by:
1. Writing the serialized graph content to a uniquely named temporary file (`${this.memoryFilePath}.${Date.now()}-${random}.tmp`) in the same directory.
2. Atomically renaming the temporary file over the target `this.memoryFilePath` using `fs.rename()`.
3. Cleaning up the temporary file if an error occurs before renaming.

## Changes
- Update `KnowledgeGraphManager.saveGraph` in `src/memory/index.ts` to write to temp file then rename.
- Add test in `src/memory/__tests__/knowledge-graph.test.ts` verifying atomic persistence and no leftover temp files.

## Verification
- Ran `npm test` and `npm run build` in `src/memory`. All 51 tests pass.