### PR TITLE
fix(filesystem): allow create_directory to create nested parent directories

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -205,6 +205,23 @@ describe('Lib Functions', () => {
           .rejects.toThrow('Parent directory does not exist');
       });
 
+      it('allows missing parent directory when allowMissingParents is true', async () => {
+        const allowedDir = process.platform === 'win32' ? 'C:\\Users\\test' : '/home/user';
+        const deeplyNestedPath = process.platform === 'win32' ? 'C:\\Users\\test\\deep\\nested\\dir' : '/home/user/deep/nested/dir';
+
+        const enoentError = new Error('ENOENT') as NodeJS.ErrnoException;
+        enoentError.code = 'ENOENT';
+
+        mockFs.realpath
+          .mockRejectedValueOnce(enoentError) // deep/nested/dir
+          .mockRejectedValueOnce(enoentError) // deep/nested
+          .mockRejectedValueOnce(enoentError) // deep
+          .mockResolvedValueOnce(allowedDir); // /home/user
+
+        const result = await validatePath(deeplyNestedPath, true);
+        expect(result).toBe(path.resolve(deeplyNestedPath));
+      });
+
       it('resolves relative paths against allowed directories instead of process.cwd()', async () => {
         const relativePath = 'test-file.txt';
         const originalCwd = process.cwd;

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -425,7 +425,7 @@ server.registerTool(
     annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false, openWorldHint: false }
   },
   async (args: z.infer<typeof CreateDirectoryArgsSchema>) => {
-    const validPath = await validatePath(args.path);
+    const validPath = await validatePath(args.path, true);
     await fs.mkdir(validPath, { recursive: true });
     const text = `Successfully created directory ${args.path}`;
     return {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -96,7 +96,7 @@ function resolveRelativePathAgainstAllowedDirectories(relativePath: string): str
 }
 
 // Security & Validation Functions
-export async function validatePath(requestedPath: string): Promise<string> {
+export async function validatePath(requestedPath: string, allowMissingParents: boolean = false): Promise<string> {
   const expandedPath = expandHome(requestedPath);
   const absolute = path.isAbsolute(expandedPath)
     ? path.resolve(expandedPath)
@@ -123,6 +123,31 @@ export async function validatePath(requestedPath: string): Promise<string> {
     // Security: For new files that don't exist yet, verify parent directory
     // This ensures we can't create files in unauthorized locations
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (allowMissingParents) {
+        let cur = path.dirname(absolute);
+        while (cur !== path.dirname(cur)) {
+          const normalizedCur = normalizePath(cur);
+          if (!isPathWithinAllowedDirectories(normalizedCur, allowedDirectories)) {
+            throw new Error(`Access denied - ancestor directory outside allowed directories: ${cur} not in ${allowedDirectories.join(', ')}`);
+          }
+          try {
+            const realCur = await fs.realpath(cur);
+            const normalizedRealCur = normalizePath(realCur);
+            if (!isPathWithinAllowedDirectories(normalizedRealCur, allowedDirectories)) {
+              throw new Error(`Access denied - ancestor directory outside allowed directories: ${realCur} not in ${allowedDirectories.join(', ')}`);
+            }
+            return absolute;
+          } catch (ancestorErr) {
+            if ((ancestorErr as NodeJS.ErrnoException).code === 'ENOENT') {
+              cur = path.dirname(cur);
+              continue;
+            }
+            throw ancestorErr;
+          }
+        }
+        return absolute;
+      }
+
       const parentDir = path.dirname(absolute);
       try {
         const realParentPath = await fs.realpath(parentDir);


### PR DESCRIPTION
## Description

Fixes #4629.

The tool description and documentation for `create_directory` explicitly state that it can create multiple nested directories in one operation ("Creates parent directories if needed", "Can create multiple nested directories in one operation"). However, `validatePath()` rejected paths when their immediate parent did not yet exist with `"Parent directory does not exist: <path>"`.

This PR adds an `allowMissingParents` parameter to `validatePath()` (defaulting to `false` for other file operations to maintain strict behavior). When enabled for `create_directory`, `validatePath()` securely verifies all ancestors up to the closest existing directory against the allowed directories list, ensuring path security is maintained while allowing `fs.mkdir(validPath, { recursive: true })` to create intermediate directories as documented.

## Changes
- Update `validatePath` in `src/filesystem/lib.ts` to accept `allowMissingParents: boolean = false` and securely walk up to the nearest existing ancestor.
- Update `create_directory` in `src/filesystem/index.ts` to pass `allowMissingParents = true`.
- Add unit test in `src/filesystem/__tests__/lib.test.ts` verifying `allowMissingParents: true` succeeds for nested non-existent directory hierarchies within allowed roots.

## Verification
- Ran `npm test` and `npm run build` in `src/filesystem`. All 153 tests pass.