### PR TITLE
fix(sequentialthinking): keep nextThoughtNeeded in inputSchema `required`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3906,7 +3906,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^4.0.0"
       },
       "bin": {
         "mcp-server-sequential-thinking": "dist/index.js"

--- a/src/sequentialthinking/__tests__/schema.test.ts
+++ b/src/sequentialthinking/__tests__/schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { coercedBoolean } from '../lib.js';
+
+describe('coercedBoolean - value coercion', () => {
+  it('accepts real booleans unchanged', () => {
+    expect(coercedBoolean.parse(true)).toBe(true);
+    expect(coercedBoolean.parse(false)).toBe(false);
+  });
+
+  it('coerces the strings "true"/"false" (case-insensitive)', () => {
+    expect(coercedBoolean.parse('true')).toBe(true);
+    expect(coercedBoolean.parse('false')).toBe(false);
+    expect(coercedBoolean.parse('TRUE')).toBe(true);
+    expect(coercedBoolean.parse('False')).toBe(false);
+  });
+
+  it('rejects other values instead of silently passing them through', () => {
+    // Regression guard: a naive coercion that returns the raw value would let
+    // the truthy string "false" through as `true`; these must all fail.
+    expect(coercedBoolean.safeParse('yes').success).toBe(false);
+    expect(coercedBoolean.safeParse('').success).toBe(false);
+    expect(coercedBoolean.safeParse(1).success).toBe(false);
+    expect(coercedBoolean.safeParse(null).success).toBe(false);
+  });
+});
+
+describe('coercedBoolean - JSON Schema generation (issue #4651)', () => {
+  async function toolInputSchema(inputSchema: Record<string, unknown>) {
+    const server = new McpServer({ name: 'test', version: '0.0.0' });
+    server.registerTool(
+      'probe',
+      { inputSchema: inputSchema as never },
+      async () => ({ content: [] }),
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const { tools } = await client.listTools();
+    await client.close();
+    return tools.find((t) => t.name === 'probe')!.inputSchema;
+  }
+
+  it('keeps a non-optional coercedBoolean field in `required`', async () => {
+    const schema = await toolInputSchema({ flag: coercedBoolean });
+    expect(schema.required).toContain('flag');
+  });
+
+  it('omits an .optional() coercedBoolean field from `required`', async () => {
+    const schema = await toolInputSchema({ flag: coercedBoolean.optional() });
+    expect(schema.required ?? []).not.toContain('flag');
+  });
+});

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -3,17 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { SequentialThinkingServer } from './lib.js';
-
-/** Safe boolean coercion that correctly handles string "false" */
-const coercedBoolean = z.preprocess((val) => {
-  if (typeof val === "boolean") return val;
-  if (typeof val === "string") {
-    if (val.toLowerCase() === "true") return true;
-    if (val.toLowerCase() === "false") return false;
-  }
-  return val;
-}, z.boolean());
+import { SequentialThinkingServer, coercedBoolean } from './lib.js';
 
 const server = new McpServer({
   name: "sequential-thinking-server",

--- a/src/sequentialthinking/lib.ts
+++ b/src/sequentialthinking/lib.ts
@@ -1,4 +1,25 @@
 import chalk from 'chalk';
+import { z } from 'zod';
+
+/**
+ * Boolean coercion that also accepts the strings "true"/"false" (case-insensitive),
+ * which some MCP clients send for boolean arguments.
+ *
+ * Implemented as a union rather than `z.preprocess(fn, z.boolean())`: `z.preprocess`
+ * widens the *input* type to `unknown`, so JSON Schema generation (`io: "input"`)
+ * treats the field as optional and drops it from `required` even when it is not
+ * `.optional()`. A union keeps a concrete input type, so required fields stay required.
+ */
+export const coercedBoolean = z.union([
+  z.boolean(),
+  z.string().transform((val, ctx) => {
+    const normalized = val.toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+    ctx.addIssue({ code: 'custom', message: `Expected "true" or "false", received "${val}"` });
+    return z.NEVER;
+  }),
+]);
 
 export interface ThoughtData {
   thought: string;

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Description

`nextThoughtNeeded` is declared as a non-optional field on the `sequentialthinking`
tool, but it is missing from the generated JSON Schema's `required` array. Clients
that build call arguments from the advertised schema omit it and get
`-32602 Input validation error`, which contradicts the schema.

Root cause: the `coercedBoolean` helper was `z.preprocess(fn, z.boolean())`. Under
Zod v4, `z.preprocess` widens the *input* type to `unknown`, so the SDK's JSON
Schema generation (`io: "input"`) treats the field as optional and drops it from
`required` — even though it is not `.optional()`. (Regression from #3533.)

Fix: reimplement `coercedBoolean` as `z.union([z.boolean(), z.string().transform(...)])`.
The union keeps a concrete input type, so non-optional fields stay in `required`,
while still coercing `"true"`/`"false"` (case-insensitively) and now rejecting other
strings with a clearer message. `isRevision` / `needsMoreThoughts` remain optional.

The only schema shape change: these boolean fields now serialize as
`{ "anyOf": [{ "type": "boolean" }, { "type": "string" }] }`, which accurately
reflects the accepted input.

## Server Details
- Server: sequentialthinking
- Changes to: tools (input schema for `sequentialthinking`)

## Motivation and Context

Fixes #4651. Without this, schema-driven MCP clients cannot call the tool without
manually knowing `nextThoughtNeeded` is required despite the schema saying otherwise.

## How Has This Been Tested?

- New `src/sequentialthinking/__tests__/schema.test.ts`:
  - Round-trips a probe tool through the MCP SDK (`McpServer` + `Client` over
    `InMemoryTransport`) and asserts a required `coercedBoolean` field stays in
    `inputSchema.required`, while an `.optional()` one does not.
  - Value coercion: `true`/`false`, `"true"`/`"false"`/`"TRUE"`/`"False"`, and
    rejection of `"yes"`, `""`, `1`, `null`.
- `npm run build` and `npm test` pass in `src/sequentialthinking` (19 tests).
- Verified against the SDK's actual conversion path (Zod v4 → `zod/v4-mini`
  `toJSONSchema`, `io: "input"`), not a hand-rolled converter.

## Breaking Changes

None for tool callers — the field was always meant to be required and the runtime
validation already required it. MCP client configs need no changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly — not needed; the README
      already lists `nextThoughtNeeded` as a non-optional `(boolean)` input
- [ ] I have tested this with an LLM client — tested with the MCP SDK client and
      automated tests
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options — n/a

## Additional context

`coercedBoolean` moved from `index.ts` to `lib.ts` (exported) so it can be unit
tested; `index.ts` now imports it. `zod` is added as an explicit dependency of the
package since it is imported directly (matching the `everything` server).