### PR TITLE
fix(filesystem): reject Windows paths on POSIX

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -155,6 +155,13 @@ describe('Lib Functions', () => {
 
   describe('Security & Validation Functions', () => {
     describe('validatePath', () => {
+      it('rejects Windows drive paths on POSIX hosts', async () => {
+        if (process.platform === 'win32') return;
+
+        await expect(validatePath('C:\\Users\\me\\notes\\file.md'))
+          .rejects.toThrow('Windows-style path received on a POSIX host');
+      });
+
       // Use Windows-compatible paths for testing
       const allowedDirs = process.platform === 'win32' ? ['C:\\Users\\test', 'C:\\temp'] : ['/home/user', '/tmp'];
 

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -98,6 +98,12 @@ function resolveRelativePathAgainstAllowedDirectories(relativePath: string): str
 // Security & Validation Functions
 export async function validatePath(requestedPath: string): Promise<string> {
   const expandedPath = expandHome(requestedPath);
+  // Do not silently reinterpret a Windows drive path as a relative POSIX path.
+  // This would create a literal filename such as `C:\\Users\\...` inside the
+  // allowed root and report success for the wrong location.
+  if (process.platform !== 'win32' && /^(?:[A-Za-z]:)(?:[\\/]|$)/.test(expandedPath)) {
+    throw new Error(`Access denied - Windows-style path received on a POSIX host: ${requestedPath}`);
+  }
   const absolute = path.isAbsolute(expandedPath)
     ? path.resolve(expandedPath)
     : resolveRelativePathAgainstAllowedDirectories(expandedPath);


### PR DESCRIPTION
## What does this PR do?

Fixes #4686.

On POSIX hosts, a Windows drive path such as `C:\\Users\\me\\notes\\file.md` was treated as a relative filename inside the allowed directory. The operation could report success while writing to the wrong path.

Reject drive-letter forms before relative path resolution when running on POSIX. Windows behavior and normal POSIX paths are unchanged. A regression test covers the rejection.

## Verification

- `git diff --check` passes.
- Local Vitest execution is currently blocked because the installed Node binary cannot start: Homebrew's `simdjson` dylib is missing.
