### PR TITLE
fix(filesystem): allow recursive directory creation

### DIFF
--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -190,21 +190,22 @@ describe('Lib Functions', () => {
         expect(result).toBe(path.resolve(newFilePath));
       });
 
-      it('rejects when parent directory does not exist', async () => {
+      it('walks up to the nearest existing ancestor for nested paths', async () => {
         const newFilePath = process.platform === 'win32' ? 'C:\\Users\\test\\nonexistent\\newfile.txt' : '/home/user/nonexistent/newfile.txt';
-        
-        // Create errors with the ENOENT code
+
+        // The target and its immediate parent are absent; the allowed root exists.
         const enoentError1 = new Error('ENOENT') as NodeJS.ErrnoException;
         enoentError1.code = 'ENOENT';
         const enoentError2 = new Error('ENOENT') as NodeJS.ErrnoException;
         enoentError2.code = 'ENOENT';
-        
+        const existingRoot = process.platform === 'win32' ? 'C:\\Users\\test' : '/home/user';
+
         mockFs.realpath
           .mockRejectedValueOnce(enoentError1)
-          .mockRejectedValueOnce(enoentError2);
-        
-        await expect(validatePath(newFilePath))
-          .rejects.toThrow('Parent directory does not exist');
+          .mockRejectedValueOnce(enoentError2)
+          .mockResolvedValueOnce(existingRoot);
+
+        await expect(validatePath(newFilePath)).resolves.toBe(path.resolve(newFilePath));
       });
 
       it('resolves relative paths against allowed directories instead of process.cwd()', async () => {

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -120,19 +120,29 @@ export async function validatePath(requestedPath: string): Promise<string> {
     }
     return realPath;
   } catch (error) {
-    // Security: For new files that don't exist yet, verify parent directory
-    // This ensures we can't create files in unauthorized locations
+    // Security: For new files/directories, resolve the nearest existing
+    // ancestor. This permits mkdir({ recursive: true }) while still checking
+    // the real path of an existing directory for symlink escapes.
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      const parentDir = path.dirname(absolute);
-      try {
-        const realParentPath = await fs.realpath(parentDir);
-        const normalizedParent = normalizePath(realParentPath);
-        if (!isPathWithinAllowedDirectories(normalizedParent, allowedDirectories)) {
-          throw new Error(`Access denied - parent directory outside allowed directories: ${realParentPath} not in ${allowedDirectories.join(', ')}`);
+      let existingAncestor = path.dirname(absolute);
+      while (true) {
+        try {
+          const realAncestorPath = await fs.realpath(existingAncestor);
+          const normalizedAncestor = normalizePath(realAncestorPath);
+          if (!isPathWithinAllowedDirectories(normalizedAncestor, allowedDirectories)) {
+            throw new Error(`Access denied - parent directory outside allowed directories: ${realAncestorPath} not in ${allowedDirectories.join(', ')}`);
+          }
+          return absolute;
+        } catch (ancestorError) {
+          if ((ancestorError as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw ancestorError;
+          }
         }
-        return absolute;
-      } catch {
-        throw new Error(`Parent directory does not exist: ${parentDir}`);
+        const parent = path.dirname(existingAncestor);
+        if (parent === existingAncestor) {
+          throw new Error(`Parent directory does not exist: ${existingAncestor}`);
+        }
+        existingAncestor = parent;
       }
     }
     throw error;


### PR DESCRIPTION
## Summary

- resolve the nearest existing ancestor when validating a new path
- preserve realpath checks for symlink escapes while allowing nested paths
- make the existing recursive `create_directory` contract work for arbitrarily deep paths
- update validation coverage for missing intermediate directories

Closes #4629

## Validation

- `git diff --check`
- TypeScript/Vitest execution is currently blocked on this host because the Homebrew Node 22 binary cannot load `libsimdjson.29.dylib`.