### PR TITLE
fix(filesystem): reject existing move destinations

### DIFF
--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -124,6 +124,20 @@ describe('structuredContent schema compliance', () => {
       // The content should contain success message
       expect(structuredContent.content).toContain('Successfully moved');
     });
+
+    it('should reject an existing destination without overwriting it', async () => {
+      const sourcePath = path.join(testDir, 'test.txt');
+      const destPath = path.join(testDir, 'existing.txt');
+      await fs.writeFile(destPath, 'keep this content');
+
+      await expect(client.callTool({
+        name: 'move_file',
+        arguments: { source: sourcePath, destination: destPath }
+      })).rejects.toThrow('Destination already exists');
+
+      await expect(fs.readFile(sourcePath, 'utf-8')).resolves.toBe('test content');
+      await expect(fs.readFile(destPath, 'utf-8')).resolves.toBe('keep this content');
+    });
   });
 
   describe('list_directory (control - already working)', () => {

--- a/src/filesystem/__tests__/structured-content.test.ts
+++ b/src/filesystem/__tests__/structured-content.test.ts
@@ -130,10 +130,15 @@ describe('structuredContent schema compliance', () => {
       const destPath = path.join(testDir, 'existing.txt');
       await fs.writeFile(destPath, 'keep this content');
 
-      await expect(client.callTool({
+      const result = await client.callTool({
         name: 'move_file',
         arguments: { source: sourcePath, destination: destPath }
-      })).rejects.toThrow('Destination already exists');
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0]).toMatchObject({
+        type: 'text',
+        text: expect.stringContaining('Destination already exists'),
+      });
 
       await expect(fs.readFile(sourcePath, 'utf-8')).resolves.toBe('test content');
       await expect(fs.readFile(destPath, 'utf-8')).resolves.toBe('keep this content');

--- a/src/filesystem/index.ts
+++ b/src/filesystem/index.ts
@@ -631,6 +631,17 @@ server.registerTool(
   async (args: z.infer<typeof MoveFileArgsSchema>) => {
     const validSourcePath = await validatePath(args.source);
     const validDestPath = await validatePath(args.destination);
+    // fs.rename replaces an existing destination on POSIX (and has platform-
+    // dependent overwrite semantics elsewhere). The tool contract promises a
+    // failed move instead, so make the check explicit to prevent data loss.
+    try {
+      await fs.lstat(validDestPath);
+      throw new Error(`Destination already exists: ${args.destination}`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
     await fs.rename(validSourcePath, validDestPath);
     const text = `Successfully moved ${args.source} to ${args.destination}`;
     const contentBlock = { type: "text" as const, text };


### PR DESCRIPTION
## Summary

- reject `move_file` when the destination already exists
- avoid platform-dependent `fs.rename` overwrite behavior and potential data loss
- add an integration regression test verifying both source and destination remain intact

Closes #4628

## Validation

- `git diff --check`
- Vitest execution is currently blocked on this host because the Homebrew Node 22 binary cannot load `libsimdjson.29.dylib`.