### PR TITLE
fix(memory): persist graph snapshots atomically

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -59,6 +59,16 @@ describe('KnowledgeGraphManager', () => {
       const newEntities = await manager.createEntities([]);
       expect(newEntities).toHaveLength(0);
     });
+
+    it('should persist graph snapshots without leaving temporary files', async () => {
+      await manager.createEntities([
+        { name: 'Atomic', entityType: 'test', observations: ['durable'] },
+      ]);
+
+      const files = await fs.readdir(path.dirname(testFilePath));
+      expect(files.filter(file => file.startsWith(path.basename(testFilePath) + '.') && file.endsWith('.tmp'))).toEqual([]);
+      await expect(fs.readFile(testFilePath, 'utf-8')).resolves.toContain('Atomic');
+    });
   });
 
   describe('createRelations', () => {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { randomUUID } from 'crypto';
 
 // Define memory file path using environment variable with fallback
 export const defaultMemoryPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'memory.jsonl');
@@ -114,7 +115,22 @@ export class KnowledgeGraphManager {
         relationType: r.relationType
       })),
     ];
-    await fs.writeFile(this.memoryFilePath, lines.join("\n"));
+    // Write the complete snapshot away from the live file, then atomically
+    // replace it. A direct writeFile truncates memory.jsonl first, so a process
+    // interruption can leave the graph permanently partial or unreadable.
+    const temporaryPath = `${this.memoryFilePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(temporaryPath, lines.join("\n"));
+      await fs.rename(temporaryPath, this.memoryFilePath);
+    } finally {
+      try {
+        await fs.unlink(temporaryPath);
+      } catch (error) {
+        if (!(error instanceof Error && 'code' in error && (error as any).code === 'ENOENT')) {
+          throw error;
+        }
+      }
+    }
   }
 
   async createEntities(entities: Entity[]): Promise<Entity[]> {


### PR DESCRIPTION
## Summary

- write memory graph snapshots to a unique temporary file
- atomically replace the live JSONL file with `rename`
- clean up temporary files on both success and failure
- add regression coverage ensuring persistence leaves no temporary artifact

Closes #4614

## Validation

- `git diff --check`
- Local Vitest execution is blocked because the Homebrew Node 22 binary cannot load `libsimdjson.29.dylib`; the change is covered by the repository test suite in CI.