### PR TITLE
everything: remove disconnected sessions from resource subscriptions

### DIFF
--- a/src/everything/resources/subscriptions.ts
+++ b/src/everything/resources/subscriptions.ts
@@ -166,3 +166,22 @@ export const stopSimulatedResourceUpdates = (sessionId?: string) => {
     subsUpdateIntervals.delete(sessionId);
   }
 };
+
+/**
+ * Removes a session from every URI's subscriber set, dropping any URI entry
+ * that ends up with no remaining subscribers.
+ *
+ * A session that disconnects without explicitly unsubscribing otherwise stays
+ * in `subscriptions` for the life of the process. Call this from the
+ * transport's `cleanup(sessionId)` when a session ends.
+ *
+ * @param {string} [sessionId]
+ */
+export const removeSubscriber = (sessionId?: string) => {
+  for (const [uri, subscribers] of subscriptions) {
+    subscribers.delete(sessionId);
+    if (subscribers.size === 0) {
+      subscriptions.delete(uri);
+    }
+  }
+};

--- a/src/everything/server/index.ts
+++ b/src/everything/server/index.ts
@@ -6,6 +6,7 @@ import {
 import {
   setSubscriptionHandlers,
   stopSimulatedResourceUpdates,
+  removeSubscriber,
 } from "../resources/subscriptions.js";
 import { registerConditionalTools, registerTools } from "../tools/index.js";
 import { registerResources, readInstructions } from "../resources/index.js";
@@ -110,6 +111,8 @@ export const createServer: () => ServerFactoryResponse = () => {
       // Stop any simulated logging or resource updates that may have been initiated.
       stopSimulatedLogging(sessionId);
       stopSimulatedResourceUpdates(sessionId);
+      // Drop this session from any resource subscriptions it left open.
+      removeSubscriber(sessionId);
       // Clean up task store timers
       taskStore.cleanup();
       if (initializeTimeout) clearTimeout(initializeTimeout);


### PR DESCRIPTION
Fixes #4710.

`subscriptions` (`Map<uri, Set<sessionId>>` in `src/everything/resources/subscriptions.ts`) only ever had entries removed via an explicit `resources/unsubscribe` call. A session that disconnects without unsubscribing stayed in every `Set` it had joined for the life of the process — `cleanup(sessionId)` stops the logging/update intervals and task-store timers but never touched `subscriptions`.

**Fix:** add `removeSubscriber(sessionId)`, which iterates the map, deletes the session from each `Set`, and drops any URI entry left with no subscribers. Call it from `cleanup()` alongside the existing calls, matching the pattern the reporter suggested in the issue.

**Verified:**
- `tsc --noEmit` — clean
- `vitest run __tests__/resources.test.ts __tests__/server.test.ts` — 29/29 passing
- `prettier --check` — passes

Impact is limited to the reference `everything` server, but per the issue, it's the example people copy, so worth fixing correctly.