### PR TITLE
fix(filesystem): prevent forced backslash conversion of drive paths on POSIX (#4686)

### DIFF
--- a/src/filesystem/path-utils.ts
+++ b/src/filesystem/path-utils.ts
@@ -93,6 +93,10 @@ export function normalizePath(p: string): string {
 
   // Handle Windows paths: convert slashes and ensure drive letter is capitalized
   if (normalized.match(/^[a-zA-Z]:/)) {
+    if (process.platform !== 'win32') {
+      // On POSIX, Windows drive paths (e.g. C:\...) are not native absolute paths; preserve or format cleanly
+      return normalized;
+    }
     let result = normalized.replace(/\//g, '\\');
     // Capitalize drive letter if present
     if (/^[a-z]:/.test(result)) {


### PR DESCRIPTION
## Summary
- Fixes #4686 by ensuring Windows-style drive paths on POSIX platforms do not get converted to invalid backslash formats during `normalizePath`.
- Preserves native path separators depending on the runtime `process.platform`.

## Test Plan
- Verified path normalization on POSIX and Windows formatted test cases.
- Validated `normalizePath('C:/Users/test')` preserves forward slashes on POSIX.