### PR TITLE
fix(memory): validate knowledge graph entries when loading from disk

### DIFF
--- a/src/memory/__tests__/knowledge-graph.test.ts
+++ b/src/memory/__tests__/knowledge-graph.test.ts
@@ -515,4 +515,51 @@ describe('KnowledgeGraphManager', () => {
       expect(result.relations[0]).not.toHaveProperty('type');
     });
   });
+
+  describe('loadGraph validation', () => {
+    it('skips corrupt entities instead of crashing search', async () => {
+      const lines = [
+        JSON.stringify({ type: 'entity', name: 'Alice', entityType: 'person', observations: ['works at Acme Corp'] }),
+        JSON.stringify({ type: 'entity', name: 'Broken', observations: ['missing entityType'] }),
+        JSON.stringify({ type: 'entity', name: 'BadObs', entityType: 'person', observations: ['ok', null] }),
+      ];
+      await fs.writeFile(testFilePath, lines.join('\n') + '\n');
+
+      const graph = await manager.readGraph();
+      expect(graph.entities).toHaveLength(1);
+      expect(graph.entities[0].name).toBe('Alice');
+
+      // searchNodes must not throw even though the file contains corrupt entries
+      const result = await manager.searchNodes('Acme');
+      expect(result.entities).toHaveLength(1);
+      expect(result.entities[0].name).toBe('Alice');
+    });
+
+    it('skips corrupt relations', async () => {
+      const lines = [
+        JSON.stringify({ type: 'entity', name: 'Alice', entityType: 'person', observations: [] }),
+        JSON.stringify({ type: 'relation', from: 'Alice', to: 'Bob' }), // missing relationType
+        JSON.stringify({ type: 'relation', from: 'Alice', to: 'Bob', relationType: 'knows' }),
+      ];
+      await fs.writeFile(testFilePath, lines.join('\n') + '\n');
+
+      const graph = await manager.readGraph();
+      expect(graph.entities).toHaveLength(1);
+      expect(graph.relations).toHaveLength(1);
+      expect(graph.relations[0].relationType).toBe('knows');
+    });
+
+    it('skips malformed JSON lines', async () => {
+      const lines = [
+        JSON.stringify({ type: 'entity', name: 'Alice', entityType: 'person', observations: [] }),
+        '{this is not valid json',
+        JSON.stringify({ type: 'entity', name: 'Bob', entityType: 'person', observations: [] }),
+      ];
+      await fs.writeFile(testFilePath, lines.join('\n') + '\n');
+
+      const graph = await manager.readGraph();
+      expect(graph.entities).toHaveLength(2);
+      expect(graph.entities.map(e => e.name)).toEqual(['Alice', 'Bob']);
+    });
+  });
 });

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -74,24 +74,47 @@ export class KnowledgeGraphManager {
     try {
       const data = await fs.readFile(this.memoryFilePath, "utf-8");
       const lines = data.split("\n").filter(line => line.trim() !== "");
-      return lines.reduce((graph: KnowledgeGraph, line) => {
-        const item = JSON.parse(line);
-        if (item.type === "entity") {
-          graph.entities.push({
-            name: item.name,
-            entityType: item.entityType,
-            observations: item.observations
-          });
+      const graph: KnowledgeGraph = { entities: [], relations: [] };
+
+      for (const line of lines) {
+        let item: unknown;
+        try {
+          item = JSON.parse(line);
+        } catch {
+          console.error("Skipping malformed line in memory file");
+          continue;
         }
-        if (item.type === "relation") {
-          graph.relations.push({
-            from: item.from,
-            to: item.to,
-            relationType: item.relationType
-          });
+
+        if (typeof item !== "object" || item === null) {
+          console.error("Skipping non-object line in memory file");
+          continue;
         }
-        return graph;
-      }, { entities: [], relations: [] });
+
+        const record = item as Record<string, unknown>;
+        if (record.type === "entity") {
+          const parsed = EntitySchema.safeParse(item);
+          if (parsed.success) {
+            graph.entities.push(parsed.data);
+          } else {
+            console.error(
+              "Skipping invalid entity in memory file:",
+              parsed.error.issues.map(issue => `${issue.path.join(".")}: ${issue.message}`).join(", ")
+            );
+          }
+        } else if (record.type === "relation") {
+          const parsed = RelationSchema.safeParse(item);
+          if (parsed.success) {
+            graph.relations.push(parsed.data);
+          } else {
+            console.error(
+              "Skipping invalid relation in memory file:",
+              parsed.error.issues.map(issue => `${issue.path.join(".")}: ${issue.message}`).join(", ")
+            );
+          }
+        }
+      }
+
+      return graph;
     } catch (error) {
       if (error instanceof Error && 'code' in error && (error as any).code === "ENOENT") {
         return { entities: [], relations: [] };


### PR DESCRIPTION
## Description

Fixes #2044 by addressing the root cause rather than adding defensive checks to `searchNodes`.

The crash happens because `loadGraph()` trusts the persisted `memory.jsonl` file and pushes every parsed line into the in-memory graph without validating it. A corrupted or legacy entry — an entity missing `entityType`, an observation that is `null`, a relation missing `relationType` — reaches `searchNodes` and throws `Cannot read properties of undefined (reading 'toLowerCase')`.

This change validates each line against the existing `EntitySchema` / `RelationSchema` before adding it to the graph, and skips malformed entries (including malformed JSON lines) with a warning on stderr. Tools already validate their inputs with these schemas, so this closes the last unvalidated path (the on-disk file) and guarantees the in-memory graph only ever contains well-formed entities and relations.

This follows the direction from the earlier attempt (#2054): fix the source of non-strings rather than papering over the crash in `searchNodes`.

## Server Details
- Server: memory
- Changes to: knowledge graph persistence (loading)

## Motivation and Context

`search_nodes` crashes with `MCP error -32603: Cannot read properties of undefined (reading 'toLowerCase')` for users whose memory file contains a legacy or hand-edited entity. See #2044.

## How Has This Been Tested?

- `npm run build` (tsc) passes.
- `npx vitest run` passes: 58 tests across 4 files (unit level; not yet exercised through a live LLM client).
- Added 3 tests in `knowledge-graph.test.ts` under `loadGraph validation`:
  - corrupt entities (missing `entityType`, `null` observation) are skipped and `searchNodes` no longer throws;
  - corrupt relations (missing `relationType`) are skipped;
  - malformed JSON lines are skipped.
- Existing tests (including "strip type field when loading") still pass.

## Breaking Changes

None. Valid memory files load exactly as before; only malformed entries are now skipped instead of crashing the server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly
- [ ] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have documented all environment variables and configuration options

## Additional context

I kept the skip-with-warning behavior minimal and scoped to loading, so no existing data is mutated and nothing is silently dropped without a stderr trace. The warning text mirrors the existing `console.error` style used for file migration notices.
