### PR TITLE
fix(time): reject nonexistent local times

### DIFF
--- a/src/time/src/mcp_server_time/server.py
+++ b/src/time/src/mcp_server_time/server.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import json
 from typing import Sequence
@@ -91,6 +91,23 @@ class TimeServer:
             parsed_time.minute,
             tzinfo=source_timezone,
         )
+
+        # Attaching ZoneInfo does not validate local wall times. During a
+        # spring-forward transition, times in the skipped interval are silently
+        # assigned the pre-transition offset even though they never occurred.
+        # A UTC round trip normalizes such a value to the first valid local time,
+        # allowing us to reject the invalid input instead of returning a
+        # misleading conversion.
+        round_tripped_source_time = source_time.astimezone(timezone.utc).astimezone(
+            source_timezone
+        )
+        if round_tripped_source_time.replace(tzinfo=None) != source_time.replace(
+            tzinfo=None
+        ):
+            raise ValueError(
+                f"Time {time_str} does not exist in {source_tz} on "
+                f"{source_time.date()} due to a UTC offset transition"
+            )
 
         target_time = source_time.astimezone(target_timezone)
         source_offset = source_time.utcoffset() or timedelta()

--- a/src/time/test/time_server_test.py
+++ b/src/time/test/time_server_test.py
@@ -120,6 +120,37 @@ def test_convert_time_errors(source_tz, time_str, target_tz, expected_error):
         time_server.convert_time(source_tz, time_str, target_tz)
 
 
+def test_convert_time_rejects_nonexistent_dst_time():
+    # New York advances from 01:59 to 03:00 on this date, so 02:30 never
+    # occurs. ZoneInfo otherwise silently assigns it the earlier UTC-05:00
+    # offset and produces a conversion for a nonexistent wall time.
+    with freeze_time("2026-03-08 12:00:00+00:00"):
+        time_server = TimeServer()
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"Time 02:30 does not exist in America/New_York on 2026-03-08 "
+                r"due to a UTC offset transition"
+            ),
+        ):
+            time_server.convert_time("America/New_York", "02:30", "UTC")
+
+
+@pytest.mark.parametrize(
+    "time_str,expected_utc",
+    [
+        ("01:30", "2026-03-08T06:30:00+00:00"),
+        ("03:30", "2026-03-08T07:30:00+00:00"),
+    ],
+)
+def test_convert_time_accepts_valid_times_around_dst_gap(time_str, expected_utc):
+    with freeze_time("2026-03-08 12:00:00+00:00"):
+        result = TimeServer().convert_time("America/New_York", time_str, "UTC")
+
+        assert result.target.datetime == expected_utc
+
+
 @pytest.mark.parametrize(
     "test_time,source_tz,time_str,target_tz,expected",
     [


### PR DESCRIPTION
## Description

Reject nonexistent local wall times during UTC offset transitions instead of silently converting them with the pre-transition offset.

## Server Details

- Server: time
- Changes to: `convert_time` tool

## Motivation and Context

Python allows `datetime` values to be constructed inside a forward clock-change gap even though those wall times never occurred. For example, `2026-03-08 02:30` in `America/New_York` was previously accepted and converted to `07:30 UTC`.

The conversion now round-trips the source time through UTC and rejects it when the local wall time changes. Valid times immediately before and after the gap keep their existing behavior.

## How Has This Been Tested?

- `uv run --python 3.12 pytest -q` — 41 passed
- `uv run --python 3.12 ruff check .`
- `uv run --python 3.12 pyright` — 0 errors, 0 warnings
- Covered a nonexistent New York time and valid times on both sides of the transition

This is a conversion validation change and was not tested through an LLM client.

## Breaking Changes

None. Inputs that do not represent a real local time now return an error instead of a misleading conversion.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My changes follow MCP security best practices
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] No README, environment variable, or client configuration changes are required

## Additional context

This uses only the standard library and the server's existing `ZoneInfo` conversion path. Python documents these skipped wall times as missing times in [PEP 495](https://peps.python.org/pep-0495/).
