### PR TITLE
fix(filesystem): support cross-device moves

### DIFF
--- a/src/filesystem/__tests__/cross-device-move.test.ts
+++ b/src/filesystem/__tests__/cross-device-move.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import net from 'net';
+import os from 'os';
+import path from 'path';
+import { moveFile } from '../lib.js';
+
+describe.skipIf(process.platform === 'win32')('moveFile cross-device fallback', () => {
+  let testDirectory: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (testDirectory) {
+      await fs.rm(testDirectory, { recursive: true, force: true });
+      testDirectory = undefined;
+    }
+  });
+
+  function simulateCrossDeviceRename() {
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, 'rename')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('cross-device link'), { code: 'EXDEV' }),
+      )
+      .mockImplementation(rename);
+  }
+
+  it('preserves relative symbolic links', async () => {
+    testDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'mcp-cross-device-symlink-'),
+    );
+    const source = path.join(testDirectory, 'source');
+    const destination = path.join(testDirectory, 'destination');
+    await fs.mkdir(source, { mode: 0o751 });
+    await fs.writeFile(path.join(source, 'target.txt'), 'payload', {
+      mode: 0o640,
+    });
+    await fs.symlink('target.txt', path.join(source, 'link.txt'));
+    simulateCrossDeviceRename();
+
+    await moveFile(source, destination);
+
+    await expect(fs.readlink(path.join(destination, 'link.txt'))).resolves.toBe(
+      'target.txt',
+    );
+    await expect(
+      fs.readFile(path.join(destination, 'link.txt'), 'utf8'),
+    ).resolves.toBe('payload');
+    expect((await fs.stat(destination)).mode & 0o777).toBe(0o751);
+    expect(
+      (await fs.stat(path.join(destination, 'target.txt'))).mode & 0o777,
+    ).toBe(0o640);
+    await expect(fs.access(source)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('does not expose a partial destination when copying fails', async () => {
+    testDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'mcp-cross-device-failure-'),
+    );
+    const source = path.join(testDirectory, 'source');
+    const destination = path.join(testDirectory, 'destination');
+    await fs.mkdir(source);
+    await fs.writeFile(path.join(source, 'copied-first.txt'), 'payload');
+
+    const socketServer = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      socketServer.once('error', reject);
+      socketServer.listen(path.join(source, 'unsupported.sock'), resolve);
+    });
+    simulateCrossDeviceRename();
+
+    try {
+      await expect(moveFile(source, destination)).rejects.toMatchObject({
+        code: 'ERR_FS_CP_SOCKET',
+      });
+    } finally {
+      await new Promise<void>((resolve) => socketServer.close(() => resolve()));
+    }
+
+    await expect(fs.access(source)).resolves.toBeUndefined();
+    await expect(fs.access(destination)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect((await fs.readdir(testDirectory)).sort()).toEqual(['source']);
+  });
+});

--- a/src/filesystem/__tests__/lib.test.ts
+++ b/src/filesystem/__tests__/lib.test.ts
@@ -393,6 +393,139 @@ describe('Lib Functions', () => {
 
         expect(mockFs.rename).not.toHaveBeenCalled();
       });
+
+      it('falls back to copy and remove across filesystem boundaries', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        const exdev = Object.assign(new Error('cross-device link'), {
+          code: 'EXDEV',
+        });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename.mockRejectedValueOnce(exdev);
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.cp.mockResolvedValueOnce(undefined);
+        mockFs.rename.mockResolvedValueOnce(undefined);
+        mockFs.rm.mockResolvedValueOnce(undefined);
+
+        await moveFile('/source/file.txt', '/mounted-volume/file.txt');
+
+        expect(mockFs.cp).toHaveBeenCalledWith(
+          '/source/file.txt',
+          expect.stringMatching(
+            /^\/mounted-volume\/file\.txt\.[a-f0-9]+\.tmp$/,
+          ),
+          {
+            recursive: true,
+            errorOnExist: true,
+            force: false,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+          },
+        );
+        const tempPath = mockFs.cp.mock.calls[0][1];
+        expect(mockFs.rename).toHaveBeenLastCalledWith(
+          tempPath,
+          '/mounted-volume/file.txt',
+        );
+        expect(mockFs.rm).toHaveBeenCalledWith('/source/file.txt', {
+          recursive: true,
+        });
+      });
+
+      it('does not copy when rename fails for another reason', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        const permissionError = Object.assign(new Error('permission denied'), {
+          code: 'EACCES',
+        });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename.mockRejectedValueOnce(permissionError);
+
+        await expect(
+          moveFile('/source/file.txt', '/mounted-volume/file.txt'),
+        ).rejects.toBe(permissionError);
+
+        expect(mockFs.cp).not.toHaveBeenCalled();
+        expect(mockFs.rm).not.toHaveBeenCalled();
+      });
+
+      it('keeps the source when the cross-filesystem copy fails', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        const exdev = Object.assign(new Error('cross-device link'), {
+          code: 'EXDEV',
+        });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename.mockRejectedValueOnce(exdev);
+        mockFs.cp.mockRejectedValueOnce(new Error('copy failed'));
+        mockFs.rm.mockResolvedValueOnce(undefined);
+
+        await expect(
+          moveFile('/source/file.txt', '/mounted-volume/file.txt'),
+        ).rejects.toThrow('copy failed');
+
+        const tempPath = mockFs.cp.mock.calls[0][1];
+        expect(mockFs.rm).toHaveBeenCalledWith(tempPath, {
+          recursive: true,
+          force: true,
+        });
+        expect(mockFs.rm).not.toHaveBeenCalledWith('/source/file.txt', {
+          recursive: true,
+        });
+      });
+
+      it('does not overwrite a destination created while copying', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        const exdev = Object.assign(new Error('cross-device link'), {
+          code: 'EXDEV',
+        });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename.mockRejectedValueOnce(exdev);
+        mockFs.cp.mockResolvedValueOnce(undefined);
+        mockFs.lstat.mockResolvedValueOnce({} as any);
+        mockFs.rm.mockResolvedValueOnce(undefined);
+
+        await expect(
+          moveFile('/source/file.txt', '/mounted-volume/file.txt'),
+        ).rejects.toThrow('Destination already exists');
+
+        const tempPath = mockFs.cp.mock.calls[0][1];
+        expect(mockFs.rename).toHaveBeenCalledTimes(1);
+        expect(mockFs.rm).toHaveBeenCalledWith(tempPath, {
+          recursive: true,
+          force: true,
+        });
+        expect(mockFs.rm).not.toHaveBeenCalledWith('/source/file.txt', {
+          recursive: true,
+        });
+      });
+
+      it('cleans the staged copy when the final rename fails', async () => {
+        const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+        const exdev = Object.assign(new Error('cross-device link'), {
+          code: 'EXDEV',
+        });
+        const permissionError = Object.assign(new Error('permission denied'), {
+          code: 'EACCES',
+        });
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rename
+          .mockRejectedValueOnce(exdev)
+          .mockRejectedValueOnce(permissionError);
+        mockFs.cp.mockResolvedValueOnce(undefined);
+        mockFs.lstat.mockRejectedValueOnce(enoent);
+        mockFs.rm.mockResolvedValueOnce(undefined);
+
+        await expect(
+          moveFile('/source/file.txt', '/mounted-volume/file.txt'),
+        ).rejects.toBe(permissionError);
+
+        const tempPath = mockFs.cp.mock.calls[0][1];
+        expect(mockFs.rm).toHaveBeenCalledWith(tempPath, {
+          recursive: true,
+          force: true,
+        });
+        expect(mockFs.rm).not.toHaveBeenCalledWith('/source/file.txt', {
+          recursive: true,
+        });
+      });
     });
 
   });

--- a/src/filesystem/lib.ts
+++ b/src/filesystem/lib.ts
@@ -241,7 +241,48 @@ export async function moveFile(sourcePath: string, destinationPath: string): Pro
     await fs.lstat(destinationPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      await fs.rename(sourcePath, destinationPath);
+      try {
+        await fs.rename(sourcePath, destinationPath);
+      } catch (renameError) {
+        if ((renameError as NodeJS.ErrnoException).code !== 'EXDEV') {
+          throw renameError;
+        }
+
+        // rename cannot cross filesystem boundaries, which is common when
+        // moving between container volumes, network mounts, and local disks.
+        // Stage the copy beside the destination, then rename it into place so
+        // a failed copy never exposes a partial destination. This follows the
+        // same temporary-file pattern used by writeFileContent and
+        // applyFileEdits.
+        const tempPath = `${destinationPath}.${randomBytes(16).toString('hex')}.tmp`;
+        try {
+          await fs.cp(sourcePath, tempPath, {
+            recursive: true,
+            errorOnExist: true,
+            force: false,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+          });
+
+          // The copy can be long-running. Recheck immediately before the final
+          // rename to minimize the existing lstat/rename race and avoid
+          // overwriting a path created during the copy.
+          try {
+            await fs.lstat(destinationPath);
+          } catch (destinationError) {
+            if ((destinationError as NodeJS.ErrnoException).code === 'ENOENT') {
+              await fs.rename(tempPath, destinationPath);
+              await fs.rm(sourcePath, { recursive: true });
+              return;
+            }
+            throw destinationError;
+          }
+          throw new Error(`Destination already exists: ${destinationPath}`);
+        } catch (copyError) {
+          await fs.rm(tempPath, { recursive: true, force: true }).catch(() => {});
+          throw copyError;
+        }
+      }
       return;
     }
     throw error;


### PR DESCRIPTION
## Description

Fall back to a staged copy-and-remove operation when `move_file` encounters an `EXDEV` cross-device rename error.

## Server Details

- Server: filesystem
- Changes to: `move_file` tool

## Motivation and Context

`fs.rename` cannot move files or directories across filesystem boundaries. This commonly occurs between container volumes, network mounts, and local disks.

The fallback copies the source to a randomized temporary path beside the destination, renames the completed copy into place, and removes the source only after finalization. Failed copies are cleaned up without exposing a partial destination.

Relative symbolic links, timestamps, permissions, and the existing no-overwrite behavior are preserved.

## How Has This Been Tested?

- `npm test` — 174 passed
- `npm run build`
- 62 focused move and filesystem tests
- Real cross-device move between `/tmp` and `/dev/shm`
- Verified directory and file permissions
- Verified relative symbolic links
- Verified cleanup and source retention after copy failure
- Verified non-`EXDEV` errors do not trigger the fallback
- Verified final rename failures clean the staged copy

## Breaking Changes

None. Same-filesystem moves continue to use the existing `rename` path.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My changes follow MCP security best practices
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] No README, environment variable, or client configuration changes are required
