### PR TITLE
fix(sequentialthinking): set readOnlyHint/idempotentHint to false

### DIFF
--- a/src/sequentialthinking/__tests__/input-schema.test.ts
+++ b/src/sequentialthinking/__tests__/input-schema.test.ts
@@ -39,6 +39,16 @@ describe.skipIf(!existsSync(distIndexPath))('sequentialthinking input schema', (
     );
   });
 
+  // Regression coverage for #4721: each call accumulates in-memory thought
+  // history, so the tool must not advertise itself as read-only or idempotent.
+  it('marks the tool as neither read-only nor idempotent', async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'sequentialthinking');
+    expect(tool).toBeDefined();
+    expect(tool!.annotations?.readOnlyHint).toBe(false);
+    expect(tool!.annotations?.idempotentHint).toBe(false);
+  });
+
   it('rejects a call that omits nextThoughtNeeded', async () => {
     const result = await client.callTool({
       name: 'sequentialthinking',

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -93,9 +93,11 @@ You should:
       needsMoreThoughts: coercedBoolean.optional().describe("If more thoughts are needed")
     },
     annotations: {
-      readOnlyHint: true,
+      // Each call appends to the server's in-memory thought history (and
+      // branch list), so the tool is neither read-only nor idempotent.
+      readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     outputSchema: {


### PR DESCRIPTION
## Description

Every `sequentialthinking` call appends to the server's in-memory
`thoughtHistory` (and `branches`), and the response's
`thoughtHistoryLength` grows monotonically. Advertising the tool as
read-only and idempotent is misleading and can cause clients to skip
confirmations or apply unsafe retry/caching policies.

This changes both annotations to `false` and adds a regression test that
lists tools over stdio and asserts the annotations. Thanks to
@hummbl-agent for the detailed reproduction and statefulness analysis in
#4721.

Fixes #4721

## Publishing Your Server

This PR modifies an existing server and does not add or publish a server
listing.

## Server Details

- Server: `sequentialthinking`
- Changes to: tool annotations and regression coverage

## Motivation and Context

The server maintains per-session thought history and branch state, so
repeated calls are not read-only or idempotent. The other annotations remain
unchanged because they accurately describe the tool.

## How Has This Been Tested?

- `npm run build`
- `npm test` in `src/sequentialthinking`: 27 tests passed across 3 test files
- The regression test lists tools over stdio and checks both annotations

No LLM client test was run; this change is limited to protocol metadata and
its automated stdio regression test.

## Breaking Changes

None. This corrects metadata that clients may use for safety and retry
behavior; it does not change the tool input or output schema.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io)
- [x] My changes follows MCP security best practices
- [ ] I have updated the server's README accordingly (not applicable; no README behavior or configuration changed)
- [ ] I have tested this with an LLM client (not run; automated stdio coverage is included)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling (not applicable; no new error path)
- [ ] I have documented all environment variables and configuration options (not applicable; none changed)

## Additional context

The server's stateful behavior means clients should not treat repeated calls as
safe to cache or retry without considering the resulting state change.