### PR TITLE
fix(workspace): add test script for workspaces and verify fetch dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "npm run build --workspaces",
     "watch": "npm run watch --workspaces",
     "publish-all": "npm publish --workspaces --access public",
-    "link-all": "npm link --workspaces"
+    "link-all": "npm link --workspaces",
+    "test": "npm test --workspaces"
   },
   "dependencies": {
     "@modelcontextprotocol/server-everything": "*",


### PR DESCRIPTION
## Description
- Add root test script (`npm test`) to run workspace tests across all workspaces
- Verify `mcp-server-fetch` dependencies (`mcp>=1.29.0,<2`) and test suites pass

Fixes #4635