### PR TITLE
Add mcp-cj: MCP framework for the Cangjie programming language

### DIFF
--- a/ADDITIONAL.md
+++ b/ADDITIONAL.md
@@ -30,6 +30,7 @@ This is a curated collection of community-built frameworks and resources that si
 * **[AgentR Universal MCP SDK](https://github.com/universal-mcp/universal-mcp)** - A python SDK to build MCP Servers with inbuilt credential management by **[Agentr](https://agentr.dev/home)**
 * **[Vercel MCP Adapter](https://github.com/vercel/mcp-adapter)** (TypeScript) - A simple package to start serving an MCP server on most major JS meta-frameworks including Next, Nuxt, Svelte, and more.
 * **[PHP MCP Server](https://github.com/php-mcp/server)** (PHP) - Core PHP implementation for the Model Context Protocol (MCP) server
+* **[mcp-cj](https://atomgit.com/ystyle/mcp-cj)** (Cangjie) - A Model Context Protocol (MCP) framework with server and client support for the Cangjie programming language, featuring Stdio and Streamable HTTP transports. [Cangjie registry](https://pkg.cangjie-lang.cn/package/mcp) by **[ystyle](https://atomgit.com/ystyle)
 
 ### For clients
 

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,18 @@
+Add [mcp-cj](https://atomgit.com/ystyle/mcp-cj) to the Frameworks (For servers) list in ADDITIONAL.md.
+
+## What is mcp-cj?
+
+**mcp-cj** is a Model Context Protocol (MCP) framework for the **Cangjie** programming language (Huawei's native programming language). It provides:
+
+- **Server and client** implementations (one SDK, both sides)
+- Multiple transports: **Stdio**, **Streamable HTTP** (2025-11-25 session-based, 2026-07-28 stateless), and HTTP+SSE (legacy 2024-11-05)
+- Full protocol coverage: tools, resources (incl. templates), prompts, and the complete notification set (progress, cancellation, list-changed, logging)
+- Type-safe APIs built on the `jsonvalue` + `json-rpc` layered architecture
+
+## Package
+
+Published on the Cangjie package registry as **`mcp` v2.3.5**: https://pkg.cangjie-lang.cn/package/mcp
+
+## Repository
+
+https://atomgit.com/ystyle/mcp-cj (AtomGit, primary home of the Cangjie ecosystem)


### PR DESCRIPTION
Add [mcp-cj](https://atomgit.com/ystyle/mcp-cj) to the Frameworks (For servers) list in ADDITIONAL.md.

## What is mcp-cj?

**mcp-cj** is a Model Context Protocol (MCP) framework for the **Cangjie** programming language (Huawei's native programming language). It provides:

- **Server and client** implementations (one SDK, both sides)
- Multiple transports: **Stdio**, **Streamable HTTP** (2025-11-25 session-based, 2026-07-28 stateless), and HTTP+SSE (legacy 2024-11-05)
- Full protocol coverage: tools, resources (incl. templates), prompts, and the complete notification set (progress, cancellation, list-changed, logging)
- Type-safe APIs built on the `jsonvalue` + `json-rpc` layered architecture

## Package

Published on the Cangjie package registry as **`mcp` v2.3.5**: https://pkg.cangjie-lang.cn/package/mcp

## Repository

https://atomgit.com/ystyle/mcp-cj (AtomGit, primary home of the Cangjie ecosystem)
