### PR TITLE
fix(memory): guard against undefined observations in searchNodes

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -192,7 +192,7 @@ export class KnowledgeGraphManager {
     const filteredEntities = graph.entities.filter(e => 
       e.name.toLowerCase().includes(query.toLowerCase()) ||
       e.entityType.toLowerCase().includes(query.toLowerCase()) ||
-      e.observations.some(o => o.toLowerCase().includes(query.toLowerCase()))
+      (e.observations ?? []).some(o => o.toLowerCase().includes(query.toLowerCase()))
     );
   
     // Create a Set of filtered entity names for quick lookup


### PR DESCRIPTION
Closes #1818

## Problem

`search_nodes` throws `TypeError: Cannot read properties of undefined (reading 'some')` when an entity in the JSONL file has a missing `observations` field. This can happen with older data files or malformed entries.

## Fix

Use nullish coalescing (`??`) to default `observations` to an empty array before calling `.some()`:

```typescript
(e.observations ?? []).some(o => o.toLowerCase().includes(query.toLowerCase()))
```

## Tests

All 50 existing tests pass. The fix is backward-compatible — entities with properly defined `observations` arrays are unaffected.