### PR TITLE
ci: run readme-pr-check on pull_request_target so fork PRs can be labeled

### DIFF
--- a/.github/workflows/readme-pr-check.yml
+++ b/.github/workflows/readme-pr-check.yml
@@ -1,7 +1,10 @@
 name: README PR Check
 
 on:
-  pull_request:
+  # pull_request_target, not pull_request: fork PRs get a read-only token under
+  # pull_request, so the label and comment calls fail with 403. This job only
+  # calls the API and never checks out PR code, so the write token is safe.
+  pull_request_target:
     types: [opened]
     paths:
       - 'README.md'
@@ -10,7 +13,7 @@ on:
 
 jobs:
   check-readme-only:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

The `check-readme-only` job fails with 403 `Resource not accessible by integration` on the `addLabels` call for README-only PRs from forks (observed on #4714 and #4726, run 33362192371). The `pull_request` event gives fork PRs a read-only `GITHUB_TOKEN`, so the declared `pull-requests: write` permission never takes effect and the gate comment is never posted for external contributors — the workflow's main audience.

This switches the trigger to `pull_request_target`, which runs with a write token. The job only calls the GitHub API (`listFiles`, `listComments`, `addLabels`, `createComment`) and never checks out or executes PR code, so the write token is safe with this event. The `issue_comment`-triggered `handle-confirmation` job is unchanged.

## Type of Change

- [x] Bug fix (CI workflow)

## How Has This Been Tested?

Reproduced the 403 in the failed run logs for #4726. The workflow change itself only takes effect once merged to `main` (`pull_request_target` runs the base-branch version), so the next fork README-only PR will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CK8vvB229h6orvkokG8YxU
