### PR TITLE
fix(docker): switch to non-root user in all MCP server Dockerfiles

### DIFF
--- a/src/everything/Dockerfile
+++ b/src/everything/Dockerfile
@@ -19,4 +19,6 @@ ENV NODE_ENV=production
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 CMD ["node", "dist/index.js"]

--- a/src/fetch/Dockerfile
+++ b/src/fetch/Dockerfile
@@ -35,5 +35,7 @@ COPY --from=uv --chown=app:app /app/.venv /app/.venv
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+USER app
+
 # when running the container, add --db-path and a bind mount to the host's db file
 ENTRYPOINT ["mcp-server-fetch"]

--- a/src/filesystem/Dockerfile
+++ b/src/filesystem/Dockerfile
@@ -22,4 +22,6 @@ ENV NODE_ENV=production
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "/app/dist/index.js"]

--- a/src/git/Dockerfile
+++ b/src/git/Dockerfile
@@ -38,5 +38,7 @@ COPY --from=uv --chown=app:app /app/.venv /app/.venv
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
 
+USER app
+
 # when running the container, add --db-path and a bind mount to the host's db file
 ENTRYPOINT ["mcp-server-git"]

--- a/src/memory/Dockerfile
+++ b/src/memory/Dockerfile
@@ -21,4 +21,6 @@ WORKDIR /app
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "dist/index.js"]

--- a/src/sequentialthinking/Dockerfile
+++ b/src/sequentialthinking/Dockerfile
@@ -21,4 +21,6 @@ WORKDIR /app
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "dist/index.js"]

--- a/src/time/Dockerfile
+++ b/src/time/Dockerfile
@@ -38,5 +38,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Set the LOCAL_TIMEZONE environment variable
 ENV LOCAL_TIMEZONE=${LOCAL_TIMEZONE:-"UTC"}
 
+USER app
+
 # when running the container, add --local-timezone and a bind mount to the host's db file
 ENTRYPOINT ["mcp-server-time", "--local-timezone", "${LOCAL_TIMEZONE}"]


### PR DESCRIPTION
### Summary
Resolves #4741.

### Problem
- The Python Dockerfiles (`fetch`, `git`, `time`) created an `app` user with `useradd -rUM -s /usr/sbin/nologin app` and chowned `/app/.venv` to `app:app`, but never switched to it with a `USER` instruction.
- The Node.js Dockerfiles (`everything`, `filesystem`, `memory`, `sequentialthinking`) used `node:22-alpine` without switching to the pre-existing `node` user.
- As a result, all seven images ran as root (`UID 0`). In the case of `src/filesystem`, bind mounts to host directories created files owned by `root`, and Kubernetes admission controllers requiring `runAsNonRoot: true` rejected the images.

### Solution
- Added `USER app` before `ENTRYPOINT` in the Python images (`src/fetch/Dockerfile`, `src/git/Dockerfile`, `src/time/Dockerfile`).
- Added `USER node` before `CMD`/`ENTRYPOINT` in the Node.js images (`src/everything/Dockerfile`, `src/filesystem/Dockerfile`, `src/memory/Dockerfile`, `src/sequentialthinking/Dockerfile`).