### PR TITLE
fix(docker): switch to non-root user in container images

### DIFF
--- a/src/fetch/Dockerfile
+++ b/src/fetch/Dockerfile
@@ -23,6 +23,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim-bookworm
 
+RUN if ! id -u app >/dev/null 2>&1; then useradd -rUM -s /usr/sbin/nologin app; fi
+
 WORKDIR /app
  
 COPY --from=uv /root/.local /root/.local
@@ -31,6 +33,8 @@ RUN if ! id -u app >/dev/null 2>&1; then \
       useradd -rUM -s /usr/sbin/nologin app; \
     fi
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+USER app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/src/filesystem/Dockerfile
+++ b/src/filesystem/Dockerfile
@@ -22,4 +22,6 @@ ENV NODE_ENV=production
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "/app/dist/index.js"]

--- a/src/git/Dockerfile
+++ b/src/git/Dockerfile
@@ -26,6 +26,8 @@ FROM python:3.12-slim-bookworm
 RUN apt-get update && apt-get install -y git git-lfs && rm -rf /var/lib/apt/lists/* \
     && git lfs install --system
 
+RUN if ! id -u app >/dev/null 2>&1; then useradd -rUM -s /usr/sbin/nologin app; fi
+
 WORKDIR /app
  
 COPY --from=uv /root/.local /root/.local
@@ -34,6 +36,8 @@ RUN if ! id -u app >/dev/null 2>&1; then \
       useradd -rUM -s /usr/sbin/nologin app; \
     fi
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+USER app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/src/memory/Dockerfile
+++ b/src/memory/Dockerfile
@@ -21,4 +21,6 @@ WORKDIR /app
 
 RUN npm ci --ignore-scripts --omit-dev
 
+USER node
+
 ENTRYPOINT ["node", "dist/index.js"]

--- a/src/time/Dockerfile
+++ b/src/time/Dockerfile
@@ -23,6 +23,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.12-slim-bookworm
 
+RUN if ! id -u app >/dev/null 2>&1; then useradd -rUM -s /usr/sbin/nologin app; fi
+
 WORKDIR /app
  
 COPY --from=uv /root/.local /root/.local
@@ -31,6 +33,8 @@ RUN if ! id -u app >/dev/null 2>&1; then \
       useradd -rUM -s /usr/sbin/nologin app; \
     fi
 COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+USER app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
### What does this PR do?

Resolves #4741.

Since #2205, the Python Dockerfiles (`fetch`, `git`, `time`) created an `app` user with `--chown=app:app`, but never included a `USER app` instruction before the `ENTRYPOINT`. As a result, containers ran as UID 0 (root).

Similarly, the Node images (`filesystem`, `memory`, etc.) inherit from `node:22-alpine` which ships with a non-root `node` user (UID 1000) that was previously unused.

This PR:
- Adds `useradd` check and `USER app` to Python Dockerfiles (`src/fetch`, `src/git`, `src/time`).
- Adds `USER node` before `ENTRYPOINT` to Node Dockerfiles (`src/filesystem`, `src/memory`).
- Prevents container operations from creating root-owned files on bind mounts and complies with Kubernetes `runAsNonRoot: true` policies.