### PR TITLE
fix(sequentialthinking): correct readOnlyHint and idempotentHint annotations

### DIFF
--- a/src/sequentialthinking/__tests__/input-schema.test.ts
+++ b/src/sequentialthinking/__tests__/input-schema.test.ts
@@ -30,6 +30,18 @@ describe.skipIf(!existsSync(distIndexPath))('sequentialthinking input schema', (
     await client?.close();
   });
 
+  it('advertises accurate annotations (stateful and non-idempotent)', async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'sequentialthinking');
+    expect(tool).toBeDefined();
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+  });
+
   it('advertises nextThoughtNeeded as required', async () => {
     const { tools } = await client.listTools();
     const tool = tools.find(t => t.name === 'sequentialthinking');

--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -93,9 +93,9 @@ You should:
       needsMoreThoughts: coercedBoolean.optional().describe("If more thoughts are needed")
     },
     annotations: {
-      readOnlyHint: true,
+      readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     outputSchema: {


### PR DESCRIPTION
Resolves #4721.

### Problem
The `sequentialthinking` tool annotations previously specified `readOnlyHint: true` and `idempotentHint: true`. However:
1. The server maintains per-session instance state (`thoughtHistory` and `branches`), which mutates on every `processThought` invocation. It is therefore stateful, not read-only.
2. Repeated calls with identical arguments yield different `thoughtHistoryLength` values (and mutate branches), making the tool non-idempotent by definition. Clients relying on `readOnlyHint` (e.g. for parallel execution safety) or `idempotentHint` (e.g. for caching or automatic retries) would encounter unexpected side effects.

### Solution
- Set `readOnlyHint: false` and `idempotentHint: false` in `src/sequentialthinking/index.ts`.
- Added regression test in `src/sequentialthinking/__tests__/input-schema.test.ts` verifying that advertised tool annotations accurately reflect statefulness.