### PR TITLE
fix(sequentialthinking): accurate readOnlyHint and idempotentHint annotations (#4721)

### DIFF
--- a/src/sequentialthinking/index.ts
+++ b/src/sequentialthinking/index.ts
@@ -93,9 +93,9 @@ You should:
       needsMoreThoughts: coercedBoolean.optional().describe("If more thoughts are needed")
     },
     annotations: {
-      readOnlyHint: true,
+      readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     outputSchema: {


### PR DESCRIPTION
## Summary
- Fixes #4721
- Corrects `readOnlyHint` from `true` to `false` because `SequentialThinkingServer` actively mutates session state (`thoughtHistory` and `branches` array) on each invocation.
- Corrects `idempotentHint` from `true` to `false` because repeated invocations with the same inputs produce different `thoughtHistoryLength` values and branch mutations.
- Both hints now accurately reflect the stateful runtime nature of the sequentialthinking tool.