### PR TITLE
feat(truecalci): add truecalci deterministic compute server

### DIFF
--- a/src/truecalci/server.json
+++ b/src/truecalci/server.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/servers/main/schema.json",
+  "name": "truecalci",
+  "title": "TrueCalci Deterministic Engine",
+  "description": "24 zero-hallucination deterministic calculation tools for financial schedules, statutory tax brackets, mortgage amortization, and engineering math over Streamable HTTP.",
+  "repository": "https://github.com/truecalci-official/truecalci",
+  "homepage": "https://truecalci.com",
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://truecalci.com/api/v1/mcp"
+  },
+  "tags": ["finance", "tax", "mortgage", "deterministic", "math", "currency"]
+}


### PR DESCRIPTION
## Description
Adds the **TrueCalci** deterministic calculation engine as a Streamable HTTP MCP server located at `src/truecalci/server.json`.

TrueCalci provides 24 zero-hallucination mathematical and statutory calculation engines (Income tax brackets, mortgage PITI/PMI, contractor parity, compound schedules, and engineering formulas) executed at Cloudflare Edge.

## Server Details
* **Server**: TrueCalci
* **Repository**: https://github.com/truecalci-official/truecalci
* **Homepage**: https://truecalci.com
* **Transport**: Streamable HTTP (`https://truecalci.com/api/v1/mcp`)
* **Engines**: 24 Deterministic Tools

## Motivation and Context
AI models frequently hallucinate compound interest schedules, tax brackets, and floating-point math. TrueCalci provides deterministic, IEEE-754 precision math tools to prevent financial and arithmetic hallucinations in AI agents.

## How Has This Been Tested?
* Verified via JSON-RPC 2.0 handshake (`initialize`, `tools/list`, `tools/call`).
* Validated live on Claude Desktop and Cursor IDE over Streamable HTTP.
* Automated unit test suite passing locally and deployed to Cloudflare Edge.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the MCP Protocol Documentation
- [x] My changes follows MCP security best practices
- [x] I have updated the server's README accordingly
- [x] I have tested this with an LLM client
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have documented all environment variables and configuration options
